### PR TITLE
Add Redis connection string URI support

### DIFF
--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -1,9 +1,7 @@
 package io.vertx.redis.client;
 
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
+import io.vertx.core.json.JsonObject;
 
 /**
  * Converter and mapper for {@link io.vertx.redis.client.RedisOptions}.
@@ -17,7 +15,7 @@ public class RedisOptionsConverter {
       switch (member.getKey()) {
         case "endpoint":
           if (member.getValue() instanceof String) {
-            obj.setEndpoint((String)member.getValue());
+            obj.setConnectionString((String)member.getValue());
           }
           break;
         case "endpoints":

--- a/src/main/java/io/vertx/redis/client/Redis.java
+++ b/src/main/java/io/vertx/redis/client/Redis.java
@@ -44,7 +44,7 @@ public interface Redis {
    * @return the client
    */
   static Redis createClient(Vertx vertx, String connectionString) {
-    return createClient(vertx, new RedisOptions().setEndpoint(connectionString));
+    return createClient(vertx, new RedisOptions().setConnectionString(connectionString));
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/Redis.java
+++ b/src/main/java/io/vertx/redis/client/Redis.java
@@ -39,7 +39,7 @@ public interface Redis {
 
   /**
    * Create a new redis client using the default client options.
-   * @param connectionString the Redis connection string URI
+   * @param connectionString a string URI following the scheme: redis://[username:password@][host][:port][/database]
    * @param vertx the vertx instance
    * @return the client
    */

--- a/src/main/java/io/vertx/redis/client/Redis.java
+++ b/src/main/java/io/vertx/redis/client/Redis.java
@@ -39,12 +39,12 @@ public interface Redis {
 
   /**
    * Create a new redis client using the default client options.
-   * @param endpoint the server address to connect to
+   * @param connectionString the Redis connection string URI
    * @param vertx the vertx instance
    * @return the client
    */
-  static Redis createClient(Vertx vertx, String endpoint) {
-    return createClient(vertx, new RedisOptions().setEndpoint(endpoint));
+  static Redis createClient(Vertx vertx, String connectionString) {
+    return createClient(vertx, new RedisOptions().setEndpoint(connectionString));
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -155,10 +155,10 @@ public class RedisOptions {
 
   /**
    * Gets the redis endpoint to use
-   * @return socket address.
+   * @return the Redis connection string URI
    */
   public String getEndpoint() {
-    if (endpoints == null || endpoints.size() == 0) {
+    if (endpoints == null || endpoints.isEmpty()) {
       return DEFAULT_ENDPOINT;
     }
 
@@ -181,31 +181,32 @@ public class RedisOptions {
    * Adds a endpoint to use while connecting to the redis server. Only the cluster mode will consider more than
    * 1 element. If more are provided, they are not considered by the client when in single server mode.
    *
-   * @param endpoint a socket addresses.
+   * @param connectionString a string following the scheme: redis://[username:password@][host][:port][/[database]
    * @return fluent self.
    */
-  public RedisOptions addEndpoint(String endpoint) {
+  public RedisOptions addEndpoint(String connectionString) {
     if (endpoints == null) {
       endpoints = new ArrayList<>();
     }
-    this.endpoints.add(endpoint);
+    this.endpoints.add(connectionString);
     return this;
   }
 
   /**
-   * Sets a single endpoint to use while connecting to the redis server. Will replace the previously configured endpoints.
+   * Sets a single connection string to use while connecting to the redis server.
+   * Will replace the previously configured connection strings.
    *
-   * @param endpoint a socket addresses.
+   * @param connectionString a string following the scheme: redis://[username:password@][host][:port][/[database]
    * @return fluent self.
    */
-  public RedisOptions setEndpoint(String endpoint) {
+  public RedisOptions setEndpoint(String connectionString) {
     if (endpoints == null) {
       endpoints = new ArrayList<>();
     } else {
       endpoints.clear();
     }
 
-    this.endpoints.add(endpoint);
+    this.endpoints.add(connectionString);
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -181,7 +181,7 @@ public class RedisOptions {
    * Adds a endpoint to use while connecting to the redis server. Only the cluster mode will consider more than
    * 1 element. If more are provided, they are not considered by the client when in single server mode.
    *
-   * @param connectionString a string following the scheme: redis://[username:password@][host][:port][/[database]
+   * @param connectionString a string URI following the scheme: redis://[username:password@][host][:port][/database]
    * @return fluent self.
    */
   public RedisOptions addEndpoint(String connectionString) {

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -198,8 +198,30 @@ public class RedisOptions {
    *
    * @param connectionString a string following the scheme: redis://[username:password@][host][:port][/[database]
    * @return fluent self.
+   *
+   * @deprecated see {@link #setConnectionString(String connectionString)} for a better naming
    */
+  @Deprecated
   public RedisOptions setEndpoint(String connectionString) {
+    if (endpoints == null) {
+      endpoints = new ArrayList<>();
+    } else {
+      endpoints.clear();
+    }
+
+    this.endpoints.add(connectionString);
+    return this;
+  }
+
+  /**
+   * Sets a single connection string to use while connecting to the redis server.
+   * Will replace the previously configured connection strings.
+   *
+   * @param connectionString a string following the scheme: redis://[username:password@][host][:port][/[database].
+   * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on www.iana.org</a>
+   * @return fluent self.
+   */
+  public RedisOptions setConnectionString(String connectionString) {
     if (endpoints == null) {
       endpoints = new ArrayList<>();
     } else {

--- a/src/main/java/io/vertx/redis/client/impl/RedisURI.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisURI.java
@@ -24,20 +24,32 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Utility to parse redis URLs
+ * Utility to parse redis URLs. An example URI can be found at <a href="https://redis.io/topics/rediscli">Redis cli docs</a>
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 public final class RedisURI {
 
-  private final String address;
+  /**
+   * Original address string
+   */
+  private final String connectionString;
+  /**
+   * Address, including host and port
+   */
   private final SocketAddress socketAddress;
+  /**
+   * Password to the Redis instance
+   */
   private final String password;
+  /**
+   * Database number
+   */
   private final Integer select;
 
-  public RedisURI(String address) {
-    this.address = address;
+  public RedisURI(String connectionString) {
+    this.connectionString = connectionString;
     try {
-      final URI uri = new URI(address);
+      final URI uri = new URI(connectionString);
 
       final String host = uri.getHost() == null ? "localhost" : uri.getHost();
       final int port = uri.getPort() == -1 ? 6379 : uri.getPort();
@@ -63,14 +75,14 @@ public final class RedisURI {
           }
           break;
         default:
-          throw new RuntimeException("Unsupported scheme [" + uri.getScheme() + "]");
+          throw new RuntimeException("Unsupported Redis connection string scheme [" + uri.getScheme() + "]");
       }
 
       String userInfo = uri.getUserInfo();
       if (userInfo != null) {
-        int col = userInfo.indexOf(':');
-        if (col != -1) {
-          password = uri.getUserInfo().substring(col + 1);
+        String[] userInfoArray = userInfo.split(":");
+        if (userInfoArray.length > 0) {
+          password = userInfoArray[userInfoArray.length - 1];
         } else {
           password = null;
         }
@@ -79,7 +91,7 @@ public final class RedisURI {
       }
 
     } catch (URISyntaxException e) {
-     throw new RuntimeException("Failed to parse the endpoint address", e);
+     throw new RuntimeException("Failed to parse the connection string", e);
     }
   }
 
@@ -112,12 +124,12 @@ public final class RedisURI {
     return select;
   }
 
-  public String address() {
-    return address;
+  public String connectionString() {
+    return connectionString;
   }
 
   @Override
   public String toString() {
-    return address;
+    return connectionString;
   }
 }

--- a/src/main/java/io/vertx/redis/client/impl/RedisURI.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisURI.java
@@ -24,7 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Utility to parse redis URLs. An example URI can be found at <a href="https://redis.io/topics/rediscli">Redis cli docs</a>
+ * Utility to parse redis URLs. The URI should follow the scheme: redis://[username:password@][host][:port][/[database]
+ * An example URI can be found at <a href="https://redis.io/topics/rediscli">Redis cli docs</a>
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 public final class RedisURI {

--- a/src/main/java/io/vertx/redis/client/impl/RedisURI.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisURI.java
@@ -26,9 +26,13 @@ import java.util.Map;
 /**
  * Utility to parse redis URLs. The URI should follow the scheme: redis://[username:password@][host][:port][/[database]
  * An example URI can be found at <a href="https://redis.io/topics/rediscli">Redis cli docs</a>
+ *
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 public final class RedisURI {
+
+  private static final String DEFAULT_HOST = "localhost";
+  private static final int DEFAULT_PORT = 6379;
 
   /**
    * Original address string
@@ -43,7 +47,7 @@ public final class RedisURI {
    */
   private final String password;
   /**
-   * Database number
+   * Database number. With a default Redis config it might be a number from 0 to 15. Not supported in clustered mode.
    */
   private final Integer select;
 
@@ -52,23 +56,28 @@ public final class RedisURI {
     try {
       final URI uri = new URI(connectionString);
 
-      final String host = uri.getHost() == null ? "localhost" : uri.getHost();
-      final int port = uri.getPort() == -1 ? 6379 : uri.getPort();
+      final String host = uri.getHost() == null ? DEFAULT_HOST : uri.getHost();
+      final int port = uri.getPort() == -1 ? DEFAULT_PORT : uri.getPort();
       final String path = (uri.getPath() == null || uri.getPath().isEmpty()) ? "/" : uri.getPath();
 
+      // According to https://www.iana.org/assignments/uri-schemes/prov/redis there is no specified order of decision
+      // in case if db number or password are given in 2 different ways (e.g. in path and query).
+      // Implementation uses the query values as a fallback if another one is missing.
+      Map<String, String> query = parseQuery(uri);
       switch (uri.getScheme()) {
         case "redis":
           socketAddress = SocketAddress.inetSocketAddress(port, host);
           if (path.length() > 1) {
             // skip initial slash
             select = Integer.parseInt(uri.getPath().substring(1));
+          } else if (query.containsKey("db")) {
+            select = Integer.parseInt(query.get("db"));
           } else {
             select = null;
           }
           break;
         case "unix":
           socketAddress = SocketAddress.domainSocketAddress(path);
-          Map<String, String> query = parseQuery(uri);
           if (query.containsKey("select")) {
             select = Integer.parseInt(query.get("select"));
           } else {
@@ -76,7 +85,7 @@ public final class RedisURI {
           }
           break;
         default:
-          throw new RuntimeException("Unsupported Redis connection string scheme [" + uri.getScheme() + "]");
+          throw new IllegalArgumentException("Unsupported Redis connection string scheme [" + uri.getScheme() + "]");
       }
 
       String userInfo = uri.getUserInfo();
@@ -85,14 +94,14 @@ public final class RedisURI {
         if (userInfoArray.length > 0) {
           password = userInfoArray[userInfoArray.length - 1];
         } else {
-          password = null;
+          password = query.getOrDefault("password", null);
         }
       } else {
         password = null;
       }
 
     } catch (URISyntaxException e) {
-     throw new RuntimeException("Failed to parse the connection string", e);
+      throw new IllegalArgumentException("Failed to parse the connection string", e);
     }
   }
 

--- a/src/test/java/io/vertx/redis/client/impl/RedisURITest.java
+++ b/src/test/java/io/vertx/redis/client/impl/RedisURITest.java
@@ -1,0 +1,41 @@
+package io.vertx.redis.client.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:artursletter@gmail.com">Artur Badretdinov</a>
+ */
+public class RedisURITest {
+
+  @Test
+  public void testHostAndPort() {
+    RedisURI redisURI = new RedisURI("redis://redis-1234.hosted.com:1234");
+    Assert.assertEquals("Host address is not correct", "redis-1234.hosted.com", redisURI.socketAddress().host());
+    Assert.assertEquals("Port is not correct", 1234, redisURI.socketAddress().port());
+  }
+
+  @Test
+  public void testOnlyPasswordGiven() {
+    RedisURI redisURI = new RedisURI("redis://p%40ssw0rd@redis-1234.hosted.com:1234/0");
+    Assert.assertEquals("Password is not correct", "p@ssw0rd", redisURI.password());
+  }
+
+  @Test
+  public void testLoginAndPasswordGiven() {
+    RedisURI redisURI = new RedisURI("redis://redundantName:p%40ssw0rd@redis-1234.hosted.com:1234/0");
+    Assert.assertEquals("Password is not correct", "p@ssw0rd", redisURI.password());
+  }
+
+  @Test
+  public void testPasswordNotGiven() {
+    RedisURI redisURI = new RedisURI("redis://redis-1234.hosted.com:1234/0");
+    Assert.assertNull("Password is not null", redisURI.password());
+  }
+
+  @Test
+  public void testDbNumberGiven() {
+    RedisURI redisURI = new RedisURI("redis://redundantName:p%40ssw0rd@redis-1234.hosted.com:1234/2");
+    Assert.assertEquals("Password is not correct", 2, (long) redisURI.select());
+  }
+}

--- a/src/test/java/io/vertx/test/redis/RedisClientTest.java
+++ b/src/test/java/io/vertx/test/redis/RedisClientTest.java
@@ -23,7 +23,10 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
 import io.vertx.redis.client.RedisOptions;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.*;
@@ -46,7 +49,7 @@ public class RedisClientTest {
   public void before(TestContext should) {
     final Async before = should.async();
 
-    client = Redis.createClient(rule.vertx(), new RedisOptions().setEndpoint("redis://localhost:7006"));
+    client = Redis.createClient(rule.vertx(), new RedisOptions().setConnectionString("redis://localhost:7006"));
     client.connect(onConnect -> {
       should.assertTrue(onConnect.succeeded());
       redis = RedisAPI.api(onConnect.result());


### PR DESCRIPTION
Added Redis connection string URI support according to discussion in the issue:
https://github.com/vert-x3/vertx-redis-client/issues/183

Overall, the changes are minimalistic: fixed support of password extraction from the uri (as it's a common thing not to have a user name in this kind of strings).

Please. review the PR commit by commit - the main changes are in the first one, while the others are rather renamings / refactoring.

The overall schema can be found at "Host, port, password and database" block at: 
https://redis.io/topics/rediscli 


There are some open questions:

There is a `RedisOptions.setEndpoint(String endpoint`) method that actually behaves (after a few small touches) as a `RedisOptions.setConnectionStringUri(String connectionStringUri)`.

Should I rename the method itself or should I create a new method with the proposed name (`RedisOptions.setConnectionStringUri(String connectionStringUri)`) but actually doing the same thing? Or let's keep it as it?