### PR TITLE
Fix #61: synchronize around queue access and socket writes otherwise …

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -140,6 +140,7 @@ Set TYPE filter
  * `port`: 6379
  * `tcpKeepAlive`: true
  * `tcpNoDelay`: true
+ * `binary`: false
 
  However there are two extra properties that have no defaults since they are optional:
 
@@ -164,6 +165,10 @@ Set the eventbus address prefix for `PUB/SUB`.
 |[[auth]]`auth`|`String`|
 +++
 Set the password for authentication at connection time.
++++
+|[[binary]]`binary`|`Boolean`|
++++
+Set the user defined character encoding, e.g.: `iso-8859-1`.
 +++
 |[[encoding]]`encoding`|`String`|
 +++

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -35,7 +35,7 @@ To use the Vert.x Redis client, add the following dependency to the _dependencie
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-redis-client</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -43,7 +43,7 @@ To use the Vert.x Redis client, add the following dependency to the _dependencie
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-redis-client:3.3.0'
+compile 'io.vertx:vertx-redis-client:3.3.1-SNAPSHOT'
 ----
 
 == Connecting to Redis

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -35,7 +35,7 @@ To use the Vert.x Redis client, add the following dependency to the _dependencie
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-redis-client</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -43,7 +43,7 @@ To use the Vert.x Redis client, add the following dependency to the _dependencie
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-redis-client:3.3.0'
+compile 'io.vertx:vertx-redis-client:3.3.1-SNAPSHOT'
 ----
 
 == Connecting to Redis

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -35,7 +35,7 @@ To use the Vert.x Redis client, add the following dependency to the _dependencie
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-redis-client</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -43,7 +43,7 @@ To use the Vert.x Redis client, add the following dependency to the _dependencie
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-redis-client:3.3.0'
+compile 'io.vertx:vertx-redis-client:3.3.1-SNAPSHOT'
 ----
 
 == Connecting to Redis

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -35,7 +35,7 @@ To use the Vert.x Redis client, add the following dependency to the _dependencie
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-redis-client</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -43,7 +43,7 @@ To use the Vert.x Redis client, add the following dependency to the _dependencie
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-redis-client:3.3.0'
+compile 'io.vertx:vertx-redis-client:3.3.1-SNAPSHOT'
 ----
 
 == Connecting to Redis

--- a/src/main/java/io/vertx/redis/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/RedisOptions.java
@@ -28,6 +28,7 @@ import io.vertx.core.json.JsonObject;
  * * `port`: 6379
  * * `tcpKeepAlive`: true
  * * `tcpNoDelay`: true
+ * * `binary`: false
  *
  * However there are two extra properties that have no defaults since they are optional:
  *
