### PR TITLE
Remove deprecation for now in 3.7

### DIFF
--- a/src/main/java/io/vertx/redis/RedisClient.java
+++ b/src/main/java/io/vertx/redis/RedisClient.java
@@ -32,12 +32,7 @@ import io.vertx.redis.op.*;
 import java.util.List;
 import java.util.Map;
 
-/**
- * @deprecated
- * @see io.vertx.redis.client.Redis for the new API.
- */
 @VertxGen
-@Deprecated
 public interface RedisClient {
 
   static RedisClient create(Vertx vertx) {

--- a/src/main/java/io/vertx/redis/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/RedisOptions.java
@@ -43,11 +43,8 @@ import java.util.List;
  * database at connection time. If you define this extra properties on every connection to Redis server this client
  * will perform the authentication handshake and database selection, however if you don't do this and call {@link io.vertx.redis.RedisClient#auth(String, Handler)}
  * yourself in case of connection failure the client will not be able to perform the correct authentication handshake.
- * @deprecated
- * @see io.vertx.redis.client.Redis for the new API.
  */
 @DataObject(generateConverter = true)
-@Deprecated
 public class RedisOptions extends NetClientOptions {
 
   private static final String DEFAULT_ENCODING = "UTF-8";

--- a/src/main/java/io/vertx/redis/RedisTransaction.java
+++ b/src/main/java/io/vertx/redis/RedisTransaction.java
@@ -29,11 +29,8 @@ import java.util.Map;
 
 /**
  * This Interface represents a TX
- * @deprecated
- * @see io.vertx.redis.client.Redis for the new API.
  */
 @VertxGen
-@Deprecated
 public interface RedisTransaction {
   /**
    * Close the client - when it is fully closed the handler will be called.

--- a/src/main/java/io/vertx/redis/Script.java
+++ b/src/main/java/io/vertx/redis/Script.java
@@ -5,11 +5,8 @@ import io.vertx.redis.impl.ScriptImpl;
 
 /**
  * Container for a script and its sha1 hash.
- * @deprecated
- * @see io.vertx.redis.client.Redis for the new API.
  */
 @VertxGen
-@Deprecated
 public interface Script {
   static Script create(String script) {
     return new ScriptImpl(script);

--- a/src/main/java/io/vertx/redis/impl/RedisClientImpl.java
+++ b/src/main/java/io/vertx/redis/impl/RedisClientImpl.java
@@ -41,7 +41,6 @@ import java.util.stream.Stream;
 
 import static io.vertx.redis.client.Command.*;
 
-@Deprecated
 public final class RedisClientImpl implements RedisClient {
 
   private final Vertx vertx;

--- a/src/main/java/io/vertx/redis/impl/RedisEncoding.java
+++ b/src/main/java/io/vertx/redis/impl/RedisEncoding.java
@@ -32,7 +32,6 @@ package io.vertx.redis.impl;
  *
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
-@Deprecated
 public class RedisEncoding {
 
   private static final char[] NUMERALS = "0123456789abcdef".toCharArray();

--- a/src/main/java/io/vertx/redis/impl/RedisSentinelClientImpl.java
+++ b/src/main/java/io/vertx/redis/impl/RedisSentinelClientImpl.java
@@ -22,7 +22,6 @@ import static io.vertx.redis.client.Command.*;
 /**
  * Implementation of {@link RedisSentinel}
  */
-@Deprecated
 public class RedisSentinelClientImpl implements RedisSentinel {
 
   private final Vertx vertx;

--- a/src/main/java/io/vertx/redis/impl/ScriptImpl.java
+++ b/src/main/java/io/vertx/redis/impl/ScriptImpl.java
@@ -4,7 +4,6 @@ import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-@Deprecated
 public class ScriptImpl implements io.vertx.redis.Script {
   private final String script;
   private final String sha1;

--- a/src/main/java/io/vertx/redis/op/AggregateOptions.java
+++ b/src/main/java/io/vertx/redis/op/AggregateOptions.java
@@ -22,7 +22,6 @@ import io.vertx.core.json.JsonArray;
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
 @VertxGen
-@Deprecated
 public enum AggregateOptions {
   NONE,
   SUM,

--- a/src/main/java/io/vertx/redis/op/BitFieldGetCommand.java
+++ b/src/main/java/io/vertx/redis/op/BitFieldGetCommand.java
@@ -4,7 +4,6 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
 @DataObject
-@Deprecated
 public class BitFieldGetCommand {
 
   private String type;

--- a/src/main/java/io/vertx/redis/op/BitFieldIncrbyCommand.java
+++ b/src/main/java/io/vertx/redis/op/BitFieldIncrbyCommand.java
@@ -4,7 +4,6 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
 @DataObject
-@Deprecated
 public class BitFieldIncrbyCommand {
 
   private String type;

--- a/src/main/java/io/vertx/redis/op/BitFieldOptions.java
+++ b/src/main/java/io/vertx/redis/op/BitFieldOptions.java
@@ -5,7 +5,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 @DataObject
-@Deprecated
 public class BitFieldOptions {
 
   private BitFieldGetCommand get;

--- a/src/main/java/io/vertx/redis/op/BitFieldOverflowOptions.java
+++ b/src/main/java/io/vertx/redis/op/BitFieldOverflowOptions.java
@@ -21,7 +21,6 @@ import io.vertx.codegen.annotations.VertxGen;
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 @VertxGen
-@Deprecated
 public enum BitFieldOverflowOptions {
   WRAP,
   SAT,

--- a/src/main/java/io/vertx/redis/op/BitFieldSetCommand.java
+++ b/src/main/java/io/vertx/redis/op/BitFieldSetCommand.java
@@ -4,7 +4,6 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
 @DataObject
-@Deprecated
 public class BitFieldSetCommand {
 
   private String type;

--- a/src/main/java/io/vertx/redis/op/BitOperation.java
+++ b/src/main/java/io/vertx/redis/op/BitOperation.java
@@ -21,7 +21,6 @@ import io.vertx.codegen.annotations.VertxGen;
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
 @VertxGen
-@Deprecated
 public enum BitOperation {
   AND,
   OR,

--- a/src/main/java/io/vertx/redis/op/ClientReplyOptions.java
+++ b/src/main/java/io/vertx/redis/op/ClientReplyOptions.java
@@ -21,7 +21,6 @@ import io.vertx.codegen.annotations.VertxGen;
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 @VertxGen
-@Deprecated
 public enum ClientReplyOptions {
   ON,
   OFF,

--- a/src/main/java/io/vertx/redis/op/FailoverOptions.java
+++ b/src/main/java/io/vertx/redis/op/FailoverOptions.java
@@ -21,7 +21,6 @@ import io.vertx.codegen.annotations.VertxGen;
  * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
  */
 @VertxGen
-@Deprecated
 public enum FailoverOptions {
   FORCE,
   TAKEOVER

--- a/src/main/java/io/vertx/redis/op/GeoMember.java
+++ b/src/main/java/io/vertx/redis/op/GeoMember.java
@@ -23,7 +23,6 @@ import io.vertx.core.json.JsonObject;
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 @DataObject
-@Deprecated
 public class GeoMember {
 
   private Double longitude;

--- a/src/main/java/io/vertx/redis/op/GeoRadiusOptions.java
+++ b/src/main/java/io/vertx/redis/op/GeoRadiusOptions.java
@@ -23,7 +23,6 @@ import io.vertx.core.json.JsonObject;
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 @DataObject
-@Deprecated
 public class GeoRadiusOptions {
 
   private boolean withcoord;

--- a/src/main/java/io/vertx/redis/op/GeoUnit.java
+++ b/src/main/java/io/vertx/redis/op/GeoUnit.java
@@ -23,7 +23,6 @@ import io.vertx.codegen.annotations.VertxGen;
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 @VertxGen
-@Deprecated
 public enum GeoUnit {
 
   /**

--- a/src/main/java/io/vertx/redis/op/InsertOptions.java
+++ b/src/main/java/io/vertx/redis/op/InsertOptions.java
@@ -21,7 +21,6 @@ import io.vertx.codegen.annotations.VertxGen;
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
 @VertxGen
-@Deprecated
 public enum InsertOptions {
   BEFORE,
   AFTER

--- a/src/main/java/io/vertx/redis/op/KillFilter.java
+++ b/src/main/java/io/vertx/redis/op/KillFilter.java
@@ -23,7 +23,6 @@ import io.vertx.core.json.JsonObject;
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
 @DataObject
-@Deprecated
 public class KillFilter {
 
   private String addr;

--- a/src/main/java/io/vertx/redis/op/LimitOptions.java
+++ b/src/main/java/io/vertx/redis/op/LimitOptions.java
@@ -23,7 +23,6 @@ import io.vertx.core.json.JsonObject;
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
 @DataObject
-@Deprecated
 public class LimitOptions {
 
   public static final LimitOptions NONE = new LimitOptions();
@@ -44,10 +43,6 @@ public class LimitOptions {
     count = obj.getLong("count");
   }
 
-  /**
-   * @deprecated use {@link #setCount(Long)} and {@link #setOffset(Long)} instead
-   */
-  @Deprecated
   public LimitOptions setLimit(long offset, long count) {
     this.offset = offset;
     this.count = count;

--- a/src/main/java/io/vertx/redis/op/MigrateOptions.java
+++ b/src/main/java/io/vertx/redis/op/MigrateOptions.java
@@ -23,7 +23,6 @@ import io.vertx.core.json.JsonObject;
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
 @DataObject
-@Deprecated
 public class MigrateOptions {
 
   public static final MigrateOptions NONE = new MigrateOptions();
@@ -54,18 +53,11 @@ public class MigrateOptions {
     return this;
   }
 
-  /**
-   * @deprecated use {@link #setCopy(Boolean)} instead
-   */
-  @Deprecated
   public MigrateOptions useCopy() {
     copy = true;
     return this;
   }
-  /**
-   * @deprecated use {@link #setReplace(Boolean)} instead
-   */
-  @Deprecated
+
   public MigrateOptions useReplace() {
     replace = true;
     return this;

--- a/src/main/java/io/vertx/redis/op/ObjectCmd.java
+++ b/src/main/java/io/vertx/redis/op/ObjectCmd.java
@@ -21,7 +21,6 @@ import io.vertx.codegen.annotations.VertxGen;
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
 @VertxGen
-@Deprecated
 public enum ObjectCmd {
   REFCOUNT,
   ENCODING,

--- a/src/main/java/io/vertx/redis/op/RangeLimitOptions.java
+++ b/src/main/java/io/vertx/redis/op/RangeLimitOptions.java
@@ -23,7 +23,6 @@ import io.vertx.core.json.JsonObject;
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
 @DataObject
-@Deprecated
 public class RangeLimitOptions extends LimitOptions {
 
   public static final RangeLimitOptions NONE = new RangeLimitOptions();
@@ -43,10 +42,6 @@ public class RangeLimitOptions extends LimitOptions {
     withscores = obj.getBoolean("withscores");
   }
 
-  /**
-   * @deprecated use {@link #setWithscores(Boolean)} instead
-   */
-  @Deprecated
   public RangeLimitOptions useWithScores() {
     withscores = true;
     return this;

--- a/src/main/java/io/vertx/redis/op/RangeOptions.java
+++ b/src/main/java/io/vertx/redis/op/RangeOptions.java
@@ -22,7 +22,6 @@ import io.vertx.core.json.JsonArray;
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
 @VertxGen
-@Deprecated
 public enum RangeOptions {
   NONE,
   WITHSCORES;

--- a/src/main/java/io/vertx/redis/op/ResetOptions.java
+++ b/src/main/java/io/vertx/redis/op/ResetOptions.java
@@ -21,7 +21,6 @@ import io.vertx.codegen.annotations.VertxGen;
  * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
  */
 @VertxGen
-@Deprecated
 public enum ResetOptions {
   HARD,
   SOFT

--- a/src/main/java/io/vertx/redis/op/ScanOptions.java
+++ b/src/main/java/io/vertx/redis/op/ScanOptions.java
@@ -24,7 +24,6 @@ import io.vertx.core.json.JsonObject;
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
 @DataObject
-@Deprecated
 public class ScanOptions {
 
   public static final ScanOptions NONE = new ScanOptions();

--- a/src/main/java/io/vertx/redis/op/ScriptDebugOptions.java
+++ b/src/main/java/io/vertx/redis/op/ScriptDebugOptions.java
@@ -21,7 +21,6 @@ import io.vertx.codegen.annotations.VertxGen;
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 @VertxGen
-@Deprecated
 public enum ScriptDebugOptions {
   YES,
   SYNC,

--- a/src/main/java/io/vertx/redis/op/SetOptions.java
+++ b/src/main/java/io/vertx/redis/op/SetOptions.java
@@ -23,7 +23,6 @@ import io.vertx.core.json.JsonObject;
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
 @DataObject
-@Deprecated
 public class SetOptions {
 
   public static final SetOptions NONE = new SetOptions();

--- a/src/main/java/io/vertx/redis/op/ShutdownOptions.java
+++ b/src/main/java/io/vertx/redis/op/ShutdownOptions.java
@@ -22,7 +22,6 @@ import io.vertx.core.json.JsonArray;
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
 @VertxGen
-@Deprecated
 public enum ShutdownOptions {
   NONE,
   SAVE,

--- a/src/main/java/io/vertx/redis/op/SlotCmd.java
+++ b/src/main/java/io/vertx/redis/op/SlotCmd.java
@@ -21,7 +21,6 @@ import io.vertx.codegen.annotations.VertxGen;
  * @author <a href="mailto:pmlopes@gmail.com">Paulo Lopes</a>
  */
 @VertxGen
-@Deprecated
 public enum SlotCmd {
   IMPORTING,
   MIGRATING,

--- a/src/main/java/io/vertx/redis/op/SortOptions.java
+++ b/src/main/java/io/vertx/redis/op/SortOptions.java
@@ -27,7 +27,6 @@ import java.util.List;
  * @author <a href="mailto:marko.strukelj@gmail.com">Marko Strukelj</a>
  */
 @DataObject
-@Deprecated
 public class SortOptions {
 
   public static final SortOptions NONE = new SortOptions();
@@ -111,10 +110,6 @@ public class SortOptions {
     return this;
   }
 
-  /**
-   * @deprecated use {@link #setDescending(Boolean)} instead
-   */
-  @Deprecated
   public SortOptions useDescending() {
     this.descending = true;
     return this;
@@ -125,10 +120,6 @@ public class SortOptions {
     return this;
   }
 
-  /**
-   * @deprecated use {@link #setAlpha(Boolean)} instead
-   */
-  @Deprecated
   public SortOptions useAlpha() {
     this.alpha = true;
     return this;

--- a/src/main/java/io/vertx/redis/sentinel/RedisSentinel.java
+++ b/src/main/java/io/vertx/redis/sentinel/RedisSentinel.java
@@ -13,11 +13,8 @@ import io.vertx.redis.impl.RedisSentinelClientImpl;
 
 /**
  * Interface for sentinel commands
- * @deprecated
- * @see io.vertx.redis.client.Redis for the new API.
  */
 @VertxGen
-@Deprecated
 public interface RedisSentinel {
 
   static RedisSentinel create(Vertx vertx) {


### PR DESCRIPTION
this PR removes RedisClient deprecation in 3.7 as it seems premature because the new API lacks of usability when it comes to concurrently using the new Redis API putting all the burden on the user to manage concurrent connection to redis.

We need to make another iteration on the new redis API to provide the same usability before deprecating the redis client.