### PR TITLE
#12 add missing cluster commands

### DIFF
--- a/src/main/java/io/vertx/redis/RedisClient.java
+++ b/src/main/java/io/vertx/redis/RedisClient.java
@@ -241,6 +241,216 @@ public interface RedisClient {
   RedisClient clientSetname(String name, Handler<AsyncResult<String>> handler);
 
   /**
+   * Assign new hash slots to receiving node.
+   *
+   * @param slots
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: server
+   */
+  RedisClient clusterAddslots(List<Long> slots, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Return the number of failure reports active for a given node.
+   *
+   * @param nodeId
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterCountFailureReports(String nodeId, Handler<AsyncResult<Long>> handler);
+
+  /**
+   * Return the number of local keys in the specified hash slot.
+   *
+   * @param slot
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterCountkeysinslot(long slot, Handler<AsyncResult<Long>> handler);
+
+  /**
+   * Set hash slots as unbound in receiving node.
+   *
+   * @param slot
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterDelslots(long slot, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Set hash slots as unbound in receiving node.
+   *
+   * @param slots
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterDelslotsMany(List<Long> slots, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Forces a slave to perform a manual failover of its master.
+   *
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterFailover(Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Forces a slave to perform a manual failover of its master.
+   *
+   * @param options
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterFailOverWithOptions(FailoverOptions options, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Remove a node from the nodes table.
+   *
+   * @param nodeId
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterForget(String nodeId, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Return local key names in the specified hash slot.
+   *
+   * @param slot
+   * @param count
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterGetkeyinslot(long slot, long count, Handler<AsyncResult<JsonArray>> handler);
+
+  /**
+   * Provides info about Redis Cluster node state.
+   *
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterInfo(Handler<AsyncResult<JsonArray>> handler);
+
+  /**
+   * Returns the hash slot of the specified key.
+   *
+   * @param key
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterKeyslot(String key, Handler<AsyncResult<Long>> handler);
+
+  /**
+   * Force a node cluster to handshake with another node.
+   *
+   * @param ip
+   * @param port
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterMeet(String ip, long port, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Get Cluster config for the node.
+   *
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterNodes(Handler<AsyncResult<JsonArray>> handler);
+
+  /**
+   * Reconfigure a node as a slave of the specified master node.
+   *
+   * @param nodeId
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterReplicate(String nodeId, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Reset a Redis Cluster node.
+   *
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterReset(Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Reset a Redis Cluster node.
+   *
+   * @param options
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterResetWithOptions(ResetOptions options, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Forces the node to save cluster state on disk.
+   *
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterSaveconfig(Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Set the configuration epoch in a new node.
+   *
+   * @param epoch
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterSetConfigEpoch(long epoch, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Bind an hash slot to a specific node.
+   *
+   * @param slot
+   * @param subcommand
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterSetslot(long slot, SlotCmd subcommand, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Bind an hash slot to a specific node.
+   *
+   * @param slot
+   * @param subcommand
+   * @param nodeId
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterSetslotWithNode(long slot, SlotCmd subcommand, String nodeId, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * List slave nodes of the specified master node.
+   *
+   * @param nodeId
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: cluster
+   */
+  RedisClient clusterSlaves(String nodeId, Handler<AsyncResult<JsonArray>> handler);
+
+  /**
    * Get array of Cluster slot to node mappings
    *
    * @since 3.0.0
@@ -1728,6 +1938,17 @@ public interface RedisClient {
    * group: transactions
    */
   RedisClient unwatch(Handler<AsyncResult<String>> handler);
+
+  /**
+   * Wait for the synchronous replication of all the write commands sent in the context of the current connection.
+   *
+   * @param numSlaves
+   * @param timeout
+   * @param handler Handler for the result of this call.
+   * @since 3.0.0
+   * group: generic
+   */
+  RedisClient wait(long numSlaves, long timeout, Handler<AsyncResult<String>> handler);
 
   /**
    * Watch the given keys to determine execution of the MULTI/EXEC block

--- a/src/main/java/io/vertx/redis/impl/RedisClientImpl.java
+++ b/src/main/java/io/vertx/redis/impl/RedisClientImpl.java
@@ -138,7 +138,133 @@ public final class RedisClientImpl extends AbstractRedisClient {
   public RedisClient clientSetname(String name, Handler<AsyncResult<String>> handler) {
     sendString("CLIENT SETNAME", toPayload(name), handler);
     return this;
-  } 
+  }
+
+  @Override
+  public RedisClient clusterAddslots(List<Long> slots, Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER ADDSLOTS", null, handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterCountFailureReports(String nodeId, Handler<AsyncResult<Long>> handler) {
+    sendLong("CLUSTER COUNT-FAILURE-REPORTS", toPayload(nodeId), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterCountkeysinslot(long slot, Handler<AsyncResult<Long>> handler) {
+    sendLong("CLUSTER COUNTKEYSINSLOT", toPayload(slot), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterDelslots(long slot, Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER DELSLOTS", toPayload(slot), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterDelslotsMany(List<Long> slots, Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER DELSLOTS", toPayload(slots), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterFailover(Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER FAILOVER", null, handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterFailOverWithOptions(FailoverOptions options, Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER FAILOVER", toPayload(options), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterForget(String nodeId, Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER FORGET", toPayload(nodeId), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterGetkeyinslot(long slot, long count, Handler<AsyncResult<JsonArray>> handler) {
+    sendJsonArray("CLUSTER GETKEYINSLOT", toPayload(slot, count), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterInfo(Handler<AsyncResult<JsonArray>> handler) {
+    sendJsonArray("CLUSTER INFO", null, handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterKeyslot(String key, Handler<AsyncResult<Long>> handler) {
+    sendLong("CLUSTER KEYSLOT", toPayload(key), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterMeet(String ip, long port, Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER MEET", toPayload(ip, port), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterNodes(Handler<AsyncResult<JsonArray>> handler) {
+    sendJsonArray("CLUSTER NODES", null, handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterReplicate(String nodeId, Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER REPLICATE", toPayload(nodeId), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterReset(Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER RESET", null, handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterResetWithOptions(ResetOptions options, Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER RESET", toPayload(options), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterSaveconfig(Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER SAVECONFIG", null, handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterSetConfigEpoch(long epoch, Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER SET-CONFIG-EPOCH", toPayload(epoch), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterSetslot(long slot, SlotCmd subcommand, Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER SETSLOT", toPayload(slot, subcommand), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterSetslotWithNode(long slot, SlotCmd subcommand, String nodeId, Handler<AsyncResult<Void>> handler) {
+    sendVoid("CLUSTER SETSLOT", toPayload(slot, subcommand, nodeId), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient clusterSlaves(String nodeId, Handler<AsyncResult<JsonArray>> handler) {
+    sendJsonArray("CLUSTER SLAVES", toPayload(nodeId), handler);
+    return this;
+  }
 
   @Override
   public RedisClient clusterSlots(Handler<AsyncResult<JsonArray>> handler) {
@@ -1015,7 +1141,13 @@ public final class RedisClientImpl extends AbstractRedisClient {
   public RedisClient unwatch(Handler<AsyncResult<String>> handler) {
     sendString("UNWATCH", null, handler);
     return this;
-  } 
+  }
+
+  @Override
+  public RedisClient wait(long numSlaves, long timeout, Handler<AsyncResult<String>> handler) {
+    sendString("WAIT", toPayload(numSlaves, timeout), handler);
+    return this;
+  }
 
   @Override
   public RedisClient watch(List<String> keys, Handler<AsyncResult<String>> handler) {

--- a/src/main/java/io/vertx/redis/op/FailoverOptions.java
+++ b/src/main/java/io/vertx/redis/op/FailoverOptions.java
@@ -1,0 +1,9 @@
+package io.vertx.redis.op;
+
+/**
+ * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
+ */
+public enum FailoverOptions {
+  FORCE,
+  TAKEOVER
+}

--- a/src/main/java/io/vertx/redis/op/ResetOptions.java
+++ b/src/main/java/io/vertx/redis/op/ResetOptions.java
@@ -1,0 +1,9 @@
+package io.vertx.redis.op;
+
+/**
+ * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
+ */
+public enum ResetOptions {
+  HARD,
+  SOFT
+}

--- a/src/main/java/io/vertx/redis/op/SlotCmd.java
+++ b/src/main/java/io/vertx/redis/op/SlotCmd.java
@@ -1,0 +1,11 @@
+package io.vertx.redis.op;
+
+/**
+ * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
+ */
+public enum SlotCmd {
+  IMPORTING,
+  MIGRATING,
+  STABLE,
+  NODE
+}

--- a/src/main/resources/vertx-redis-js/redis_client.js
+++ b/src/main/resources/vertx-redis-js/redis_client.js
@@ -499,6 +499,447 @@ var RedisClient = function(j_val) {
   };
 
   /**
+   Assign new hash slots to receiving node.
+
+   @public
+   @param slots {Array.<number>} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterAddslots = function(slots, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'object' && __args[0] instanceof Array && typeof __args[1] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterAddslots(java.util.List,io.vertx.core.Handler)"](utils.convParamListLong(slots), function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Return the number of failure reports active for a given node.
+
+   @public
+   @param nodeId {string} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterCountFailureReports = function(nodeId, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'string' && typeof __args[1] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterCountFailureReports(java.lang.String,io.vertx.core.Handler)"](nodeId, function(ar) {
+      if (ar.succeeded()) {
+        handler(ar.result(), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Return the number of local keys in the specified hash slot.
+
+   @public
+   @param slot {number} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterCountkeysinslot = function(slot, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] ==='number' && typeof __args[1] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterCountkeysinslot(long,io.vertx.core.Handler)"](slot, function(ar) {
+      if (ar.succeeded()) {
+        handler(ar.result(), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Set hash slots as unbound in receiving node.
+
+   @public
+   @param slot {number} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterDelslots = function(slot, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] ==='number' && typeof __args[1] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterDelslots(long,io.vertx.core.Handler)"](slot, function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Set hash slots as unbound in receiving node.
+
+   @public
+   @param slots {Array.<number>} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterDelslotsMany = function(slots, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'object' && __args[0] instanceof Array && typeof __args[1] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterDelslotsMany(java.util.List,io.vertx.core.Handler)"](utils.convParamListLong(slots), function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Forces a slave to perform a manual failover of its master.
+
+   @public
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterFailover = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterFailover(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Forces a slave to perform a manual failover of its master.
+
+   @public
+   @param options {Object} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterFailOverWithOptions = function(options, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'string' && typeof __args[1] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterFailOverWithOptions(io.vertx.redis.op.FailoverOptions,io.vertx.core.Handler)"](io.vertx.redis.op.FailoverOptions.valueOf(__args[0]), function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Remove a node from the nodes table.
+
+   @public
+   @param nodeId {string} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterForget = function(nodeId, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'string' && typeof __args[1] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterForget(java.lang.String,io.vertx.core.Handler)"](nodeId, function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Return local key names in the specified hash slot.
+
+   @public
+   @param slot {number} 
+   @param count {number} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterGetkeyinslot = function(slot, count, handler) {
+    var __args = arguments;
+    if (__args.length === 3 && typeof __args[0] ==='number' && typeof __args[1] ==='number' && typeof __args[2] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterGetkeyinslot(long,long,io.vertx.core.Handler)"](slot, count, function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnJson(ar.result()), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Provides info about Redis Cluster node state.
+
+   @public
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterInfo = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterInfo(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnJson(ar.result()), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Returns the hash slot of the specified key.
+
+   @public
+   @param key {string} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterKeyslot = function(key, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'string' && typeof __args[1] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterKeyslot(java.lang.String,io.vertx.core.Handler)"](key, function(ar) {
+      if (ar.succeeded()) {
+        handler(ar.result(), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Force a node cluster to handshake with another node.
+
+   @public
+   @param ip {string} 
+   @param port {number} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterMeet = function(ip, port, handler) {
+    var __args = arguments;
+    if (__args.length === 3 && typeof __args[0] === 'string' && typeof __args[1] ==='number' && typeof __args[2] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterMeet(java.lang.String,long,io.vertx.core.Handler)"](ip, port, function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Get Cluster config for the node.
+
+   @public
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterNodes = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterNodes(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnJson(ar.result()), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Reconfigure a node as a slave of the specified master node.
+
+   @public
+   @param nodeId {string} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterReplicate = function(nodeId, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'string' && typeof __args[1] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterReplicate(java.lang.String,io.vertx.core.Handler)"](nodeId, function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Reset a Redis Cluster node.
+
+   @public
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterReset = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterReset(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Reset a Redis Cluster node.
+
+   @public
+   @param options {Object} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterResetWithOptions = function(options, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'string' && typeof __args[1] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterResetWithOptions(io.vertx.redis.op.ResetOptions,io.vertx.core.Handler)"](io.vertx.redis.op.ResetOptions.valueOf(__args[0]), function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Forces the node to save cluster state on disk.
+
+   @public
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterSaveconfig = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterSaveconfig(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Set the configuration epoch in a new node.
+
+   @public
+   @param epoch {number} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterSetConfigEpoch = function(epoch, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] ==='number' && typeof __args[1] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterSetConfigEpoch(long,io.vertx.core.Handler)"](epoch, function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Bind an hash slot to a specific node.
+
+   @public
+   @param slot {number} 
+   @param subcommand {Object} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterSetslot = function(slot, subcommand, handler) {
+    var __args = arguments;
+    if (__args.length === 3 && typeof __args[0] ==='number' && typeof __args[1] === 'string' && typeof __args[2] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterSetslot(long,io.vertx.redis.op.SlotCmd,io.vertx.core.Handler)"](slot, io.vertx.redis.op.SlotCmd.valueOf(__args[1]), function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Bind an hash slot to a specific node.
+
+   @public
+   @param slot {number} 
+   @param subcommand {Object} 
+   @param nodeId {string} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterSetslotWithNode = function(slot, subcommand, nodeId, handler) {
+    var __args = arguments;
+    if (__args.length === 4 && typeof __args[0] ==='number' && typeof __args[1] === 'string' && typeof __args[2] === 'string' && typeof __args[3] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterSetslotWithNode(long,io.vertx.redis.op.SlotCmd,java.lang.String,io.vertx.core.Handler)"](slot, io.vertx.redis.op.SlotCmd.valueOf(__args[1]), nodeId, function(ar) {
+      if (ar.succeeded()) {
+        handler(null, null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   List slave nodes of the specified master node.
+
+   @public
+   @param nodeId {string} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.clusterSlaves = function(nodeId, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'string' && typeof __args[1] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["clusterSlaves(java.lang.String,io.vertx.core.Handler)"](nodeId, function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnJson(ar.result()), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
    Get array of Cluster slot to node mappings
 
    @public
@@ -3598,6 +4039,28 @@ var RedisClient = function(j_val) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'function') {
       return utils.convReturnVertxGen(j_redisClient["unwatch(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(ar.result(), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    }), RedisClient);
+    } else utils.invalidArgs();
+  };
+
+  /**
+   Wait for the synchronous replication of all the write commands sent in the context of the current connection.
+
+   @public
+   @param numSlaves {number} 
+   @param timeout {number} 
+   @param handler {function} Handler for the result of this call. 
+   @return {RedisClient}
+   */
+  this.wait = function(numSlaves, timeout, handler) {
+    var __args = arguments;
+    if (__args.length === 3 && typeof __args[0] ==='number' && typeof __args[1] ==='number' && typeof __args[2] === 'function') {
+      return utils.convReturnVertxGen(j_redisClient["wait(long,long,io.vertx.core.Handler)"](numSlaves, timeout, function(ar) {
       if (ar.succeeded()) {
         handler(ar.result(), null);
       } else {

--- a/src/main/resources/vertx-redis/redis_client.rb
+++ b/src/main/resources/vertx-redis/redis_client.rb
@@ -248,6 +248,216 @@ module VertxRedis
       end
       raise ArgumentError, "Invalid arguments when calling client_setname(name)"
     end
+    #  Assign new hash slots to receiving node.
+    # @param [Array<Fixnum>] slots 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_addslots(slots=nil)
+      if slots.class == Array && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterAddslots, [Java::JavaUtil::List.java_class,Java::IoVertxCore::Handler.java_class]).call(slots.map { |element| element },(Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_addslots(slots)"
+    end
+    #  Return the number of failure reports active for a given node.
+    # @param [String] nodeId 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_count_failure_reports(nodeId=nil)
+      if nodeId.class == String && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterCountFailureReports, [Java::java.lang.String.java_class,Java::IoVertxCore::Handler.java_class]).call(nodeId,(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_count_failure_reports(nodeId)"
+    end
+    #  Return the number of local keys in the specified hash slot.
+    # @param [Fixnum] slot 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_countkeysinslot(slot=nil)
+      if slot.class == Fixnum && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterCountkeysinslot, [Java::long.java_class,Java::IoVertxCore::Handler.java_class]).call(slot,(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_countkeysinslot(slot)"
+    end
+    #  Set hash slots as unbound in receiving node.
+    # @param [Fixnum] slot 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_delslots(slot=nil)
+      if slot.class == Fixnum && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterDelslots, [Java::long.java_class,Java::IoVertxCore::Handler.java_class]).call(slot,(Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_delslots(slot)"
+    end
+    #  Set hash slots as unbound in receiving node.
+    # @param [Array<Fixnum>] slots 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_delslots_many(slots=nil)
+      if slots.class == Array && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterDelslotsMany, [Java::JavaUtil::List.java_class,Java::IoVertxCore::Handler.java_class]).call(slots.map { |element| element },(Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_delslots_many(slots)"
+    end
+    #  Forces a slave to perform a manual failover of its master.
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_failover
+      if block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterFailover, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_failover()"
+    end
+    #  Forces a slave to perform a manual failover of its master.
+    # @param [:FORCE,:TAKEOVER] options 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_fail_over_with_options(options=nil)
+      if options.class == Symbol && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterFailOverWithOptions, [Java::IoVertxRedisOp::FailoverOptions.java_class,Java::IoVertxCore::Handler.java_class]).call(Java::IoVertxRedisOp::FailoverOptions.valueOf(options),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_fail_over_with_options(options)"
+    end
+    #  Remove a node from the nodes table.
+    # @param [String] nodeId 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_forget(nodeId=nil)
+      if nodeId.class == String && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterForget, [Java::java.lang.String.java_class,Java::IoVertxCore::Handler.java_class]).call(nodeId,(Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_forget(nodeId)"
+    end
+    #  Return local key names in the specified hash slot.
+    # @param [Fixnum] slot 
+    # @param [Fixnum] count 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_getkeyinslot(slot=nil,count=nil)
+      if slot.class == Fixnum && count.class == Fixnum && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterGetkeyinslot, [Java::long.java_class,Java::long.java_class,Java::IoVertxCore::Handler.java_class]).call(slot,count,(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_getkeyinslot(slot,count)"
+    end
+    #  Provides info about Redis Cluster node state.
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_info
+      if block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterInfo, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_info()"
+    end
+    #  Returns the hash slot of the specified key.
+    # @param [String] key 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_keyslot(key=nil)
+      if key.class == String && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterKeyslot, [Java::java.lang.String.java_class,Java::IoVertxCore::Handler.java_class]).call(key,(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_keyslot(key)"
+    end
+    #  Force a node cluster to handshake with another node.
+    # @param [String] ip 
+    # @param [Fixnum] port 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_meet(ip=nil,port=nil)
+      if ip.class == String && port.class == Fixnum && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterMeet, [Java::java.lang.String.java_class,Java::long.java_class,Java::IoVertxCore::Handler.java_class]).call(ip,port,(Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_meet(ip,port)"
+    end
+    #  Get Cluster config for the node.
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_nodes
+      if block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterNodes, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_nodes()"
+    end
+    #  Reconfigure a node as a slave of the specified master node.
+    # @param [String] nodeId 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_replicate(nodeId=nil)
+      if nodeId.class == String && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterReplicate, [Java::java.lang.String.java_class,Java::IoVertxCore::Handler.java_class]).call(nodeId,(Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_replicate(nodeId)"
+    end
+    #  Reset a Redis Cluster node.
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_reset
+      if block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterReset, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_reset()"
+    end
+    #  Reset a Redis Cluster node.
+    # @param [:HARD,:SOFT] options 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_reset_with_options(options=nil)
+      if options.class == Symbol && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterResetWithOptions, [Java::IoVertxRedisOp::ResetOptions.java_class,Java::IoVertxCore::Handler.java_class]).call(Java::IoVertxRedisOp::ResetOptions.valueOf(options),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_reset_with_options(options)"
+    end
+    #  Forces the node to save cluster state on disk.
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_saveconfig
+      if block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterSaveconfig, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_saveconfig()"
+    end
+    #  Set the configuration epoch in a new node.
+    # @param [Fixnum] epoch 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_set_config_epoch(epoch=nil)
+      if epoch.class == Fixnum && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterSetConfigEpoch, [Java::long.java_class,Java::IoVertxCore::Handler.java_class]).call(epoch,(Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_set_config_epoch(epoch)"
+    end
+    #  Bind an hash slot to a specific node.
+    # @param [Fixnum] slot 
+    # @param [:IMPORTING,:MIGRATING,:STABLE,:NODE] subcommand 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_setslot(slot=nil,subcommand=nil)
+      if slot.class == Fixnum && subcommand.class == Symbol && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterSetslot, [Java::long.java_class,Java::IoVertxRedisOp::SlotCmd.java_class,Java::IoVertxCore::Handler.java_class]).call(slot,Java::IoVertxRedisOp::SlotCmd.valueOf(subcommand),(Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_setslot(slot,subcommand)"
+    end
+    #  Bind an hash slot to a specific node.
+    # @param [Fixnum] slot 
+    # @param [:IMPORTING,:MIGRATING,:STABLE,:NODE] subcommand 
+    # @param [String] nodeId 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_setslot_with_node(slot=nil,subcommand=nil,nodeId=nil)
+      if slot.class == Fixnum && subcommand.class == Symbol && nodeId.class == String && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterSetslotWithNode, [Java::long.java_class,Java::IoVertxRedisOp::SlotCmd.java_class,Java::java.lang.String.java_class,Java::IoVertxCore::Handler.java_class]).call(slot,Java::IoVertxRedisOp::SlotCmd.valueOf(subcommand),nodeId,(Proc.new { |ar| yield(ar.failed ? ar.cause : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_setslot_with_node(slot,subcommand,nodeId)"
+    end
+    #  List slave nodes of the specified master node.
+    # @param [String] nodeId 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def cluster_slaves(nodeId=nil)
+      if nodeId.class == String && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:clusterSlaves, [Java::java.lang.String.java_class,Java::IoVertxCore::Handler.java_class]).call(nodeId,(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result != nil ? JSON.parse(ar.result.encode) : nil : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling cluster_slaves(nodeId)"
+    end
     #  Get array of Cluster slot to node mappings
     # @yield 
     # @return [::VertxRedis::RedisClient]
@@ -1761,6 +1971,17 @@ module VertxRedis
         return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:unwatch, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result : nil) })),::VertxRedis::RedisClient)
       end
       raise ArgumentError, "Invalid arguments when calling unwatch()"
+    end
+    #  Wait for the synchronous replication of all the write commands sent in the context of the current connection.
+    # @param [Fixnum] numSlaves 
+    # @param [Fixnum] timeout 
+    # @yield Handler for the result of this call.
+    # @return [::VertxRedis::RedisClient]
+    def wait(numSlaves=nil,timeout=nil)
+      if numSlaves.class == Fixnum && timeout.class == Fixnum && block_given?
+        return ::Vertx::Util::Utils.safe_create(@j_del.java_method(:wait, [Java::long.java_class,Java::long.java_class,Java::IoVertxCore::Handler.java_class]).call(numSlaves,timeout,(Proc.new { |ar| yield(ar.failed ? ar.cause : nil, ar.succeeded ? ar.result : nil) })),::VertxRedis::RedisClient)
+      end
+      raise ArgumentError, "Invalid arguments when calling wait(numSlaves,timeout)"
     end
     #  Watch the given keys to determine execution of the MULTI/EXEC block
     # @param [Array<String>] keys List of keys to watch

--- a/src/test/java/io/vertx/test/redis/RedisClientTestBase.java
+++ b/src/test/java/io/vertx/test/redis/RedisClientTestBase.java
@@ -608,7 +608,7 @@ public abstract class RedisClientTestBase extends VertxTestBase {
   @Test
   public void testEvalshaNumKeysAndValuesDifferent() {
     String inline = "return 1";
-    redis.scriptLoad(inline, reply->{
+    redis.scriptLoad(inline, reply -> {
       assertTrue(reply.succeeded());
       assertNotNull(reply.result());
 
@@ -618,7 +618,7 @@ public abstract class RedisClientTestBase extends VertxTestBase {
       keys.add("key2");
       values.add("value1");
 
-      redis.evalsha(reply.result(), keys, values, reply2 ->{
+      redis.evalsha(reply.result(), keys, values, reply2 -> {
         assertTrue(reply2.succeeded());
         testComplete();
       });
@@ -649,14 +649,14 @@ public abstract class RedisClientTestBase extends VertxTestBase {
       assertTrue(reply.succeeded());
       redis.set("multi-key", "first", reply2 -> {
         assertTrue(reply2.succeeded());
-        redis.set("multi-key2", "second", reply3 ->{
+        redis.set("multi-key2", "second", reply3 -> {
           assertTrue(reply3.succeeded());
         });
-        redis.get("multi-key", reply4 ->{
+        redis.get("multi-key", reply4 -> {
           assertTrue(reply4.succeeded());
           assertTrue("QUEUED".equalsIgnoreCase(reply4.result()));
         });
-        redis.exec(reply5 ->{
+        redis.exec(reply5 -> {
           assertTrue(reply5.succeeded());
           testComplete();
         });
@@ -1660,16 +1660,16 @@ public abstract class RedisClientTestBase extends VertxTestBase {
 
     String key = makeKey();
 
-    redis.set(key, "0", rep ->{
+    redis.set(key, "0", rep -> {
       assertTrue(rep.succeeded());
       redis.multi(reply -> {
         assertTrue(reply.succeeded());
         redis.set(makeKey(), "0", reply2 -> {
           assertTrue(reply2.succeeded());
-          redis.set(makeKey(), "0", reply3 ->{
+          redis.set(makeKey(), "0", reply3 -> {
             assertTrue(reply3.succeeded());
           });
-          redis.exec(reply4 ->{
+          redis.exec(reply4 -> {
             assertTrue(reply4.succeeded());
             testComplete();
           });
@@ -3247,7 +3247,7 @@ public abstract class RedisClientTestBase extends VertxTestBase {
         assertTrue(String.valueOf(reply1.cause()), reply1.succeeded());
         assertEquals(12, reply1.result().longValue());
 
-        final byte[] value2 = new byte[] {0, 0, 0};
+        final byte[] value2 = new byte[]{0, 0, 0};
         redis.setBinary(key, new String(value2, charset), reply2 -> {
           assertTrue(reply2.succeeded());
           redis.bitpos(key, 1, reply3 -> {


### PR DESCRIPTION
Add missing 3.0 API related to clustering, testing however is more complicated since both docker images and embedded redis do not support clustering, still need to figure out how to automate testing for this.

There is nothing really exciting here just add the commands to the client interface and delegate to the generic redis command on the impl.

@purplefox @vietj @cescoffier please review