### PR TITLE
Support for movable keys commands on clustered Redis client (send and batch) -> master

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/KeyExtractor.java
+++ b/src/main/java/io/vertx/redis/client/impl/KeyExtractor.java
@@ -1,0 +1,142 @@
+package io.vertx.redis.client.impl;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static io.vertx.redis.client.Command.*;
+
+class KeyExtractor {
+
+  static final byte[] STREAMS_UPPER_CASE = "STREAMS".getBytes(StandardCharsets.UTF_8);
+  static final byte[] STREAMS_LOWER_CASE = "streams".getBytes(StandardCharsets.UTF_8);
+  static final byte[] KEYS_UPPER_CASE = "KEYS".getBytes(StandardCharsets.UTF_8);
+  static final byte[] KEYS_LOWER_CASE = "keys".getBytes(StandardCharsets.UTF_8);
+  static final byte[] STORE_UPPER_CASE = "STORE".getBytes(StandardCharsets.UTF_8);
+  static final byte[] STORE_LOWER_CASE = "store".getBytes(StandardCharsets.UTF_8);
+  static final byte[] STOREDIST_UPPER_CASE = "STOREDIST".getBytes(StandardCharsets.UTF_8);
+  static final byte[] STOREDIST_LOWER_CASE = "storedist".getBytes(StandardCharsets.UTF_8);
+  private static final byte ZERO = 48;
+  private static final byte HYPHEN = 45;
+  private static final byte DOLLAR = 36;
+
+
+  /**
+   * Extract movable keys from given command request. Movable means the count of keys and may even their position within
+   * command is movable.
+   *
+   * @return All keys of the command of the given request.
+   */
+  static byte[][] extractMovableKeys(final RequestImpl req) {
+    final List<byte[]> args = Collections.unmodifiableList(req.getArgs());
+    final List<byte[]> keys = new ArrayList<>();
+
+    if (req.command().equals(EVAL) || req.command().equals(EVALSHA)) {
+      final int keyCount = Integer.parseInt(new String(args.get(1)));
+      final int keysStartIndex = 2;
+      keys.addAll(args.subList(keysStartIndex, keysStartIndex + keyCount));
+    }
+
+    if (req.command().equals(GEORADIUS)
+      || req.command().equals(GEORADIUS_RO)
+      || req.command().equals(GEORADIUSBYMEMBER)
+      || req.command().equals(GEORADIUSBYMEMBER_RO)) {
+      keys.add(args.get(0));
+      if (!addKeyAfterKeywordIfPresent(args, keys, STORE_LOWER_CASE)) {
+        addKeyAfterKeywordIfPresent(args, keys, STORE_UPPER_CASE);
+      }
+      if (!addKeyAfterKeywordIfPresent(args, keys, STOREDIST_LOWER_CASE)) {
+        addKeyAfterKeywordIfPresent(args, keys, STOREDIST_UPPER_CASE);
+      }
+    }
+
+    if (req.command().equals(SORT)) {
+      keys.add(args.get(0));
+      if (!addKeyAfterKeywordIfPresent(args, keys, STORE_LOWER_CASE)) {
+        addKeyAfterKeywordIfPresent(args, keys, STORE_UPPER_CASE);
+      }
+    }
+
+    if (req.command().equals(MIGRATE)) {
+      int keysKeywordIndex = getIndexOfArgContainsKeyword(args, KEYS_UPPER_CASE);
+      if (keysKeywordIndex == -1) {
+        keysKeywordIndex = getIndexOfArgContainsKeyword(args, KEYS_LOWER_CASE);
+      }
+      if (keysKeywordIndex > -1) {
+        keys.addAll(args.subList(keysKeywordIndex + 1, args.size()));
+      } else {
+        keys.add(args.get(2));
+      }
+    }
+
+    if (req.command().equals(XREAD) || req.command().equals(XREADGROUP)) {
+      int streamsKeywordIndex = getIndexOfArgContainsKeyword(args, STREAMS_UPPER_CASE);
+      if (streamsKeywordIndex == -1) {
+        streamsKeywordIndex = getIndexOfArgContainsKeyword(args, STREAMS_LOWER_CASE);
+      }
+
+      final List<byte[]> argsAfterStreamsKeyword = args.subList(streamsKeywordIndex + 1, args.size());
+
+      for (byte[] arg : argsAfterStreamsKeyword) {
+        if (!isArgEqualsSign(arg, DOLLAR) && !isArgEqualsSign(arg, ZERO) && !isArgContainsSign(arg, HYPHEN)) {
+          keys.add(arg);
+        } else if (isArgContainsSign(arg, HYPHEN)) {
+          // If hyphen separator, we need to verify both parts, before and after hyphen are parsable to long
+          String mayId = new String(arg, StandardCharsets.UTF_8);
+          String[] millisAndSequence = mayId.split("-");
+          try {
+            Long.parseLong(millisAndSequence[0]);
+            Long.parseLong(millisAndSequence[1]);
+          } catch (NumberFormatException e) {
+            keys.add(arg);
+          }
+        }
+      }
+    }
+
+    if (req.command().equals(ZINTERSTORE) || req.command().equals(ZUNIONSTORE)) {
+      final int keyCount = Integer.parseInt(new String(args.get(1)));
+      // destination
+      keys.add(args.get(0));
+      final int keysStartIndex = 2;
+      keys.addAll(args.subList(keysStartIndex, keysStartIndex + keyCount));
+    }
+
+    return keys.toArray(new byte[keys.size()][]);
+  }
+
+  private static boolean addKeyAfterKeywordIfPresent(List<byte[]> args, List<byte[]> keys, byte[] keyword) {
+    int keywordIndex = getIndexOfArgContainsKeyword(args, keyword);
+    if (keywordIndex > -1) {
+      keys.add(args.get(keywordIndex + 1));
+      return true;
+    }
+    return false;
+  }
+
+  private static int getIndexOfArgContainsKeyword(List<byte[]> args, byte[] keyword) {
+    int keywordIndex = -1;
+    for (int i = 0; i < args.size(); i++) {
+      if (Arrays.equals(args.get(i), keyword)) {
+        keywordIndex = i;
+        break;
+      }
+    }
+    return keywordIndex;
+  }
+
+  private static boolean isArgContainsSign(byte[] arg, byte sign) {
+    for (byte argByte : arg) {
+      if (argByte == sign) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isArgEqualsSign(byte[] arg, byte sign) {
+    return arg.length == 1 && arg[0] == sign;
+  }
+}

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -41,6 +41,10 @@ public class RedisClusterClient implements Redis {
     RedisClusterConnection.addUnSupportedCommand(command, error);
   }
 
+  public static void addMasterOnlyCommand(Command command) {
+    RedisClusterConnection.addMasterOnlyCommand(command);
+  }
+
   static {
     // provided reducers
 
@@ -97,6 +101,8 @@ public class RedisClusterClient implements Redis {
       SYNC, SENTINEL).forEach(command -> addUnSupportedCommand(command, null));
 
     addUnSupportedCommand(FLUSHALL, "RedisClusterClient does not handle command FLUSHALL, use FLUSHDB");
+
+    addMasterOnlyCommand(WAIT);
   }
 
   private final Vertx vertx;

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
@@ -25,6 +25,8 @@ public class RedisClusterConnection implements RedisConnection {
   private static final Map<Command, String> UNSUPPORTEDCOMMANDS = new HashMap<>();
   // reduce from list fo responses to a single response
   private static final Map<Command, Function<List<Response>, Response>> REDUCERS = new HashMap<>();
+  // List of commands they should run every time only against master nodes
+  private static final List<Command> MASTER_ONLY_COMMANDS = new ArrayList<>();
 
   public static void addReducer(Command command, Function<List<Response>, Response> fn) {
     REDUCERS.put(command, fn);
@@ -37,6 +39,10 @@ public class RedisClusterConnection implements RedisConnection {
     } else {
       UNSUPPORTEDCOMMANDS.put(command, error);
     }
+  }
+
+  public static void addMasterOnlyCommand(Command command) {
+    MASTER_ONLY_COMMANDS.add(command);
   }
 
   private final Vertx vertx;
@@ -116,6 +122,7 @@ public class RedisClusterConnection implements RedisConnection {
     // process commands for cluster mode
     final RequestImpl req = (RequestImpl) request;
     final Command cmd = req.command();
+    final boolean forceMasterEndpoint = MASTER_ONLY_COMMANDS.contains(cmd);
 
     if (UNSUPPORTEDCOMMANDS.containsKey(cmd)) {
       handler.handle(Future.failedFuture(UNSUPPORTEDCOMMANDS.get(cmd)));
@@ -133,7 +140,7 @@ public class RedisClusterConnection implements RedisConnection {
       }
 
       String[] endpoints = slots.endpointsForKey(hashSlot);
-      send(selectMasterOrSlaveEndpoint(req.command().isReadOnly(), endpoints), RETRIES, req, handler);
+      send(selectMasterOrSlaveEndpoint(req.command().isReadOnly(), endpoints, forceMasterEndpoint), RETRIES, req, handler);
       return this;
     }
 
@@ -145,7 +152,7 @@ public class RedisClusterConnection implements RedisConnection {
         String[] endpoints = slots.endpointsForSlot(i);
 
         final Promise<Response> p = Promise.promise();
-        send(selectMasterOrSlaveEndpoint(req.command().isReadOnly(), endpoints), RETRIES, req, p);
+        send(selectMasterOrSlaveEndpoint(req.command().isReadOnly(), endpoints, forceMasterEndpoint), RETRIES, req, p);
         responses.add(p.future());
       }
       CompositeFuture.all(responses).setHandler(composite -> {
@@ -162,7 +169,7 @@ public class RedisClusterConnection implements RedisConnection {
 
     if (cmd.isKeyless()) {
       // it doesn't matter which node to use
-      send(selectEndpoint(-1, cmd.isReadOnly()), RETRIES, req, handler);
+      send(selectEndpoint(-1, cmd.isReadOnly(), forceMasterEndpoint), RETRIES, req, handler);
       return this;
     }
 
@@ -201,7 +208,7 @@ public class RedisClusterConnection implements RedisConnection {
 
           for (Map.Entry<Integer, Request> kv : requests.entrySet()) {
             final Promise<Response> p = Promise.promise();
-            send(selectEndpoint(kv.getKey(), cmd.isReadOnly()), RETRIES, kv.getValue(), p);
+            send(selectEndpoint(kv.getKey(), cmd.isReadOnly(), forceMasterEndpoint), RETRIES, kv.getValue(), p);
             responses.add(p.future());
           }
 
@@ -219,13 +226,13 @@ public class RedisClusterConnection implements RedisConnection {
       }
 
       // all keys are on the same slot!
-      send(selectEndpoint(currentSlot, cmd.isReadOnly()), RETRIES, req, handler);
+      send(selectEndpoint(currentSlot, cmd.isReadOnly(), forceMasterEndpoint), RETRIES, req, handler);
       return this;
     }
 
     // last option the command is single key
     int start = cmd.getFirstKey() - 1;
-    send(selectEndpoint(ZModem.generate(args.get(start)), cmd.isReadOnly()), RETRIES, req, handler);
+    send(selectEndpoint(ZModem.generate(args.get(start)), cmd.isReadOnly(), forceMasterEndpoint), RETRIES, req, handler);
     return this;
   }
 
@@ -328,6 +335,7 @@ public class RedisClusterConnection implements RedisConnection {
   public RedisConnection batch(List<Request> requests, Handler<AsyncResult<List<Response>>> handler) {
     int currentSlot = -1;
     boolean readOnly = false;
+    boolean forceMasterEndpoint = false;
 
     // look up the base slot for the batch
     for (int i = 0; i < requests.size(); i++) {
@@ -341,6 +349,7 @@ public class RedisClusterConnection implements RedisConnection {
       }
 
       readOnly |= cmd.isReadOnly();
+      forceMasterEndpoint |= MASTER_ONLY_COMMANDS.contains(cmd);
 
       // this command can run anywhere
       if (cmd.isKeyless()) {
@@ -390,15 +399,21 @@ public class RedisClusterConnection implements RedisConnection {
       }
 
       // last option the command is single key
-      int start = cmd.getFirstKey() - 1;
-      if (currentSlot != ZModem.generate(args.get(start))) {
+      final int start = cmd.getFirstKey() - 1;
+      final int slot = ZModem.generate(args.get(start));
+      // we are checking the first request key
+      if (currentSlot == -1) {
+        currentSlot = slot;
+        continue;
+      }
+      if (currentSlot != slot) {
         // in cluster mode we currently do not handle batching commands which keys are not on the same slot
         handler.handle(Future.failedFuture(buildCrossslotFailureMsg(req)));
         return this;
       }
     }
 
-    batch(selectEndpoint(currentSlot, readOnly), RETRIES, requests, handler);
+    batch(selectEndpoint(currentSlot, readOnly, forceMasterEndpoint), RETRIES, requests, handler);
     return this;
   }
 
@@ -479,11 +494,11 @@ public class RedisClusterConnection implements RedisConnection {
   /**
    * Select a Redis client for the given key
    */
-  private String selectEndpoint(int keySlot, boolean readOnly) {
+  private String selectEndpoint(int keySlot, boolean readOnly, boolean forceMasterEndpoint) {
     // this command doesn't have keys, return any connection
     // NOTE: this means slaves may be used for no key commands regardless of slave config
     if (keySlot == -1) {
-      return slots.randomEndPoint();
+      return slots.randomEndPoint(forceMasterEndpoint);
     }
 
     String[] endpoints = slots.endpointsForKey(keySlot);
@@ -492,11 +507,15 @@ public class RedisClusterConnection implements RedisConnection {
     if (endpoints == null || endpoints.length == 0) {
       return options.getEndpoint();
     }
-    return selectMasterOrSlaveEndpoint(readOnly, endpoints);
+    return selectMasterOrSlaveEndpoint(readOnly, endpoints, forceMasterEndpoint);
   }
 
-  private String selectMasterOrSlaveEndpoint(boolean readOnly, String[] endpoints) {
+  private String selectMasterOrSlaveEndpoint(boolean readOnly, String[] endpoints, boolean forceMasterEndpoint) {
     int index = 0;
+
+    if (forceMasterEndpoint) {
+      return endpoints[index];
+    }
 
     // always, never, share
     RedisSlaves useSlaves = options.getUseSlave();

--- a/src/test/java/io/vertx/redis/client/impl/KeyExtractorTest.java
+++ b/src/test/java/io/vertx/redis/client/impl/KeyExtractorTest.java
@@ -1,0 +1,540 @@
+package io.vertx.redis.client.impl;
+
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Request;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class KeyExtractorTest {
+
+  @Test
+  public void geoRadius() {
+    String key = "Sicily";
+    Request req = Request.cmd(Command.GEORADIUS).arg(key).arg(15).arg(37).arg(200).arg("km").arg("WITHDIST");
+
+    byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(1, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusWithStore() {
+    final String key = "Sicily";
+    final String storeKey = "sicily_store_key";
+    final Request req = Request.cmd(Command.GEORADIUS).arg(key).arg(15).arg(37).arg(200).arg("km").arg("WITHDIST")
+      .arg(KeyExtractor.STORE_UPPER_CASE).arg(storeKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(2, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeKey, new String(keys[1], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusWithStoreDist() {
+    final String key = "Sicily";
+    final String storeDistKey = "sicily_storedist_key";
+    final Request req = Request.cmd(Command.GEORADIUS).arg(key).arg(15).arg(37).arg(200).arg("km").arg("WITHDIST")
+      .arg(KeyExtractor.STOREDIST_UPPER_CASE).arg(storeDistKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(2, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeDistKey, new String(keys[1], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusWithStoreAndStoreDist() {
+    final String key = "Sicily";
+    final String storeKey = "sicily_store_key";
+    final String storeDistKey = "sicily_storedist_key";
+    final Request req = Request.cmd(Command.GEORADIUS).arg(key).arg(15).arg(37).arg(200).arg("km").arg("WITHDIST")
+      .arg(KeyExtractor.STORE_LOWER_CASE).arg(storeKey)
+      .arg(KeyExtractor.STOREDIST_LOWER_CASE).arg(storeDistKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(3, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeKey, new String(keys[1], StandardCharsets.UTF_8));
+    assertEquals(storeDistKey, new String(keys[2], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusRo() {
+    String key = "Sicily";
+    Request req = Request.cmd(Command.GEORADIUS_RO).arg(key).arg(15).arg(37).arg(200).arg("km").arg("WITHDIST");
+
+    byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(1, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusWithStoreRo() {
+    final String key = "Sicily";
+    final String storeKey = "sicily_store_key";
+    final Request req = Request.cmd(Command.GEORADIUS_RO).arg(key).arg(15).arg(37).arg(200).arg("km").arg("WITHDIST")
+      .arg(KeyExtractor.STORE_UPPER_CASE).arg(storeKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(2, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeKey, new String(keys[1], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusWithStoreDistRo() {
+    final String key = "Sicily";
+    final String storeDistKey = "sicily_storedist_key";
+    final Request req = Request.cmd(Command.GEORADIUS_RO).arg(key).arg(15).arg(37).arg(200).arg("km").arg("WITHDIST")
+      .arg(KeyExtractor.STOREDIST_UPPER_CASE).arg(storeDistKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(2, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeDistKey, new String(keys[1], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusWithStoreAndStoreDistRo() {
+    final String key = "Sicily";
+    final String storeKey = "sicily_store_key";
+    final String storeDistKey = "sicily_storedist_key";
+    final Request req = Request.cmd(Command.GEORADIUS_RO).arg(key).arg(15).arg(37).arg(200).arg("km").arg("WITHDIST")
+      .arg(KeyExtractor.STORE_LOWER_CASE).arg(storeKey)
+      .arg(KeyExtractor.STOREDIST_LOWER_CASE).arg(storeDistKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(3, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeKey, new String(keys[1], StandardCharsets.UTF_8));
+    assertEquals(storeDistKey, new String(keys[2], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusByMember() {
+    String key = "Sicily";
+    Request req = Request.cmd(Command.GEORADIUSBYMEMBER).arg(key).arg("Agrigento").arg(100).arg("km");
+
+    byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(1, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusByMemberWithStore() {
+    final String key = "Sicily";
+    final String storeKey = "sicily_store_key";
+    final Request req = Request.cmd(Command.GEORADIUSBYMEMBER).arg(key).arg("Agrigento").arg(100).arg("km")
+      .arg(KeyExtractor.STORE_UPPER_CASE).arg(storeKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(2, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeKey, new String(keys[1], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusByMemberWithStoreDist() {
+    final String key = "Sicily";
+    final String storeDistKey = "sicily_storedist_key";
+    final Request req = Request.cmd(Command.GEORADIUSBYMEMBER).arg(key).arg("Agrigento").arg(100).arg("km")
+      .arg(KeyExtractor.STOREDIST_UPPER_CASE).arg(storeDistKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(2, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeDistKey, new String(keys[1], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusByMemberWithStoreAndStoreDist() {
+    final String key = "Sicily";
+    final String storeKey = "sicily_store_key";
+    final String storeDistKey = "sicily_storedist_key";
+    final Request req = Request.cmd(Command.GEORADIUSBYMEMBER).arg(key).arg("Agrigento").arg(100).arg("km")
+      .arg(KeyExtractor.STORE_LOWER_CASE).arg(storeKey)
+      .arg(KeyExtractor.STOREDIST_LOWER_CASE).arg(storeDistKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(3, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeKey, new String(keys[1], StandardCharsets.UTF_8));
+    assertEquals(storeDistKey, new String(keys[2], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusByMemberRo() {
+    String key = "Sicily";
+    Request req = Request.cmd(Command.GEORADIUSBYMEMBER_RO).arg(key).arg("Agrigento").arg(100).arg("km");
+
+    byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(1, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusByMemberWithStoreRo() {
+    final String key = "Sicily";
+    final String storeKey = "sicily_store_key";
+    final Request req = Request.cmd(Command.GEORADIUSBYMEMBER_RO).arg(key).arg("Agrigento").arg(100).arg("km")
+      .arg(KeyExtractor.STORE_UPPER_CASE).arg(storeKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(2, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeKey, new String(keys[1], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusByMemberWithStoreDistRo() {
+    final String key = "Sicily";
+    final String storeDistKey = "sicily_storedist_key";
+    final Request req = Request.cmd(Command.GEORADIUSBYMEMBER_RO).arg(key).arg("Agrigento").arg(100).arg("km")
+      .arg(KeyExtractor.STOREDIST_UPPER_CASE).arg(storeDistKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(2, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeDistKey, new String(keys[1], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void geoRadiusByMemberWithStoreAndStoreDistRo() {
+    final String key = "Sicily";
+    final String storeKey = "sicily_store_key";
+    final String storeDistKey = "sicily_storedist_key";
+    final Request req = Request.cmd(Command.GEORADIUSBYMEMBER_RO).arg(key).arg("Agrigento").arg(100).arg("km")
+      .arg(KeyExtractor.STORE_LOWER_CASE).arg(storeKey)
+      .arg(KeyExtractor.STOREDIST_LOWER_CASE).arg(storeDistKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(3, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeKey, new String(keys[1], StandardCharsets.UTF_8));
+    assertEquals(storeDistKey, new String(keys[2], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void sort() {
+    final String key = "sort-key";
+    final Request req = Request.cmd(Command.SORT).arg(key);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(1, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void sortWithStoreLowerCase() {
+    final String key = "sort-key";
+    final String storeKey = "store-key";
+    final Request req = Request.cmd(Command.SORT).arg(key).arg(KeyExtractor.STORE_LOWER_CASE).arg(storeKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(2, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeKey, new String(keys[1], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void sortWithStoreUpperCase() {
+    final String key = "some-key";
+    final String storeKey = "store-key";
+    final Request req = Request.cmd(Command.SORT).arg(key).arg(KeyExtractor.STORE_UPPER_CASE).arg(storeKey);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(2, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(storeKey, new String(keys[1], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void migrateSingleKey() {
+    final String key = "some-key";
+    final Request req = Request.cmd(Command.MIGRATE).arg("127.0.0.1").arg(6379).arg(key);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(1, keys.length);
+    assertEquals(key, new String(keys[0], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void migrateSingleKeyKeysList() {
+    final String[] migrationKeys = {"first-key"};
+    final Request req = Request.cmd(Command.MIGRATE).arg("127.0.0.1").arg(6379).arg(0).arg(5000)
+      .arg(KeyExtractor.KEYS_LOWER_CASE)
+      .arg(migrationKeys[0]);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(migrationKeys.length, keys.length);
+    for (int i = 0; i < migrationKeys.length; i++) {
+      String migrationKey = migrationKeys[i];
+      assertEquals(migrationKey, new String(keys[i], StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  public void migrateTwoKeys() {
+    final String[] migrationKeys = {"first-key", "second-key"};
+    final Request req = Request.cmd(Command.MIGRATE).arg("127.0.0.1").arg(6379).arg(0).arg(5000)
+      .arg(KeyExtractor.KEYS_LOWER_CASE)
+      .arg(migrationKeys[0]).arg(migrationKeys[1]);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(migrationKeys.length, keys.length);
+    for (int i = 0; i < migrationKeys.length; i++) {
+      String migrationKey = migrationKeys[i];
+      assertEquals(migrationKey, new String(keys[i], StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  public void migrateThreeKeys() {
+    final String[] migrationKeys = {"first-key", "second-key", "third-key"};
+    final Request req = Request.cmd(Command.MIGRATE).arg("127.0.0.1").arg(6379).arg(0).arg(5000)
+      .arg(KeyExtractor.KEYS_UPPER_CASE)
+      .arg(migrationKeys[0]).arg(migrationKeys[1]).arg(migrationKeys[2]);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(migrationKeys.length, keys.length);
+    for (int i = 0; i < migrationKeys.length; i++) {
+      String migrationKey = migrationKeys[i];
+      assertEquals(migrationKey, new String(keys[i], StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  public void xreadSingleKey() {
+    final String streamName = "mystream";
+    // Valid ID
+    Request req = Request.cmd(Command.XREAD).arg("COUNT").arg(2).arg(KeyExtractor.STREAMS_UPPER_CASE).arg(streamName)
+      .arg("0-0");
+
+    byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(1, keys.length);
+    assertEquals(streamName, new String(keys[0], StandardCharsets.UTF_8));
+
+    // Without sequence
+    req = Request.cmd(Command.XREAD).arg("COUNT").arg(2).arg(KeyExtractor.STREAMS_LOWER_CASE).arg(streamName)
+      .arg("0");
+
+    keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(1, keys.length);
+    assertEquals(streamName, new String(keys[0], StandardCharsets.UTF_8));
+
+    // Special $ ID
+    req = Request.cmd(Command.XREAD).arg("COUNT").arg(2).arg(KeyExtractor.STREAMS_UPPER_CASE).arg(streamName)
+      .arg("$");
+
+    keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(1, keys.length);
+    assertEquals(streamName, new String(keys[0], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void xreadTwoKeys() {
+    final String[] streamNames = {"my-stream", "other-stream"};
+    final Request req = Request.cmd(Command.XREAD).arg("COUNT").arg(2).arg(KeyExtractor.STREAMS_UPPER_CASE)
+      .arg(streamNames[0])
+      .arg(streamNames[1])
+      .arg("0-0")
+      .arg("$");
+
+    byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(streamNames.length, keys.length);
+    for (int i = 0; i < streamNames.length; i++) {
+      String streamName = streamNames[i];
+      assertEquals(streamName, new String(keys[i], StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  public void xreadThreeKeys() {
+    final String[] streamNames = {"my-stream", "other-stream", "further_stream"};
+    final Request req = Request.cmd(Command.XREAD).arg("COUNT").arg(2).arg(KeyExtractor.STREAMS_UPPER_CASE)
+      .arg(streamNames[0])
+      .arg(streamNames[1])
+      .arg(streamNames[2])
+      .arg("0-0")
+      .arg("$")
+      .arg("0");
+
+    byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(streamNames.length, keys.length);
+    for (int i = 0; i < streamNames.length; i++) {
+      String streamName = streamNames[i];
+      assertEquals(streamName, new String(keys[i], StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  public void xreadGroupSingleKey() {
+    final String streamName = "mystream";
+    // Valid ID
+    Request req = Request.cmd(Command.XREADGROUP).arg("GROUP").arg("group-name").arg("consumer-name")
+      .arg("COUNT").arg(2).arg(KeyExtractor.STREAMS_UPPER_CASE).arg(streamName)
+      .arg("0-0");
+
+    byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(1, keys.length);
+    assertEquals(streamName, new String(keys[0], StandardCharsets.UTF_8));
+
+    // Without sequence
+    req = Request.cmd(Command.XREADGROUP).arg("GROUP").arg("group-name").arg("consumer-name")
+      .arg("COUNT").arg(2).arg(KeyExtractor.STREAMS_LOWER_CASE).arg(streamName)
+      .arg("0");
+
+    keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(1, keys.length);
+    assertEquals(streamName, new String(keys[0], StandardCharsets.UTF_8));
+
+    // Special $ ID
+    req = Request.cmd(Command.XREADGROUP).arg("GROUP").arg("group-name").arg("consumer-name")
+      .arg("COUNT").arg(2).arg(KeyExtractor.STREAMS_UPPER_CASE).arg(streamName)
+      .arg("$");
+
+    keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(1, keys.length);
+    assertEquals(streamName, new String(keys[0], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void xreadGroupTwoKeys() {
+    final String[] streamNames = {"my-stream", "other-stream"};
+    final Request req = Request.cmd(Command.XREADGROUP).arg("GROUP").arg("group-name").arg("consumer-name")
+      .arg("COUNT").arg(2).arg(KeyExtractor.STREAMS_UPPER_CASE)
+      .arg(streamNames[0])
+      .arg(streamNames[1])
+      .arg("0-0")
+      .arg("$");
+
+    byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(streamNames.length, keys.length);
+    for (int i = 0; i < streamNames.length; i++) {
+      String streamName = streamNames[i];
+      assertEquals(streamName, new String(keys[i], StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  public void xreadGroupThreeKeys() {
+    final String[] streamNames = {"my-stream", "other-stream", "further_stream"};
+    final Request req = Request.cmd(Command.XREADGROUP).arg("GROUP").arg("group-name").arg("consumer-name")
+      .arg("COUNT").arg(2).arg(KeyExtractor.STREAMS_UPPER_CASE)
+      .arg(streamNames[0])
+      .arg(streamNames[1])
+      .arg(streamNames[2])
+      .arg("0-0")
+      .arg("$")
+      .arg("0");
+
+    byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(streamNames.length, keys.length);
+    for (int i = 0; i < streamNames.length; i++) {
+      String streamName = streamNames[i];
+      assertEquals(streamName, new String(keys[i], StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  public void zInterstoreSingleKey() {
+    final String destination = "destination";
+    final String key = "some-key";
+    final Request req = Request.cmd(Command.ZINTERSTORE).arg(destination).arg(1).arg(key).arg("WEIGHTS").arg(1);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(2, keys.length);
+    assertEquals(destination, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(key, new String(keys[1], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void zInterstoreTwoKeys() {
+    final String destination = "destination";
+    final String[] keys = {"some-key", "other-key"};
+    final Request req = Request.cmd(Command.ZINTERSTORE).arg(destination).arg(keys.length)
+      .arg(keys[0])
+      .arg(keys[1])
+      .arg("WEIGHTS").arg(1).arg(2).arg("AGGREGATE").arg("SUM");
+
+    final byte[][] movableKeys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(keys.length + 1, movableKeys.length);
+    assertEquals(destination, new String(movableKeys[0], StandardCharsets.UTF_8));
+    for (int i = 0; i < keys.length; i++) {
+      String key = keys[i];
+      assertEquals(key, new String(movableKeys[i + 1], StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  public void zInterstoreThreeKeys() {
+    final String destination = "destination";
+    final String[] keys = {"some-key", "other-key", "further-key"};
+    final Request req = Request.cmd(Command.ZINTERSTORE).arg(destination).arg(keys.length)
+      .arg(keys[0])
+      .arg(keys[1])
+      .arg(keys[2])
+      .arg("WEIGHTS").arg(1).arg(2).arg("AGGREGATE").arg("SUM");
+
+    final byte[][] movableKeys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(keys.length + 1, movableKeys.length);
+    assertEquals(destination, new String(movableKeys[0], StandardCharsets.UTF_8));
+    for (int i = 0; i < keys.length; i++) {
+      String key = keys[i];
+      assertEquals(key, new String(movableKeys[i +1], StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  public void zUnionstoreSingleKey() {
+    final String destination = "destination";
+    final String key = "some-key";
+    final Request req = Request.cmd(Command.ZUNIONSTORE).arg(destination).arg(1).arg(key).arg("WEIGHTS").arg(1);
+
+    final byte[][] keys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(2, keys.length);
+    assertEquals(destination, new String(keys[0], StandardCharsets.UTF_8));
+    assertEquals(key, new String(keys[1], StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void zUnionstoreTwoKeys() {
+    final String destination = "destination";
+    final String[] keys = {"some-key", "other-key"};
+    final Request req = Request.cmd(Command.ZUNIONSTORE).arg(destination).arg(keys.length)
+      .arg(keys[0])
+      .arg(keys[1])
+      .arg("WEIGHTS").arg(1).arg(2).arg("AGGREGATE").arg("SUM");
+
+    final byte[][] movableKeys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(keys.length + 1, movableKeys.length);
+    assertEquals(destination, new String(movableKeys[0], StandardCharsets.UTF_8));
+    for (int i = 0; i < keys.length; i++) {
+      String key = keys[i];
+      assertEquals(key, new String(movableKeys[i + 1], StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  public void zUnionstoreThreeKeys() {
+    final String destination = "destination";
+    final String[] keys = {"some-key", "other-key", "further-key"};
+    final Request req = Request.cmd(Command.ZUNIONSTORE).arg(destination).arg(keys.length)
+      .arg(keys[0])
+      .arg(keys[1])
+      .arg(keys[2])
+      .arg("WEIGHTS").arg(1).arg(2).arg("AGGREGATE").arg("SUM");
+
+    final byte[][] movableKeys = KeyExtractor.extractMovableKeys((RequestImpl) req);
+    assertEquals(keys.length + 1, movableKeys.length);
+    assertEquals(destination, new String(movableKeys[0], StandardCharsets.UTF_8));
+    for (int i = 0; i < keys.length; i++) {
+      String key = keys[i];
+      assertEquals(key, new String(movableKeys[i +1], StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
@@ -876,4 +876,105 @@ public class RedisClusterTest {
         });
       });
   }
+
+  @Test(timeout = 30_000)
+  public void evalSingleKey(TestContext should) {
+    final Async test = should.async();
+
+    final String key = "{hash_tag}.some-key";
+    final String argv = "some-value";
+
+    Redis.createClient(rule.vertx(), options).connect(should.asyncAssertSuccess(cluster -> {
+        cluster.send(cmd(EVAL).arg("return redis.call('SET', KEYS[1], ARGV[1])").arg(1).arg(key).arg(argv),
+          should.asyncAssertSuccess(response -> {
+            should.assertEquals("OK", response.toString());
+            test.complete();
+        }));
+      }
+    ));
+  }
+
+  @Test(timeout = 30_000)
+  public void evalSingleKeyBatch(TestContext should) {
+    final Async test = should.async();
+
+    final String key = "{hash_tag}.some-key";
+    final String argv = "some-value";
+
+    Request req = cmd(EVAL).arg("return redis.call('SET', KEYS[1], ARGV[1])").arg(1).arg(key).arg(argv);
+    final List<Request> cmdList = new ArrayList<>();
+    cmdList.add(req);
+    cmdList.add(req);
+    Redis.createClient(rule.vertx(), options).connect(should.asyncAssertSuccess(cluster -> {
+      cluster.batch(cmdList,
+          should.asyncAssertSuccess(response -> {
+            should.assertEquals(2, response.size());
+            response.forEach(r -> should.assertEquals("OK", r.toString()));
+            test.complete();
+        }));
+      }
+    ));
+  }
+
+  @Test(timeout = 30_000)
+  public void evalMultiKey(TestContext should) {
+    final Async test = should.async();
+
+    final String key1 = "{hash_tag}.some-key";
+    final String argv1 = "some-value";
+    final String key2 = "{hash_tag}.other-key";
+    final String argv2 = "other-value";
+
+    Redis.createClient(rule.vertx(), options).connect(should.asyncAssertSuccess(cluster -> {
+        cluster.send(cmd(EVAL).arg("local r1 = redis.call('SET', KEYS[1], ARGV[1]) \n" +
+            "local r2 = redis.call('SET', KEYS[2], ARGV[2]) \n" +
+            "return {r1, r2}").arg(2).arg(key1).arg(key2).arg(argv1).arg(argv2),
+          should.asyncAssertSuccess(response -> {
+            should.assertEquals(2, response.size());
+            response.forEach(r -> should.assertEquals("OK", r.toString()));
+            test.complete();
+        }));
+      }
+    ));
+  }
+
+  @Test(timeout = 30_000)
+  public void evalMultiKeyDifferentSlots(TestContext should) {
+    final Async test = should.async();
+
+    final String key1 = "{hash_tag}.some-key";
+    final String argv1 = "some-value";
+    final String key2 = "{other_hash_tag}.other-key";
+    final String argv2 = "other-value";
+
+    Redis.createClient(rule.vertx(), options).connect(should.asyncAssertSuccess(cluster -> {
+      cluster.send(cmd(EVAL).arg("local r1 = redis.call('SET', KEYS[1], ARGV[1]) \n" +
+          "local r2 = redis.call('SET', KEYS[2], ARGV[2]) \n" +
+          "return {r1, r2}").arg(2).arg(key1).arg(key2).arg(argv1).arg(argv2),
+        should.asyncAssertFailure(throwable ->  {
+          should.assertTrue(throwable.getMessage().startsWith("Keys of command or batch"));
+          test.complete();
+        }));
+      }
+    ));
+  }
+
+  @Test(timeout = 30_000)
+  public void evalSingleKeyDifferentSlotsBatch(TestContext should) {
+    final Async test = should.async();
+
+    final String argv = "some-value";
+
+    final List<Request> cmdList = new ArrayList<>();
+    cmdList.add(cmd(EVAL).arg("return redis.call('SET', KEYS[1], ARGV[1])").arg(1).arg("{hash_tag}.some-key").arg(argv));
+    cmdList.add(cmd(EVAL).arg("return redis.call('SET', KEYS[1], ARGV[1])").arg(1).arg("{other_hash_tag}.some-key").arg(argv));
+    Redis.createClient(rule.vertx(), options).connect(should.asyncAssertSuccess(cluster -> {
+        cluster.batch(cmdList,
+          should.asyncAssertFailure(throwable ->  {
+            should.assertTrue(throwable.getMessage().startsWith("Keys of command or batch"));
+            test.complete();
+          }));
+      }
+    ));
+  }
 }


### PR DESCRIPTION
https://github.com/vert-x3/vertx-redis-client/issues/198

- Extraction of the keys on movable key commands.
- Validation of those keys that they target the same hash slot.
- Normalization of hash slot issue related exception messages.
- Consider commands (currently only WAIT) they must be run against master nodes.
- Fix for batch if the first command is a single key command. 