### PR TITLE
Add Support for Command 'UNLINK' and 'SWAPDB'

### DIFF
--- a/src/main/java/io/vertx/redis/RedisClient.java
+++ b/src/main/java/io/vertx/redis/RedisClient.java
@@ -2824,4 +2824,38 @@ public interface RedisClient {
    */
   @Fluent
   RedisClient bitfieldWithOverflow(String key, BitFieldOptions commands, BitFieldOverflowOptions overflow, Handler<AsyncResult<JsonArray>> handler);
+
+  /**
+   * Delete a key asynchronously in another thread. Otherwise it is just as DEL, but non blocking.
+   *
+   * @param key     Key to delete
+   * @param handler Handler for the result of this call.
+   * @since Redis 4.0.0
+   * group: generic
+   */
+  @Fluent
+  RedisClient unlink(String key, Handler<AsyncResult<Long>> handler);
+
+  /**
+   * Delete multiple keys asynchronously in another thread. Otherwise it is just as DEL, but non blocking.
+   *
+   * @param keys    List of keys to delete
+   * @param handler Handler for the result of this call.
+   * @since Redis 4.0.0
+   * group: generic
+   */
+  @Fluent
+  RedisClient unlinkMany(List<String> keys, Handler<AsyncResult<Long>> handler);
+
+  /**
+   * Swaps two Redis databases
+   *
+   * @param index1  index of first database to swap
+   * @param index2  index of second database to swap
+   * @param handler Handler for the result of this call.
+   * @since Redis 4.0.0
+   * group: connection
+   */
+  @Fluent
+  RedisClient swapdb(int index1, int index2, Handler<AsyncResult<String>> handler);
 }

--- a/src/main/java/io/vertx/redis/RedisTransaction.java
+++ b/src/main/java/io/vertx/redis/RedisTransaction.java
@@ -2772,4 +2772,37 @@ public interface RedisTransaction {
    */
   @Fluent
   RedisTransaction georadiusbymemberWithOptions(String key, String member, double radius, GeoUnit unit, GeoRadiusOptions options, Handler<AsyncResult<String>> handler);
+
+  /**
+   * Delete a key asynchronously in another thread. Otherwise it is just as DEL, but non blocking.
+   *
+   * @param key Key string
+   * @since Redis 4.0.0
+   * group: generic
+   */
+  @Fluent
+  RedisTransaction unlink(String key, Handler<AsyncResult<String>> handler);
+
+  /**
+   * Delete multiple keys asynchronously in another thread. Otherwise it is just as DEL, but non blocking.
+   *
+   * @param keys    List of keys to delete
+   * @param handler Handler for the result of this call.
+   * @since Redis 4.0.0
+   * group: generic
+   */
+  @Fluent
+  RedisTransaction unlinkMany(List<String> keys, Handler<AsyncResult<String>> handler);
+
+  /**
+   * Swaps two Redis databases
+   *
+   * @param index1  index of first database to swap
+   * @param index2  index of second database to swap
+   * @param handler Handler for the result of this call.
+   * @since Redis 4.0.0
+   * group: connection
+   */
+  @Fluent
+  RedisTransaction swapdb(int index1, int index2, Handler<AsyncResult<String>> handler);
 }

--- a/src/main/java/io/vertx/redis/impl/RedisClientImpl.java
+++ b/src/main/java/io/vertx/redis/impl/RedisClientImpl.java
@@ -1532,6 +1532,24 @@ public final class RedisClientImpl extends AbstractRedisClient {
     return this;
   }
 
+  @Override
+  public RedisClient unlink(String key, Handler<AsyncResult<Long>> handler) {
+    sendLong(UNLINK, toPayload(key), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient unlinkMany(List<String> keys, Handler<AsyncResult<Long>> handler) {
+    sendLong(UNLINK, toPayload(keys), handler);
+    return this;
+  }
+
+  @Override
+  public RedisClient swapdb(int index1, int index2, Handler<AsyncResult<String>> handler) {
+    sendString(SWAPDB, toPayload(index1, index2), handler);
+    return this;
+  }
+
   public class RedisTransactionImpl implements RedisTransaction {
 
     @Override
@@ -2954,6 +2972,24 @@ public final class RedisClientImpl extends AbstractRedisClient {
     @Override
     public RedisTransaction georadiusbymemberWithOptions(String key, String member, double radius, GeoUnit unit, GeoRadiusOptions options, Handler<AsyncResult<String>> handler) {
       sendString(GEORADIUSBYMEMBER, toPayload(key, member, radius, unit, options != null ? options.toJsonArray() : null), handler);
+      return this;
+    }
+
+    @Override
+    public RedisTransaction unlink(String key, Handler<AsyncResult<String>> handler) {
+      sendString(UNLINK, toPayload(key), handler);
+      return this;
+    }
+
+    @Override
+    public RedisTransaction unlinkMany(List<String> keys, Handler<AsyncResult<String>> handler) {
+      sendString(UNLINK, toPayload(keys), handler);
+      return this;
+    }
+
+    @Override
+    public RedisTransaction swapdb(int index1, int index2, Handler<AsyncResult<String>> handler) {
+      sendString(SWAPDB, toPayload(index1, index2), handler);
       return this;
     }
   }

--- a/src/main/java/io/vertx/redis/impl/RedisCommand.java
+++ b/src/main/java/io/vertx/redis/impl/RedisCommand.java
@@ -215,7 +215,9 @@ public enum RedisCommand implements AbstractCommand {
   CLIENT_REPLY("CLIENT REPLY"),
   HSTRLEN("HSTRLEN"),
   SCRIPT_DEBUG("SCRIPT DEBUG"),
-  TOUCH("TOUCH");
+  TOUCH("TOUCH"),
+  UNLINK("UNLINK"),
+  SWAPDB("SWAPDB");
 
   private final String[] tokens;
 


### PR DESCRIPTION
It seems that the client presently doesn't support the new command 'UNLINK' and 'SWAPDB' since Redis 4.0.0, I spend some time to make it work:)