### PR TITLE
Add redis URI support according to IANA

### DIFF
--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -1,9 +1,7 @@
 package io.vertx.redis.client;
 
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
+import io.vertx.core.json.JsonObject;
 
 /**
  * Converter and mapper for {@link io.vertx.redis.client.RedisOptions}.
@@ -17,7 +15,7 @@ public class RedisOptionsConverter {
       switch (member.getKey()) {
         case "endpoint":
           if (member.getValue() instanceof String) {
-            obj.setEndpoint((String)member.getValue());
+            obj.setConnectionString((String)member.getValue());
           }
           break;
         case "endpoints":

--- a/src/main/java/examples/RedisExamples.java
+++ b/src/main/java/examples/RedisExamples.java
@@ -55,9 +55,9 @@ public class RedisExamples {
       vertx,
       new RedisOptions()
         .setType(RedisClientType.SENTINEL)
-        .addEndpoint("redis://127.0.0.1:5000")
-        .addEndpoint("redis://127.0.0.1:5001")
-        .addEndpoint("redis://127.0.0.1:5002")
+        .addConnectionString("redis://127.0.0.1:5000")
+        .addConnectionString("redis://127.0.0.1:5001")
+        .addConnectionString("redis://127.0.0.1:5002")
         .setMasterName("sentinel7000")
         .setRole(RedisRole.MASTER))
       .connect(onConnect -> {
@@ -72,12 +72,12 @@ public class RedisExamples {
 
   public void example6() {
     final RedisOptions options = new RedisOptions()
-      .addEndpoint("redis://127.0.0.1:7000")
-      .addEndpoint("redis://127.0.0.1:7001")
-      .addEndpoint("redis://127.0.0.1:7002")
-      .addEndpoint("redis://127.0.0.1:7003")
-      .addEndpoint("redis://127.0.0.1:7004")
-      .addEndpoint("redis://127.0.0.1:7005");
+      .addConnectionString("redis://127.0.0.1:7000")
+      .addConnectionString("redis://127.0.0.1:7001")
+      .addConnectionString("redis://127.0.0.1:7002")
+      .addConnectionString("redis://127.0.0.1:7003")
+      .addConnectionString("redis://127.0.0.1:7004")
+      .addConnectionString("redis://127.0.0.1:7005");
   }
 
   public void example7(Vertx vertx) {

--- a/src/main/java/io/vertx/redis/client/Redis.java
+++ b/src/main/java/io/vertx/redis/client/Redis.java
@@ -39,12 +39,12 @@ public interface Redis {
 
   /**
    * Create a new redis client using the default client options.
-   * @param endpoint the server address to connect to
+   * @param connectionString a string URI following the scheme: redis://[username:password@][host][:port][/database]
    * @param vertx the vertx instance
    * @return the client
    */
