### PR TITLE
Use a single factory

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -203,6 +203,9 @@ Set the role name (only considered in HA mode).
 |[[select]]`@select`|`Number (Integer)`|+++
 Set the provided database to be selected when establishing a connection to the server.
 +++
+|[[type]]`@type`|`link:enums.html#RedisClientType[RedisClientType]`|+++
+Set the desired client type to be created.
++++
 |[[useSlave]]`@useSlave`|`link:enums.html#RedisSlaves[RedisSlaves]`|+++
 Set whether or not to use slave nodes (only considered in Cluster mode).
 +++

--- a/src/main/asciidoc/enums.adoc
+++ b/src/main/asciidoc/enums.adoc
@@ -153,6 +153,33 @@ Feet
 |[[WITHSCORES]]`WITHSCORES`|-
 |===
 
+[[RedisClientType]]
+== RedisClientType
+
+++++
+ Define what kind of behavior is expected from the client.
+++++
+'''
+
+[cols=">25%,75%"]
+[frame="topbot"]
+|===
+^|Name | Description
+|[[STANDALONE]]`STANDALONE`|+++
+The client should work in single server mode (the default).
++++
+|[[SENTINEL]]`SENTINEL`|+++
+The client should work in sentinel mode. When this mode is active
+ use the link to define which role to get the client
+ connection to.
++++
+|[[CLUSTER]]`CLUSTER`|+++
+The client should work in cluster mode. When this mode is active
+ use the link to define when slave nodes can be used
+ for read only queries.
++++
+|===
+
 [[RedisRole]]
 == RedisRole
 

--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -49,6 +49,11 @@ public class RedisOptionsConverter {
             obj.setSelect(((Number)member.getValue()).intValue());
           }
           break;
+        case "type":
+          if (member.getValue() instanceof String) {
+            obj.setType(io.vertx.redis.client.RedisClientType.valueOf((String)member.getValue()));
+          }
+          break;
         case "useSlave":
           if (member.getValue() instanceof String) {
             obj.setUseSlave(io.vertx.redis.client.RedisSlaves.valueOf((String)member.getValue()));
@@ -79,6 +84,9 @@ public class RedisOptionsConverter {
     }
     if (obj.getSelect() != null) {
       json.put("select", obj.getSelect());
+    }
+    if (obj.getType() != null) {
+      json.put("type", obj.getType().name());
     }
     if (obj.getUseSlave() != null) {
       json.put("useSlave", obj.getUseSlave().name());

--- a/src/main/java/examples/RedisExamples.java
+++ b/src/main/java/examples/RedisExamples.java
@@ -54,9 +54,10 @@ public class RedisExamples {
   }
 
   public void example5(Vertx vertx) {
-    Redis.createSentinelClient(
+    Redis.createClient(
       vertx,
       new RedisOptions()
+        .setType(RedisClientType.SENTINEL)
         .addEndpoint(SocketAddress.inetSocketAddress(5000, "127.0.0.1"))
         .addEndpoint(SocketAddress.inetSocketAddress(5001, "127.0.0.1"))
         .addEndpoint(SocketAddress.inetSocketAddress(5002, "127.0.0.1"))

--- a/src/main/java/io/vertx/redis/client/Redis.java
+++ b/src/main/java/io/vertx/redis/client/Redis.java
@@ -65,35 +65,6 @@ public interface Redis extends ReadStream<Response> {
   }
 
   /**
-   * Connect to redis in sentinel mode, the {@code onConnect} will get the {@link Redis} instance.
-   *
-   * This is a helper factory which uses a preset of defaults for the connection:
-   *
-   * <ul>
-   *     <li>client type - <b>SENTINEL</b></li>
-   *     <li>role - <b>MASTER</b></li>
-   *     <li>master name - <b>"mymaster"</b></li>
-   * </ul>
-   */
-  static void createSentinelClient(Vertx vertx, SocketAddress address, Handler<AsyncResult<Redis>> onCreate) {
-    createClient(vertx, new RedisOptions().setType(RedisClientType.SENTINEL).setEndpoint(address).setRole(RedisRole.MASTER).setMasterName("mymaster"), onCreate);
-  }
-
-  /**
-   * Connect to redis in cluster mode, the {@code onConnect} will get the {@link Redis} instance.
-   *
-   * This is a helper factory which uses a preset of defaults for the connection:
-   *
-   * <ul>
-   *     <li>client type - <b>CLUSTER</b></li>
-   *     <li>slave usage - <b>NEVER</b></li>
-   * </ul>
-   */
-  static void createClusterClient(Vertx vertx, SocketAddress address, Handler<AsyncResult<Redis>> onCreate) {
-    createClient(vertx, new RedisOptions().setType(RedisClientType.CLUSTER).setEndpoint(address).setUseSlave(RedisSlaves.NEVER), onCreate);
-  }
-
-  /**
    * Set an exception handler on the read stream.
    *
    * @param handler  the exception handler

--- a/src/main/java/io/vertx/redis/client/RedisClientType.java
+++ b/src/main/java/io/vertx/redis/client/RedisClientType.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ * <p>
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.redis.client;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * Define what kind of behavior is expected from the client.
+ */
+@VertxGen
+public enum RedisClientType {
+
+  /**
+   * The client should work in single server mode (the default).
+   */
+  STANDALONE,
+
+  /**
+   * The client should work in sentinel mode. When this mode is active
+   * use the {@link RedisRole} to define which role to get the client
+   * connection to.
+   */
+  SENTINEL,
+
+  /**
+   * The client should work in cluster mode. When this mode is active
+   * use the {@link RedisSlaves} to define when slave nodes can be used
+   * for read only queries.
+   */
+  CLUSTER
+}

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -31,6 +31,7 @@ import java.util.List;
 @DataObject(generateConverter = true)
 public class RedisOptions {
 
+  private RedisClientType type;
   private NetClientOptions netClientOptions;
   private List<SocketAddress> endpoints;
   private int maxWaitingHandlers;
@@ -52,6 +53,7 @@ public class RedisOptions {
     masterName = "mymaster";
     role = RedisRole.MASTER;
     slaves = RedisSlaves.NEVER;
+    type = RedisClientType.STANDALONE;
   }
 
   /**
@@ -66,6 +68,7 @@ public class RedisOptions {
    * @param other the object to clone.
    */
   public RedisOptions(RedisOptions other) {
+    this.type = other.type;
     this.netClientOptions = other.netClientOptions;
     this.endpoints = other.endpoints;
     this.maxWaitingHandlers = other.maxWaitingHandlers;
@@ -85,6 +88,25 @@ public class RedisOptions {
     init();
     RedisOptionsConverter.fromJson(json, this);
   }
+
+  /**
+   * Get the type of client to be created.
+   * @return the desired client type.
+   */
+  public RedisClientType getType() {
+    return type;
+  }
+
+  /**
+   * Set the desired client type to be created.
+   * @param type the client type.
+   * @return fluent self.
+   */
+  public RedisOptions setType(RedisClientType type) {
+    this.type = type;
+    return this;
+  }
+
 
   /**
    * Get the net client options used to connect to the server.

--- a/src/main/java/io/vertx/redis/client/impl/RedisClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClient.java
@@ -36,7 +36,11 @@ public class RedisClient implements Redis, ParserHandler {
 
   private static final ErrorType CONNECTION_CLOSED = ErrorType.create("CONNECTION_CLOSED");
 
-  public static void create(Vertx vertx, SocketAddress address, RedisOptions options, Handler<AsyncResult<Redis>> onConnect) {
+  public static void create(Vertx vertx, RedisOptions options, Handler<AsyncResult<Redis>> onConnect) {
+    create(vertx, options.getEndpoint(), options, onConnect);
+  }
+
+  static void create(Vertx vertx, SocketAddress address, RedisOptions options, Handler<AsyncResult<Redis>> onConnect) {
     final NetClient netClient = vertx.createNetClient(options.getNetClientOptions());
     final int maxWaitingQueue = options.getMaxWaitingHandlers();
     final int maxNesting = options.getMaxNestedArrays();

--- a/src/main/java/io/vertx/redis/impl/RedisSentinelClientImpl.java
+++ b/src/main/java/io/vertx/redis/impl/RedisSentinelClientImpl.java
@@ -7,9 +7,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.redis.client.Redis;
-import io.vertx.redis.client.Request;
-import io.vertx.redis.client.Response;
+import io.vertx.redis.client.*;
 import io.vertx.redis.sentinel.RedisSentinel;
 
 import java.util.*;
@@ -26,7 +24,7 @@ public class RedisSentinelClientImpl implements RedisSentinel {
   private final Redis client;
 
   public static void create(Vertx vertx, io.vertx.redis.client.RedisOptions options, Handler<AsyncResult<RedisSentinel>> ready) {
-    Redis.createSentinelClient(vertx, options, onReady -> {
+    Redis.createClient(vertx, options.setType(RedisClientType.SENTINEL), onReady -> {
       if (onReady.succeeded()) {
         ready.handle(Future.succeededFuture(new RedisSentinelClientImpl(onReady.result())));
       } else {

--- a/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
@@ -9,6 +9,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisClientType;
 import io.vertx.redis.client.RedisOptions;
 import io.vertx.redis.client.Response;
 import org.junit.Ignore;
@@ -31,6 +32,7 @@ public class RedisClusterTest {
 
   // Server: https://github.com/Grokzen/docker-redis-cluster
   final RedisOptions options = new RedisOptions()
+    .setType(RedisClientType.CLUSTER)
     // we will flood the redis server
     .setMaxWaitingHandlers(128 * 1024)
     .addEndpoint(SocketAddress.inetSocketAddress(7000, "127.0.0.1"))
@@ -52,7 +54,7 @@ public class RedisClusterTest {
   public void runTheSlotScope(TestContext should) {
     final Async test = should.async();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -88,6 +90,7 @@ public class RedisClusterTest {
     final Async test = should.async();
 
     final RedisOptions options = new RedisOptions()
+      .setType(RedisClientType.CLUSTER)
       // we will flood the redis server
       .setMaxWaitingHandlers(128 * 1024)
       .addEndpoint(SocketAddress.inetSocketAddress(7000, "127.0.0.1"))
@@ -96,7 +99,7 @@ public class RedisClusterTest {
 
     // we miss add the odd port nodes on purpose
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -132,13 +135,14 @@ public class RedisClusterTest {
     final Async test = should.async();
 
     final RedisOptions options = new RedisOptions()
+      .setType(RedisClientType.CLUSTER)
       // we will flood the redis server
       .setMaxWaitingHandlers(128 * 1024)
       .addEndpoint(SocketAddress.inetSocketAddress(7000, "127.0.0.1"));
 
     // we only provide 1 node
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -174,6 +178,7 @@ public class RedisClusterTest {
     final Async test = should.async();
 
     final RedisOptions options = new RedisOptions()
+      .setType(RedisClientType.CLUSTER)
       // we will flood the redis server
       .setMaxWaitingHandlers(128 * 1024)
       .addEndpoint(SocketAddress.inetSocketAddress(7000, "127.0.0.1"));
@@ -182,7 +187,7 @@ public class RedisClusterTest {
 
     for (int i = 0; i < 24; i++) {
       Future f = Future.future();
-      Redis.createClusterClient(rule.vertx(), options, f);
+      Redis.createClient(rule.vertx(), options, f);
       futures.add(f);
     }
 
@@ -229,7 +234,7 @@ public class RedisClusterTest {
   public void testHgetall(TestContext should) {
     final Async test = should.async();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -260,7 +265,7 @@ public class RedisClusterTest {
     final Async test = should.async();
     final String key = makeKey();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -293,7 +298,7 @@ public class RedisClusterTest {
     final Async test = should.async();
     final String key = makeKey();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -329,7 +334,7 @@ public class RedisClusterTest {
     final String key2 = makeKey();
     final String destkey = makeKey();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -359,7 +364,7 @@ public class RedisClusterTest {
     final String list1 = makeKey();
     final String list2 = makeKey();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -395,7 +400,7 @@ public class RedisClusterTest {
     final byte[] value1 = new byte[]{(byte) 0xff, (byte) 0xf0, (byte) 0x00};
     final byte[] value2 = new byte[]{0, 0, 0};
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -429,7 +434,7 @@ public class RedisClusterTest {
     final String list1 = makeKey();
     final String list2 = makeKey();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -460,7 +465,7 @@ public class RedisClusterTest {
     final Async test = should.async();
     final String key = makeKey();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -483,7 +488,7 @@ public class RedisClusterTest {
     final Async test = should.async();
     final String key = makeKey();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -507,7 +512,7 @@ public class RedisClusterTest {
     final String key1 = makeKey();
     final String key2 = makeKey();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -533,7 +538,7 @@ public class RedisClusterTest {
   public void testEcho(TestContext should) {
     final Async test = should.async();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -555,7 +560,7 @@ public class RedisClusterTest {
 
     final AtomicInteger counter = new AtomicInteger();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -588,7 +593,7 @@ public class RedisClusterTest {
     final Async test = should.async();
     final String key = makeKey();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -626,7 +631,7 @@ public class RedisClusterTest {
     final Async test = should.async();
     final String key = makeKey();
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();
@@ -662,7 +667,7 @@ public class RedisClusterTest {
     final String nonExistentKey = makeKey();
 
 
-    Redis.createClusterClient(rule.vertx(), options, onCreate -> {
+    Redis.createClient(rule.vertx(), options, onCreate -> {
       should.assertTrue(onCreate.succeeded());
 
       final Redis cluster = onCreate.result();

--- a/src/test/java/io/vertx/redis/client/test/RedisSentinelTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisSentinelTest.java
@@ -19,9 +19,10 @@ public class RedisSentinelTest {
   public void testGetClientToMaster(TestContext should) {
     final Async test = should.async();
 
-    Redis.createSentinelClient(
+    Redis.createClient(
       rule.vertx(),
       new RedisOptions()
+        .setType(RedisClientType.SENTINEL)
         .addEndpoint(SocketAddress.inetSocketAddress(5000, "127.0.0.1"))
         .addEndpoint(SocketAddress.inetSocketAddress(5001, "127.0.0.1"))
         .addEndpoint(SocketAddress.inetSocketAddress(5002, "127.0.0.1"))
@@ -44,9 +45,10 @@ public class RedisSentinelTest {
   public void testGetClientToSlave(TestContext should) {
     final Async test = should.async();
 
-    Redis.createSentinelClient(
+    Redis.createClient(
       rule.vertx(),
       new RedisOptions()
+        .setType(RedisClientType.SENTINEL)
         .addEndpoint(SocketAddress.inetSocketAddress(5000, "127.0.0.1"))
         .addEndpoint(SocketAddress.inetSocketAddress(5001, "127.0.0.1"))
         .addEndpoint(SocketAddress.inetSocketAddress(5002, "127.0.0.1"))
@@ -69,9 +71,10 @@ public class RedisSentinelTest {
   public void testGetClientToSentinel(TestContext should) {
     final Async test = should.async();
 
-    Redis.createSentinelClient(
+    Redis.createClient(
       rule.vertx(),
       new RedisOptions()
+        .setType(RedisClientType.SENTINEL)
         .addEndpoint(SocketAddress.inetSocketAddress(5000, "127.0.0.1"))
         .addEndpoint(SocketAddress.inetSocketAddress(5001, "127.0.0.1"))
         .addEndpoint(SocketAddress.inetSocketAddress(5002, "127.0.0.1"))


### PR DESCRIPTION
This will allow instances of redis clients to be configurable instead of hard coded.