### PR TITLE
fixes #160 Cluster Client send READONLY command on connection proposal

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -619,8 +619,7 @@ public class RedisClusterClient implements Redis {
     }
   }
 
-  private void send(final Redis client, final RedisOptions options, final int retries, Request
-    command, Handler<AsyncResult<Response>> handler) {
+  private void send(final Redis client, final RedisOptions options, final int retries, Request command, Handler<AsyncResult<Response>> handler) {
     if (client == null) {
       try {
         handler.handle(Future.failedFuture("No connection available."));
@@ -707,8 +706,7 @@ public class RedisClusterClient implements Redis {
     });
   }
 
-  private void batch(final Redis client, final RedisOptions options, final int retries, List<
-    Request> commands, Handler<AsyncResult<List<Response>>> handler) {
+  private void batch(final Redis client, final RedisOptions options, final int retries, List<Request> commands, Handler<AsyncResult<List<Response>>> handler) {
 
     if (client == null) {
       try {

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -20,8 +20,6 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.redis.client.*;
-import io.vertx.redis.client.Redis;
-import io.vertx.redis.client.RedisOptions;
 import io.vertx.redis.client.impl.types.ErrorType;
 import io.vertx.redis.client.impl.types.IntegerType;
 import io.vertx.redis.client.impl.types.MultiType;
@@ -590,7 +588,18 @@ public class RedisClusterClient implements Redis {
       final int idx = i;
       final SocketAddress address = addresses.get(idx);
 
-      getClient(address, options, getClient -> {
+      final Future<Redis> getClientFuture = Future.future();
+      getClient(address, options, getClientFuture);
+
+      getClientFuture.compose(getClient -> {
+        if (RedisSlaves.NEVER != options.getUseSlave()) {
+          final Future<Response> readOnlyFuture = Future.future();
+          getClient.send(cmd(READONLY), readOnlyFuture);
+          return readOnlyFuture.map(getClient);
+        } else {
+          return Future.succeededFuture(getClient);
+        }
+      }).setHandler(getClient -> {
         // we don't care if we can't get a client, in this case the client is ignored
         if (getClient.failed()) {
           LOG.warn("Could not get a connection to node [" + address + "]");
@@ -610,7 +619,8 @@ public class RedisClusterClient implements Redis {
     }
   }
 
-  private void send(final Redis client, final RedisOptions options, final int retries, Request command, Handler<AsyncResult<Response>> handler) {
+  private void send(final Redis client, final RedisOptions options, final int retries, Request
+    command, Handler<AsyncResult<Response>> handler) {
     if (client == null) {
       try {
         handler.handle(Future.failedFuture("No connection available."));
@@ -697,7 +707,8 @@ public class RedisClusterClient implements Redis {
     });
   }
 
-  private void batch(final Redis client, final RedisOptions options, final int retries, List<Request> commands, Handler<AsyncResult<List<Response>>> handler) {
+  private void batch(final Redis client, final RedisOptions options, final int retries, List<
+    Request> commands, Handler<AsyncResult<List<Response>>> handler) {
 
     if (client == null) {
       try {


### PR DESCRIPTION
This is PR related to issue #160

Following discussion on Gitter between @damianofontana85 and @pmlopes I have implemented a possible solution for the related issue. The redis cluster client sends READONLY command if the slave mode is ALWAYS or SHARE to slave nodes at connection time.