### PR TITLE
convert commands to lowercase to compare with switch cases string literals

### DIFF
--- a/src/main/java/io/vertx/redis/impl/AbstractRedisClient.java
+++ b/src/main/java/io/vertx/redis/impl/AbstractRedisClient.java
@@ -110,7 +110,7 @@ public abstract class AbstractRedisClient implements RedisClient {
     // subscribe/psubscribe and unsubscribe/punsubscribe commands can have multiple (including zero) replies
     int expectedReplies = 1;
 
-    switch (command) {
+    switch (command.toLowerCase()) {
       // argument "pattern" ["pattern"...]
       case "psubscribe":
         // in this case we need also to register handlers


### PR DESCRIPTION
The switch case comparison fails for command as of 3.0.0 since we pass ing upper case commands, but in the switch cases we're using lower case string literals.