@@ -59,6 +60,28 @@ public class RedisOptions {
    */
   public RedisOptions setEncoding(String encoding) {
     json.put("encoding", encoding);
+    if ("iso-8859-1".equalsIgnoreCase(encoding)) {
+      json.put("binary", true);
+    }
+    return this;
+  }
+
+  /**
+   * Return if the messages to/from redis are binary, default `false`.
+   * @return are messages binary
+   */
+  public boolean isBinary() {
+    return json.getBoolean("binary", false);
+  }
+
+  /**
+   * Set the user defined character encoding, e.g.: `iso-8859-1`.
+   * @param binary use binary messages
+   * @return self
+   */
+  public RedisOptions setBinary(boolean binary) {
+    json.put("binary", binary);
+    json.put("encoding", "iso-8859-1");
     return this;
   }
 
@@ -199,6 +222,16 @@ public class RedisOptions {
 
   public RedisOptions(JsonObject json) {
     this.json = json.copy();
+
+    // process the binary support
+    if (getEncoding().equalsIgnoreCase("iso-8859-1")) {
+      setBinary(true);
+      return;
+    }
+
+    if (isBinary()) {
+      setEncoding("iso-8859-1");
+    }
   }
 
   public RedisOptions(RedisOptions options) {

--- a/src/main/java/io/vertx/redis/impl/AbstractRedisClient.java
+++ b/src/main/java/io/vertx/redis/impl/AbstractRedisClient.java
@@ -28,7 +28,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class AbstractRedisClient implements RedisClient {
 
-  private final Vertx vertx;
   private final EventBus eb;
   private final RedisSubscriptions subscriptions;
   private final String encoding;
@@ -41,7 +40,6 @@ public abstract class AbstractRedisClient implements RedisClient {
   private final RedisConnection pubsub;
 
   AbstractRedisClient(Vertx vertx, RedisOptions config) {
-    this.vertx = vertx;
     this.eb = vertx.eventBus();
     this.encoding = config.getEncoding();
     this.charset = Charset.forName(encoding);
@@ -85,37 +83,30 @@ public abstract class AbstractRedisClient implements RedisClient {
   }
 
   final void sendString(final RedisCommand command, final List<?> args, final Handler<AsyncResult<String>> resultHandler) {
-    send(command, args, String.class, resultHandler);
+    send(command, args, String.class, false, resultHandler);
   }
 
   final void sendLong(final RedisCommand command, final List<?> args, final Handler<AsyncResult<Long>> resultHandler) {
-    send(command, args, Long.class, resultHandler);
+    send(command, args, Long.class, false, resultHandler);
   }
 
   final void sendVoid(final RedisCommand command, final List<?> args, final Handler<AsyncResult<Void>> resultHandler) {
-    send(command, args, Void.class, resultHandler);
+    send(command, args, Void.class, false, resultHandler);
   }
 
   final void sendJsonArray(final RedisCommand command, final List<?> args, final Handler<AsyncResult<JsonArray>> resultHandler) {
-    send(command, args, JsonArray.class, resultHandler);
+    send(command, args, JsonArray.class, false, resultHandler);
   }
 
   final void sendJsonObject(final RedisCommand command, final List<?> args, final Handler<AsyncResult<JsonObject>> resultHandler) {
-    send(command, args, JsonObject.class, resultHandler);
-  }
-
-  final <T> void send(final RedisCommand command, final List<?> redisArgs,
-                      final Class<T> returnType,
-                      final Handler<AsyncResult<T>> resultHandler) {
-
-    send(command, redisArgs, returnType, false, resultHandler);
+    send(command, args, JsonObject.class, false, resultHandler);
   }
 
   final <T> void send(final RedisCommand command, final List<?> redisArgs, final Class<T> returnType,
                       final boolean binary,
                       final Handler<AsyncResult<T>> resultHandler) {
 
-    final Command<T> cmd = new Command<>(vertx.getOrCreateContext(), command, redisArgs, binary ? binaryCharset : charset, getResponseTransformFor(command), returnType).handler(resultHandler);
+    final Command<T> cmd = new Command<>(Vertx.currentContext(), command, redisArgs, binary ? binaryCharset : charset, getResponseTransformFor(command), returnType).handler(resultHandler);
 
     switch (command) {
       case PSUBSCRIBE:

--- a/src/main/java/io/vertx/redis/impl/Command.java
+++ b/src/main/java/io/vertx/redis/impl/Command.java
@@ -18,6 +18,7 @@ package io.vertx.redis.impl;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.streams.WriteStream;
 
@@ -150,7 +151,11 @@ public class Command<T> {
   public void handle(AsyncResult<T> asyncResult) {
     if (handler != null) {
       if (context != null) {
-        context.runOnContext(v -> handler.handle(asyncResult));
+        if (Vertx.currentContext() == context) {
+          handler.handle(asyncResult);
+        } else {
+          context.runOnContext(v -> handler.handle(asyncResult));
+        }
       } else {
         handler.handle(asyncResult);
       }

--- a/src/main/java/io/vertx/redis/impl/Command.java
+++ b/src/main/java/io/vertx/redis/impl/Command.java
@@ -18,7 +18,6 @@ package io.vertx.redis.impl;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.streams.WriteStream;
 
@@ -83,8 +82,8 @@ public class Command<T> {
   private int expectedReplies = 1;
   private Handler<AsyncResult<T>> handler;
 
-  public Command(RedisCommand command, final List<?> args, Charset encoding, ResponseTransform transform, Class<T> returnType) {
-    this.context = Vertx.currentContext();
+  public Command(Context context, RedisCommand command, final List<?> args, Charset encoding, ResponseTransform transform, Class<T> returnType) {
+    this.context = context;
     this.encoding = encoding.name();
 
     this.transform = transform;

--- a/src/main/java/io/vertx/redis/impl/RedisConnection.java
+++ b/src/main/java/io/vertx/redis/impl/RedisConnection.java
@@ -248,10 +248,14 @@ class RedisConnection {
         break;
       case CONNECTING:
       case ERROR:
-        pending.add(command);
+        runOnContext(v -> {
+          pending.add(command);
+        });
         break;
       case DISCONNECTED:
-        pending.add(command);
+        runOnContext(v -> {
+          pending.add(command);
+        });
         connect();
         break;
     }

--- a/src/main/java/io/vertx/redis/impl/ReplyParser.java
+++ b/src/main/java/io/vertx/redis/impl/ReplyParser.java
@@ -21,7 +21,7 @@ import io.vertx.core.buffer.Buffer;
 public class ReplyParser implements Handler<Buffer> {
   
   private static class IndexOutOfBoundsException extends Exception {
-    public IndexOutOfBoundsException(String message) {
+    IndexOutOfBoundsException(String message) {
       super(message);
     }
     
@@ -41,9 +41,11 @@ public class ReplyParser implements Handler<Buffer> {
     this.handler = handler;
   }
 
-  public void reset() {
+  public ReplyParser reset() {
     _buffer = null;
     _offset = 0;
+
+    return this;
   }
 
 

--- a/src/test/java/io/vertx/test/redis/RedisAuthRecoverTest.java
+++ b/src/test/java/io/vertx/test/redis/RedisAuthRecoverTest.java
@@ -67,16 +67,18 @@ public class RedisAuthRecoverTest extends AbstractRedisClientBase {
         // INFO: there are 2 gets here because we are killing the server process before and do not let the
         // OS deliver the socket error in time, so the 1st attempt will get a connection lost error and the
         // second will the properly reconnect.
-        rdx.get(key, get -> {
+        vertx.runOnContext(v -> {
+          rdx.get(key, get -> {
 
-          assertTrue(get.succeeded());
+            assertTrue(get.succeeded());
 
-          try {
-            server.stop();
-          } catch (Exception ignore) {
-          }
+            try {
+              server.stop();
+            } catch (Exception ignore) {
+            }
 
-          testComplete();
+            testComplete();
+          });
         });
       });
     });


### PR DESCRIPTION
…the pipeline will get out of order and responses are not aligned with handlers

The client was using a concurrent list to safeguard from concurrent access to the handler/response queue, however the proper control should be around the queue and the socket writes a write must be properly aligned with a offer to the queue otherwise the waiting handlers will be offset (the cast exception).