### PR TITLE
Add high level scripting method

### DIFF
--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.redis.RedisClient;
 import io.vertx.redis.RedisOptions;
 import io.vertx.redis.RedisTransaction;
+import io.vertx.redis.Script;
 
 /**
  * These are the examples used in the documentation.
@@ -74,6 +75,17 @@ public class Examples {
           });
         }
       });
+    });
+  }
+
+  public void example6() {
+    RedisClient client = RedisClient.create(Vertx.vertx(), new RedisOptions().setAddress("127.0.0.1").setPort(6379));
+    client.evalScript(Script.create("return 42"), null, null, res -> {
+      if (res.succeeded()) {
+        System.out.println(res.result().getInteger(0));
+      } else {
+        System.err.println(res.cause());
+      }
     });
   }
 }

--- a/src/main/java/io/vertx/redis/RedisClient.java
+++ b/src/main/java/io/vertx/redis/RedisClient.java
@@ -741,6 +741,25 @@ public interface RedisClient {
   RedisClient evalsha(String sha1, List<String> keys, List<String> values, Handler<AsyncResult<JsonArray>> handler);
 
   /**
+   * Execute a Lua script server side. This method is a high level wrapper around EVAL and EVALSHA
+   * using the latter if possible, falling back to EVAL if the script is not cached by the server yet.
+   * According to Redis documentation, executed scripts are guaranteed to be in the script cache of a
+   * given execution of a Redis instance forever, which means typically the overhead incurred by
+   * optimistically sending EVALSHA is minimal, while improving performance and saving bandwidth
+   * compared to using EVAL every time.
+   *
+   * @see <a href="https://redis.io/commands/eval#script-cache-semantics">Redis - Script cache semantics</a>
+   *
+   * @param script  Lua script and its SHA1 digest
+   * @param keys    List of keys
+   * @param args    List of argument values
+   * @param handler Handler for the result of this call.
+   * group: scripting
+   */
+  @Fluent
+  RedisClient evalScript(Script script, List<String> keys, List<String> args, Handler<AsyncResult<JsonArray>> handler);
+
+  /**
    * Determine if a key exists
    *
    * @param key     Key string

--- a/src/main/java/io/vertx/redis/Script.java
+++ b/src/main/java/io/vertx/redis/Script.java
@@ -1,0 +1,20 @@
+package io.vertx.redis;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.redis.impl.ScriptImpl;
+
+/**
+ * Container for a script and its sha1 hash.
+ */
+@VertxGen
+public interface Script {
+  static Script create(String script) {
+    return new ScriptImpl(script);
+  }
+  static Script create(String script, String sha1) {
+    return new ScriptImpl(script, sha1);
+  }
+
+  String getScript();
+  String getSha1();
+}

--- a/src/main/java/io/vertx/redis/impl/RedisClientImpl.java
+++ b/src/main/java/io/vertx/redis/impl/RedisClientImpl.java
@@ -25,6 +25,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.redis.RedisClient;
 import io.vertx.redis.RedisOptions;
 import io.vertx.redis.RedisTransaction;
+import io.vertx.redis.Script;
 import io.vertx.redis.op.*;
 
 import java.util.*;
@@ -461,6 +462,18 @@ public final class RedisClientImpl extends AbstractRedisClient {
     keys = (keys != null) ? keys : Collections.emptyList();
     args = (args != null) ? args : Collections.emptyList();
     sendJsonArray(EVALSHA, toPayload(sha1, keys.size(), keys, args), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient evalScript(Script script, List<String> keys, List<String> args, Handler<AsyncResult<JsonArray>> handler) {
+    this.evalsha(script.getSha1(), keys, args, res -> {
+      if (res.failed() && res.cause().getMessage().startsWith("NOSCRIPT")) {
+        this.eval(script.getScript(), keys, args, handler);
+      } else {
+        handler.handle(res);
+      }
+    });
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/impl/ScriptImpl.java
+++ b/src/main/java/io/vertx/redis/impl/ScriptImpl.java
@@ -1,0 +1,57 @@
+package io.vertx.redis.impl;
+
+import java.nio.charset.Charset;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class ScriptImpl implements io.vertx.redis.Script {
+  private final String script;
+  private final String sha1;
+
+  private static final char[] DIGITS_LOWER =
+    {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+  public ScriptImpl(String script) {
+    this(script, digestSha1(script));
+  }
+
+  public ScriptImpl(String script, byte[] sha1) {
+    this(script, String.valueOf(encodeHex(sha1)));
+  }
+
+  public ScriptImpl(String script, String sha1) {
+    this.script = script;
+    this.sha1 = sha1;
+  }
+
+  private static byte[] digestSha1(String script) {
+    final MessageDigest sha1;
+    try {
+      sha1 = MessageDigest.getInstance("SHA1");
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+    return sha1.digest(script.getBytes(Charset.forName("UTF-8")));
+  }
+
+  private static char[] encodeHex(byte[] data) {
+    final int l = data.length;
+    final char[] out = new char[l << 1];
+    // two characters form the hex value.
+    for (int i = 0, j = 0; i < l; i++) {
+      out[j++] = DIGITS_LOWER[(0xF0 & data[i]) >>> 4];
+      out[j++] = DIGITS_LOWER[0x0F & data[i]];
+    }
+    return out;
+  }
+
+  @Override
+  public String getScript() {
+    return script;
+  }
+
+  @Override
+  public String getSha1() {
+    return sha1;
+  }
+}

--- a/src/test/java/io/vertx/test/redis/EvalTest.java
+++ b/src/test/java/io/vertx/test/redis/EvalTest.java
@@ -15,6 +15,7 @@
  */
 package io.vertx.test.redis;
 
+import io.vertx.redis.Script;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -73,6 +74,21 @@ public class EvalTest extends AbstractRedisClientBase {
         redis.evalsha("6b1bf486c81ceb7edf3c093f4c48582e38c0e791", null, null, res2 -> {
           assertTrue(res1.succeeded());
           // expect "bar"
+          testComplete();
+        });
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void test6() {
+    redis.scriptFlush(res -> {
+      assertTrue(res.succeeded());
+      redis.evalScript(Script.create("return 1"), null, null, res1 -> {
+        assertTrue(res1.succeeded());
+        redis.evalScript(Script.create("return 1"), null, null, res2 -> {
+          assertTrue(res2.succeeded());
           testComplete();
         });
       });


### PR DESCRIPTION
Adds the method `evalScript` to `RedisClient`. 

This is not a Redis command, rather a higher level function that can be used to evaluate a script on Redis without worrying about script caching. It is modelled after [defineCommand in luin/ioredis](https://github.com/luin/ioredis#lua-scripting), and basically serves as a replacement for `eval`.
When calling `evalScript` it executes EVALSHA, and if the server responds with NOSCRIPT error, it tries again using EVAL. (This makes it impossible to do in a transaction).

See [Bandwith and EVALSHA](https://redis.io/commands/eval#bandwidth-and-evalsha)

