### PR TITLE
Fixes #187

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/ConnectionManager.java
+++ b/src/main/java/io/vertx/redis/client/impl/ConnectionManager.java
@@ -9,6 +9,7 @@ import io.vertx.core.http.impl.pool.ConnectionListener;
 import io.vertx.core.http.impl.pool.ConnectionProvider;
 import io.vertx.core.http.impl.pool.Pool;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.PromiseInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.net.NetClient;
@@ -78,7 +79,7 @@ class ConnectionManager {
         // socket connection succeeded
         final NetSocket netSocket = clientConnect.result();
         // the connection
-        final RedisConnectionImpl connection = new RedisConnectionImpl(vertx, connectionListener, netSocket, options);
+        final RedisConnectionImpl connection = new RedisConnectionImpl(vertx.eventBus(), contextInternal, connectionListener, netSocket, options);
 
         // parser utility
         netSocket
@@ -176,6 +177,8 @@ class ConnectionManager {
 
   public void getConnection(String connectionString, Request setup, Handler<AsyncResult<RedisConnection>> handler) {
     final ConnectionProvider<RedisConnection> connectionProvider = new RedisConnectionProvider(connectionString, setup);
+    PromiseInternal<RedisConnection> promise = ctx.promise();
+    promise.future().setHandler(handler);
     while (true) {
       Pool<RedisConnection> endpoint = endpointMap.computeIfAbsent(connectionString, targetAddress ->
         new Pool<>(
@@ -189,7 +192,7 @@ class ConnectionManager {
           conn -> connectionMap.put(connectionString, conn),
           conn -> connectionMap.remove(connectionString, conn),
           false));
-      if (endpoint.getConnection(handler)) {
+      if (endpoint.getConnection(promise)) {
         break;
       }
     }

--- a/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
@@ -1,6 +1,7 @@
 package io.vertx.redis.client.test;
 
 import io.vertx.core.CompositeFuture;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
@@ -70,6 +71,16 @@ public class RedisClusterTest {
         client.close();
         test.complete();
       });
+    });
+  }
+
+  @Test
+  public void testContextReturn(TestContext should) {
+    final Async test = should.async();
+    Context context = rule.vertx().getOrCreateContext();
+    client.connect(onCreate -> {
+      should.assertEquals(context, rule.vertx().getOrCreateContext());
+      test.complete();
     });
   }
 

--- a/src/test/java/io/vertx/test/redis/RedisClientTest.java
+++ b/src/test/java/io/vertx/test/redis/RedisClientTest.java
@@ -15,6 +15,7 @@
  */
 package io.vertx.test.redis;
 
+import io.vertx.core.Context;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -49,9 +50,11 @@ public class RedisClientTest {
   public void before(TestContext should) {
     final Async before = should.async();
 
+    Context context = rule.vertx().getOrCreateContext();
     client = Redis.createClient(rule.vertx(), new RedisOptions().setConnectionString("redis://localhost:7006"));
     client.connect(onConnect -> {
       should.assertTrue(onConnect.succeeded());
+      should.assertEquals(context, rule.vertx().getOrCreateContext());
       redis = RedisAPI.api(onConnect.result());
       before.complete();
     });
@@ -103,6 +106,16 @@ public class RedisClientTest {
   @SafeVarargs
   private static <T> List<T> toList(final T... params) {
     return Arrays.asList(params);
+  }
+
+  @Test
+  public void testContextReturn(TestContext should) {
+    final Async test = should.async();
+    Context context = rule.vertx().getOrCreateContext();
+    redis.append(makeKey(), "Hello", reply1 -> {
+      should.assertEquals(context, rule.vertx().getOrCreateContext());
+      test.complete();
+    });
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: zenios <dimitris.zenios@gmail.com>

Since we don't support shared client we assume that all methods of RedisConnectionImpl will be called either from the context that initialised the RedisClient or the context of io.vertx.core.http.impl.pool

In either case both contexts share the same event loop so no synchronisation issues. This is what is stated on the documention of pool

> A connection is delivered to a {@link Waiter} on the pool's context event loop thread, the waiter must take care of calling {@link io.vertx.core.impl.ContextInternal#emitFromIO} if necessary.

Having that in mind content.runOnContext (Context here is the context used when creating the client)  should only be used in cases where a call to RedisConnectionImpl  arrived from the pools context. 