-  static Redis createClient(Vertx vertx, String endpoint) {
-    return createClient(vertx, new RedisOptions().setEndpoint(endpoint));
+  static Redis createClient(Vertx vertx, String connectionString) {
+    return createClient(vertx, new RedisOptions().setConnectionString(connectionString));
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/Redis.java
+++ b/src/main/java/io/vertx/redis/client/Redis.java
@@ -38,10 +38,11 @@ public interface Redis {
   }
 
   /**
-   * Create a new redis client using the default client options.
+   * Create a new redis client using the default client options. Does not support rediss (redis over ssl scheme) for now.
    * @param connectionString a string URI following the scheme: redis://[username:password@][host][:port][/database]
    * @param vertx the vertx instance
    * @return the client
+   * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on www.iana.org</a>
    */
   static Redis createClient(Vertx vertx, String connectionString) {
     return createClient(vertx, new RedisOptions().setConnectionString(connectionString));

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -76,6 +76,7 @@ public class RedisOptions {
 
   /**
    * Copy constructor.
+   *
    * @param other the object to clone.
    */
   public RedisOptions(RedisOptions other) {
@@ -96,6 +97,7 @@ public class RedisOptions {
 
   /**
    * Copy from JSON constructor.
+   *
    * @param json source json
    */
   public RedisOptions(JsonObject json) {
@@ -105,6 +107,7 @@ public class RedisOptions {
 
   /**
    * Get the type of client to be created.
+   *
    * @return the desired client type.
    */
   public RedisClientType getType() {
@@ -113,6 +116,7 @@ public class RedisOptions {
 
   /**
    * Set the desired client type to be created.
+   *
    * @param type the client type.
    * @return fluent self.
    */
@@ -124,6 +128,7 @@ public class RedisOptions {
 
   /**
    * Get the net client options used to connect to the server.
+   *
    * @return the net socket options.
    */
   public NetClientOptions getNetClientOptions() {
@@ -143,6 +148,7 @@ public class RedisOptions {
 
   /**
    * Gets the list of redis endpoints to use (mostly used while connecting to a cluster)
+   *
    * @return list of socket addresses.
    */
   public List<String> getEndpoints() {
@@ -155,6 +161,7 @@ public class RedisOptions {
 
   /**
    * Gets the redis endpoint to use
+   *
    * @return the Redis connection string URI
    */
   public String getEndpoint() {
@@ -178,12 +185,14 @@ public class RedisOptions {
   }
 
   /**
-   * Adds a endpoint to use while connecting to the redis server. Only the cluster mode will consider more than
+   * Adds an endpoint to use while connecting to the redis server. Only the cluster mode will consider more than
    * 1 element. If more are provided, they are not considered by the client when in single server mode.
    *
    * @param connectionString a string URI following the scheme: redis://[username:password@][host][:port][/database]
    * @return fluent self.
+   * @deprecated see {@link #setConnectionString(String connectionString)} for a better naming
    */
+  @Deprecated
   public RedisOptions addEndpoint(String connectionString) {
     if (endpoints == null) {
       endpoints = new ArrayList<>();
@@ -198,7 +207,6 @@ public class RedisOptions {
    *
    * @param connectionString a string following the scheme: redis://[username:password@][host][:port][/[database]
    * @return fluent self.
-   *
    * @deprecated see {@link #setConnectionString(String connectionString)} for a better naming
    */
   @Deprecated
@@ -214,14 +222,33 @@ public class RedisOptions {
   }
 
   /**
-   * Sets a single connection string to use while connecting to the redis server.
+   * Adds a connection string (endpoint) to use while connecting to the redis server. Only the cluster mode will
+   * consider more than 1 element. If more are provided, they are not considered by the client when in single server mode.
+   * <p>
+   * Does not support rediss (redis over ssl scheme) for now.
+   *
+   * @param connectionString a string URI following the scheme: redis://[username:password@][host][:port][/database]
+   * @return fluent self.
+   *
+   * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on www.iana.org</a>
+   */
+  public RedisOptions addConnectionString(String connectionString) {
+    if (endpoints == null) {
+      endpoints = new ArrayList<>();
+    }
+    this.endpoints.add(connectionString);
+    return this;
+  }
+
+  /**
+   * Sets a single connection string (endpoint) to use while connecting to the redis server.
    * Will replace the previously configured connection strings.
    * <p>
    * Does not support rediss (redis over ssl scheme) for now.
    *
    * @param connectionString a string following the scheme: redis://[username:password@][host][:port][/[database].
-   * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on www.iana.org</a>
    * @return fluent self.
+   * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on www.iana.org</a>
    */
   public RedisOptions setConnectionString(String connectionString) {
     if (endpoints == null) {
@@ -258,6 +285,7 @@ public class RedisOptions {
 
   /**
    * Get the master name (only considered in HA mode).
+   *
    * @return the master name.
    */
   public String getMasterName() {
@@ -266,6 +294,7 @@ public class RedisOptions {
 
   /**
    * Set the master name (only considered in HA mode).
+   *
    * @param masterName the master name.
    * @return fluent self.
    */
@@ -276,6 +305,7 @@ public class RedisOptions {
 
   /**
    * Get the role name (only considered in HA mode).
+   *
    * @return the master name.
    */
   public RedisRole getRole() {
@@ -284,6 +314,7 @@ public class RedisOptions {
 
   /**
    * Set the role name (only considered in HA mode).
+   *
    * @param role the master name.
    * @return fluent self.
    */
@@ -294,6 +325,7 @@ public class RedisOptions {
 
   /**
    * Get whether or not to use slave nodes (only considered in Cluster mode).
+   *
    * @return the cluster slave mode.
    */
   public RedisSlaves getUseSlave() {
@@ -302,6 +334,7 @@ public class RedisOptions {
 
   /**
    * Set whether or not to use slave nodes (only considered in Cluster mode).
+   *
    * @param slaves the cluster slave mode.
    * @return fluent self.
    */
@@ -313,6 +346,7 @@ public class RedisOptions {
 
   /**
    * Tune how much nested arrays are allowed on a redis response. This affects the parser performance.
+   *
    * @return the configured max nested arrays allowance.
    */
   public int getMaxNestedArrays() {
@@ -321,6 +355,7 @@ public class RedisOptions {
 
   /**
    * Tune how much nested arrays are allowed on a redis response. This affects the parser performance.
+   *
    * @param maxNestedArrays the configured max nested arrays allowance.
    * @return fluent self.
    */
@@ -331,6 +366,7 @@ public class RedisOptions {
 
   /**
    * Tune how often in milliseconds should the connection pool cleaner execute.
+   *
    * @return the cleaning internal
    */
   public int getPoolCleanerInterval() {
@@ -339,6 +375,7 @@ public class RedisOptions {
 
   /**
    * Tune how often in milliseconds should the connection pool cleaner execute.
+   *
    * @param poolCleanerInterval the interval in milliseconds (-1 for never)
    * @return fluent self.
    */
@@ -349,6 +386,7 @@ public class RedisOptions {
 
   /**
    * Tune the maximum size of the connection pool.
+   *
    * @return the size.
    */
   public int getMaxPoolSize() {
@@ -369,6 +407,7 @@ public class RedisOptions {
 
   /**
    * Tune the maximum waiting requests for a connection from the pool.
+   *
    * @return the maximum waiting requests.
    */
   public int getMaxPoolWaiting() {
@@ -377,6 +416,7 @@ public class RedisOptions {
 
   /**
    * Tune the maximum waiting requests for a connection from the pool.
+   *
    * @param maxPoolWaiting max waiting requests
    * @return fluent self.
    */
@@ -387,6 +427,7 @@ public class RedisOptions {
 
   /**
    * Tune when a connection should be recycled in milliseconds.
+   *
    * @return the timeout for recycling.
    */
   public int getPoolRecycleTimeout() {
@@ -395,6 +436,7 @@ public class RedisOptions {
 
   /**
    * Tune when a connection should be recycled in milliseconds.
+   *
    * @param poolRecycleTimeout the timeout for recycling.
    * @return fluent self.
    */
@@ -402,8 +444,10 @@ public class RedisOptions {
     this.poolRecycleTimeout = poolRecycleTimeout;
     return this;
   }
+
   /**
    * Converts this object to JSON notation.
+   *
    * @return JSON
    */
   public JsonObject toJson() {

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -155,10 +155,10 @@ public class RedisOptions {
 
   /**
    * Gets the redis endpoint to use
-   * @return socket address.
+   * @return the Redis connection string URI
    */
   public String getEndpoint() {
-    if (endpoints == null || endpoints.size() == 0) {
+    if (endpoints == null || endpoints.isEmpty()) {
       return DEFAULT_ENDPOINT;
     }
 
@@ -181,31 +181,56 @@ public class RedisOptions {
    * Adds a endpoint to use while connecting to the redis server. Only the cluster mode will consider more than
    * 1 element. If more are provided, they are not considered by the client when in single server mode.
    *
-   * @param endpoint a socket addresses.
+   * @param connectionString a string URI following the scheme: redis://[username:password@][host][:port][/database]
    * @return fluent self.
    */
-  public RedisOptions addEndpoint(String endpoint) {
+  public RedisOptions addEndpoint(String connectionString) {
     if (endpoints == null) {
       endpoints = new ArrayList<>();
     }
-    this.endpoints.add(endpoint);
+    this.endpoints.add(connectionString);
     return this;
   }
 
   /**
-   * Sets a single endpoint to use while connecting to the redis server. Will replace the previously configured endpoints.
+   * Sets a single connection string to use while connecting to the redis server.
+   * Will replace the previously configured connection strings.
    *
-   * @param endpoint a socket addresses.
+   * @param connectionString a string following the scheme: redis://[username:password@][host][:port][/[database]
    * @return fluent self.
+   *
+   * @deprecated see {@link #setConnectionString(String connectionString)} for a better naming
    */
-  public RedisOptions setEndpoint(String endpoint) {
+  @Deprecated
+  public RedisOptions setEndpoint(String connectionString) {
     if (endpoints == null) {
       endpoints = new ArrayList<>();
     } else {
       endpoints.clear();
     }
 
-    this.endpoints.add(endpoint);
+    this.endpoints.add(connectionString);
+    return this;
+  }
+
+  /**
+   * Sets a single connection string to use while connecting to the redis server.
+   * Will replace the previously configured connection strings.
+   * <p>
+   * Does not support rediss (redis over ssl scheme) for now.
+   *
+   * @param connectionString a string following the scheme: redis://[username:password@][host][:port][/[database].
+   * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on www.iana.org</a>
+   * @return fluent self.
+   */
+  public RedisOptions setConnectionString(String connectionString) {
+    if (endpoints == null) {
+      endpoints = new ArrayList<>();
+    } else {
+      endpoints.clear();
+    }
+
+    this.endpoints.add(connectionString);
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisURI.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisURI.java
@@ -24,38 +24,60 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Utility to parse redis URLs
+ * Utility to parse redis URLs. The URI should follow the scheme: redis://[username:password@][host][:port][/[database]
+ * An example URI can be found at <a href="https://redis.io/topics/rediscli">Redis cli docs</a>
+ *
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 public final class RedisURI {
 
-  private final String address;
+  private static final String DEFAULT_HOST = "localhost";
+  private static final int DEFAULT_PORT = 6379;
+
+  /**
+   * Original address string
+   */
+  private final String connectionString;
+  /**
+   * Address, including host and port
+   */
   private final SocketAddress socketAddress;
+  /**
+   * Password to the Redis instance
+   */
   private final String password;
+  /**
+   * Database number. With a default Redis config it might be a number from 0 to 15. Not supported in clustered mode.
+   */
   private final Integer select;
 
-  public RedisURI(String address) {
-    this.address = address;
+  public RedisURI(String connectionString) {
+    this.connectionString = connectionString;
     try {
-      final URI uri = new URI(address);
+      final URI uri = new URI(connectionString);
 
-      final String host = uri.getHost() == null ? "localhost" : uri.getHost();
-      final int port = uri.getPort() == -1 ? 6379 : uri.getPort();
+      final String host = uri.getHost() == null ? DEFAULT_HOST : uri.getHost();
+      final int port = uri.getPort() == -1 ? DEFAULT_PORT : uri.getPort();
       final String path = (uri.getPath() == null || uri.getPath().isEmpty()) ? "/" : uri.getPath();
 
+      // According to https://www.iana.org/assignments/uri-schemes/prov/redis there is no specified order of decision
+      // in case if db number or password are given in 2 different ways (e.g. in path and query).
+      // Implementation uses the query values as a fallback if another one is missing.
+      Map<String, String> query = parseQuery(uri);
       switch (uri.getScheme()) {
         case "redis":
           socketAddress = SocketAddress.inetSocketAddress(port, host);
           if (path.length() > 1) {
             // skip initial slash
             select = Integer.parseInt(uri.getPath().substring(1));
+          } else if (query.containsKey("db")) {
+            select = Integer.parseInt(query.get("db"));
           } else {
             select = null;
           }
           break;
         case "unix":
           socketAddress = SocketAddress.domainSocketAddress(path);
-          Map<String, String> query = parseQuery(uri);
           if (query.containsKey("select")) {
             select = Integer.parseInt(query.get("select"));
           } else {
@@ -63,23 +85,23 @@ public final class RedisURI {
           }
           break;
         default:
-          throw new RuntimeException("Unsupported scheme [" + uri.getScheme() + "]");
+          throw new IllegalArgumentException("Unsupported Redis connection string scheme [" + uri.getScheme() + "]");
       }
 
       String userInfo = uri.getUserInfo();
       if (userInfo != null) {
-        int col = userInfo.indexOf(':');
-        if (col != -1) {
-          password = uri.getUserInfo().substring(col + 1);
+        String[] userInfoArray = userInfo.split(":");
+        if (userInfoArray.length > 0) {
+          password = userInfoArray[userInfoArray.length - 1];
         } else {
-          password = null;
+          password = query.getOrDefault("password", null);
         }
       } else {
-        password = null;
+        password = query.getOrDefault("password", null);
       }
 
     } catch (URISyntaxException e) {
-     throw new RuntimeException("Failed to parse the endpoint address", e);
+      throw new IllegalArgumentException("Failed to parse the connection string", e);
     }
   }
 
@@ -112,12 +134,12 @@ public final class RedisURI {
     return select;
   }
 
-  public String address() {
-    return address;
+  public String connectionString() {
+    return connectionString;
   }
 
   @Override
   public String toString() {
-    return address;
+    return connectionString;
   }
 }

--- a/src/test/java/io/vertx/redis/client/impl/RedisURITest.java
+++ b/src/test/java/io/vertx/redis/client/impl/RedisURITest.java
@@ -1,0 +1,65 @@
+package io.vertx.redis.client.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:artursletter@gmail.com">Artur Badretdinov</a>
+ */
+public class RedisURITest {
+
+  @Test
+  public void testHostAndPort() {
+    RedisURI redisURI = new RedisURI("redis://redis-1234.hosted.com:1234");
+    Assert.assertEquals("Host address is not correct", "redis-1234.hosted.com", redisURI.socketAddress().host());
+    Assert.assertEquals("Port is not correct", 1234, redisURI.socketAddress().port());
+  }
+
+  @Test
+  public void testOnlyPasswordGiven() {
+    RedisURI redisURI = new RedisURI("redis://p%40ssw0rd@redis-1234.hosted.com:1234/0");
+    Assert.assertEquals("Password is not correct", "p@ssw0rd", redisURI.password());
+  }
+
+  @Test
+  public void testOnlyPasswordInQueryGiven() {
+    RedisURI redisURI = new RedisURI("redis://redis-1234.hosted.com:1234/0?password=p%40ssw0rd");
+    Assert.assertEquals("Password is not correct", "p@ssw0rd", redisURI.password());
+  }
+
+  @Test
+  public void testTwoPasswordsAreGiven() {
+    RedisURI redisURI = new RedisURI("redis://pass@redis-1234.hosted.com:1234/0?password=p%40ssw0rd");
+    Assert.assertEquals("Password is not correct", "pass", redisURI.password());
+  }
+
+  @Test
+  public void testLoginAndPasswordGiven() {
+    RedisURI redisURI = new RedisURI("redis://redundantName:p%40ssw0rd@redis-1234.hosted.com:1234/0");
+    Assert.assertEquals("Password is not correct", "p@ssw0rd", redisURI.password());
+  }
+
+  @Test
+  public void testPasswordNotGiven() {
+    RedisURI redisURI = new RedisURI("redis://redis-1234.hosted.com:1234/0");
+    Assert.assertNull("Password is not null", redisURI.password());
+  }
+
+  @Test
+  public void testDbNumberGiven() {
+    RedisURI redisURI = new RedisURI("redis://redundantName:p%40ssw0rd@redis-1234.hosted.com:1234/2");
+    Assert.assertEquals("DB number is not correct", 2, (long) redisURI.select());
+  }
+
+  @Test
+  public void testDbNumberGivenInQuery() {
+    RedisURI redisURI = new RedisURI("redis://redundantName:p%40ssw0rd@redis-1234.hosted.com:1234?db=2");
+    Assert.assertEquals("DB number is not correct", 2, (long) redisURI.select());
+  }
+
+  @Test
+  public void testDbNumberPriorityPathOverQuery() {
+    RedisURI redisURI = new RedisURI("redis://redundantName:p%40ssw0rd@redis-1234.hosted.com:1234/1?db=2");
+    Assert.assertEquals("DB number is not correct", 1, (long) redisURI.select());
+  }
+}

--- a/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
@@ -9,11 +9,13 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.redis.client.*;
-
 import org.junit.*;
 import org.junit.runner.RunWith;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.vertx.redis.client.Command.*;
@@ -32,12 +34,12 @@ public class RedisClusterTest {
     .setUseSlave(RedisSlaves.SHARE)
     // we will flood the redis server
     .setMaxWaitingHandlers(128 * 1024)
-    .addEndpoint("redis://127.0.0.1:7000")
-    .addEndpoint("redis://127.0.0.1:7001")
-    .addEndpoint("redis://127.0.0.1:7002")
-    .addEndpoint("redis://127.0.0.1:7003")
-    .addEndpoint("redis://127.0.0.1:7004")
-    .addEndpoint("redis://127.0.0.1:7005")
+    .addConnectionString("redis://127.0.0.1:7000")
+    .addConnectionString("redis://127.0.0.1:7001")
+    .addConnectionString("redis://127.0.0.1:7002")
+    .addConnectionString("redis://127.0.0.1:7003")
+    .addConnectionString("redis://127.0.0.1:7004")
+    .addConnectionString("redis://127.0.0.1:7005")
     .setMaxPoolSize(8)
     .setMaxPoolWaiting(16);
 
@@ -118,9 +120,9 @@ public class RedisClusterTest {
       .setType(RedisClientType.CLUSTER)
       // we will flood the redis server
       .setMaxWaitingHandlers(128 * 1024)
-      .addEndpoint("redis://127.0.0.1:7000")
-      .addEndpoint("redis://127.0.0.1:7002")
-      .addEndpoint("redis://127.0.0.1:7004")
+      .addConnectionString("redis://127.0.0.1:7000")
+      .addConnectionString("redis://127.0.0.1:7002")
+      .addConnectionString("redis://127.0.0.1:7004")
       .setMaxPoolSize(8)
       .setMaxPoolWaiting(16);
 
@@ -169,7 +171,7 @@ public class RedisClusterTest {
       .setType(RedisClientType.CLUSTER)
       // we will flood the redis server
       .setMaxWaitingHandlers(128 * 1024)
-      .addEndpoint("redis://127.0.0.1:7000")
+      .addConnectionString("redis://127.0.0.1:7000")
       .setMaxPoolSize(8)
       .setMaxPoolWaiting(16);
 
@@ -218,7 +220,7 @@ public class RedisClusterTest {
       .setType(RedisClientType.CLUSTER)
       // we will flood the redis server
       .setMaxWaitingHandlers(128 * 1024)
-      .addEndpoint("redis://127.0.0.1:7000")
+      .addConnectionString("redis://127.0.0.1:7000")
       .setMaxPoolSize(8)
       .setMaxPoolWaiting(16);
 

--- a/src/test/java/io/vertx/redis/client/test/RedisSentinelTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisSentinelTest.java
@@ -5,7 +5,8 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.redis.client.*;
-import org.junit.*;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(VertxUnitRunner.class)
@@ -22,9 +23,9 @@ public class RedisSentinelTest {
       rule.vertx(),
       new RedisOptions()
         .setType(RedisClientType.SENTINEL)
-        .addEndpoint("redis://localhost:5000")
-        .addEndpoint("redis://localhost:5001")
-        .addEndpoint("redis://localhost:5002")
+        .addConnectionString("redis://localhost:5000")
+        .addConnectionString("redis://localhost:5001")
+        .addConnectionString("redis://localhost:5002")
         .setMasterName("sentinel7000")
         .setRole(RedisRole.MASTER)
         .setMaxPoolSize(4)
@@ -50,9 +51,9 @@ public class RedisSentinelTest {
       rule.vertx(),
       new RedisOptions()
         .setType(RedisClientType.SENTINEL)
-        .addEndpoint("redis://localhost:5000")
-        .addEndpoint("redis://localhost:5001")
-        .addEndpoint("redis://localhost:5002")
+        .addConnectionString("redis://localhost:5000")
+        .addConnectionString("redis://localhost:5001")
+        .addConnectionString("redis://localhost:5002")
         .setMasterName("sentinel7000")
         .setRole(RedisRole.SLAVE)
         .setMaxPoolSize(4)
@@ -78,9 +79,9 @@ public class RedisSentinelTest {
       rule.vertx(),
       new RedisOptions()
         .setType(RedisClientType.SENTINEL)
-        .addEndpoint("redis://localhost:5000")
-        .addEndpoint("redis://localhost:5001")
-        .addEndpoint("redis://localhost:5002")
+        .addConnectionString("redis://localhost:5000")
+        .addConnectionString("redis://localhost:5001")
+        .addConnectionString("redis://localhost:5002")
         .setMasterName("sentinel7000")
         .setRole(RedisRole.SENTINEL)
         .setMaxPoolSize(4)

--- a/src/test/java/io/vertx/redis/client/test/RedisTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisTest.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import static io.vertx.redis.client.Command.*;
-import static io.vertx.redis.client.Request.*;
+import static io.vertx.redis.client.Request.cmd;
 
 @RunWith(VertxUnitRunner.class)
 public class RedisTest {
@@ -74,7 +74,7 @@ public class RedisTest {
   public void simpleSelectTest(TestContext should) {
     final Async test = should.async();
 
-    Redis.createClient(rule.vertx(), new RedisOptions().addEndpoint("redis://localhost:7006/0"))
+    Redis.createClient(rule.vertx(), new RedisOptions().addConnectionString("redis://localhost:7006/0"))
       .connect(create -> {
         should.assertTrue(create.succeeded());
 

--- a/src/test/java/io/vertx/test/redis/RedisClientTest.java
+++ b/src/test/java/io/vertx/test/redis/RedisClientTest.java
@@ -23,7 +23,10 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
 import io.vertx.redis.client.RedisOptions;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.*;
@@ -46,7 +49,7 @@ public class RedisClientTest {
   public void before(TestContext should) {
     final Async before = should.async();
 
-    client = Redis.createClient(rule.vertx(), new RedisOptions().setEndpoint("redis://localhost:7006"));
+    client = Redis.createClient(rule.vertx(), new RedisOptions().setConnectionString("redis://localhost:7006"));
     client.connect(onConnect -> {
       should.assertTrue(onConnect.succeeded());
       redis = RedisAPI.api(onConnect.result());


### PR DESCRIPTION
Added Redis URI support according to IANA spec for the issue: https://github.com/vert-x3/vertx-redis-client/issues/183

Overall, the changes are minimalistic: fixed support of password extraction from the uri (as it's a common thing not to have a username in this kind of strings).

The overall schema can be found at https://www.iana.org/assignments/uri-schemes/prov/redis as pointed by @pmlopes 

In a separate commit, replaces `addEndpoint` calls with `addConnectionString` which does the same thing but highlights that a connection URI can be passed as a param. This change might be reverted if needed.