### PR TITLE
fixes #158 Cluster Client error handling fix proposal

### DIFF
--- a/src/main/java/io/vertx/redis/client/RedisException.java
+++ b/src/main/java/io/vertx/redis/client/RedisException.java
@@ -21,6 +21,8 @@ package io.vertx.redis.client;
  *
  * @author Paulo Lopes
  */
+
+@Deprecated
 public final class RedisException extends RuntimeException {
 
   public RedisException(String message) {
@@ -57,7 +59,7 @@ public final class RedisException extends RuntimeException {
    * Some messages are well formatted and allow extracting data from.
    * This method will extract the indexed slice of the message given the seperator sep.
    *
-   * @param sep a char seperator
+   * @param sep   a char seperator
    * @param index the desired index.
    * @return the slice or null.
    */

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -621,8 +621,8 @@ public class RedisClusterClient implements Redis {
     }
 
     client.send(command, send -> {
-      if (send.failed() && send.cause() instanceof RedisException && retries >= 0) {
-        final RedisException cause = (RedisException) send.cause();
+      if (send.failed() && send.cause() instanceof ErrorType && retries >= 0) {
+        final ErrorType cause = (ErrorType) send.cause();
 
         boolean ask = cause.is("ASK");
         boolean moved = !ask && cause.is("MOVED");
@@ -709,8 +709,8 @@ public class RedisClusterClient implements Redis {
     }
 
     client.batch(commands, send -> {
-      if (send.failed() && send.cause() instanceof RedisException && retries >= 0) {
-        final RedisException cause = (RedisException) send.cause();
+      if (send.failed() && send.cause() instanceof ErrorType && retries >= 0) {
+        final ErrorType cause = (ErrorType) send.cause();
 
         boolean ask = cause.is("ASK");
         boolean moved = !ask && cause.is("MOVED");

--- a/src/main/java/io/vertx/redis/client/impl/types/ErrorType.java
+++ b/src/main/java/io/vertx/redis/client/impl/types/ErrorType.java
@@ -61,4 +61,29 @@ public final class ErrorType extends Throwable implements Response {
   public String toString() {
     return getMessage();
   }
+
+  public String slice(char sep, int index) {
+    String message = getMessage();
+    if (message == null) {
+      return null;
+    }
+
+    int start = 0;
+    int count = 0;
+    for (int i = 0; i < message.length(); i++) {
+      if (message.charAt(i) == sep) {
+        if (++count > index) {
+          return message.substring(start, i);
+        } else {
+          start = i + 1;
+        }
+      }
+    }
+    // EOL
+    if (count == index) {
+      return message.substring(start);
+    }
+
+    return null;
+  }
 }

--- a/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
@@ -8,10 +8,7 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.redis.client.Redis;
-import io.vertx.redis.client.RedisClientType;
-import io.vertx.redis.client.RedisOptions;
-import io.vertx.redis.client.Response;
+import io.vertx.redis.client.*;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,6 +30,7 @@ public class RedisClusterTest {
   // Server: https://github.com/Grokzen/docker-redis-cluster
   final RedisOptions options = new RedisOptions()
     .setType(RedisClientType.CLUSTER)
+    .setUseSlave(RedisSlaves.SHARE)
     // we will flood the redis server
     .setMaxWaitingHandlers(128 * 1024)
     .addEndpoint(SocketAddress.inetSocketAddress(7000, "127.0.0.1"))


### PR DESCRIPTION
This is PR related to issue #158 
The fixes proposed are:

1. In RedisClusterClient check ErrorType instead of RedisException
1. Adding slice method in ErrorType
1. Mark RedisException @Depecrated because is not used in client code
1. Modified RedisClusterClientTest to test this behavior
