### PR TITLE
Fix an issue in Example. Backoff calculations led to constant backoff timing

### DIFF
--- a/src/main/java/examples/RedisExamples.java
+++ b/src/main/java/examples/RedisExamples.java
@@ -158,8 +158,8 @@ public class RedisExamples {
         if (retry > MAX_RECONNECT_RETRIES) {
           // we should stop now, as there's nothing we can do.
         } else {
-          // retry with backoff up to 1280ms
-          long backoff = (long) (Math.pow(2, MAX_RECONNECT_RETRIES - Math.max(MAX_RECONNECT_RETRIES - retry, 9)) * 10);
+          // retry with backoff up to 10240 ms
+          long backoff = (long) (Math.pow(2, Math.min(retry, 10)) * 10);
 
           vertx.setTimer(backoff, timer -> createRedisClient(onReconnect -> {
             if (onReconnect.failed()) {


### PR DESCRIPTION
Motivation:

I wanted to apply an exponential backoff mechanism for Redis reconnection from the docs (https://vertx.io/docs/vertx-redis-client/java/#_implementing_reconnect_on_error) and found, that there is a bug in it: instead of increasing the timeout up to some limit, it constantly returned the same number: 20, due to a mistake in the `pow` argument.

I applied similar logic that increases the timeouts as next:
```20, 40, 80, 160, 320, 640, 1280, 2560, 5120, 10240, 10240, 10240, 10240, 10240, 10240, 10240, 10240, 10240, 10240, 10240```

I haven't added a proper test case, as it's just an example, but here is a simple test that you can run to visualise the new or old algorithm:

It's on Junit5, but you can run it as a main function as well.

``` 
 @Test
  void printBackoffValues() {
    int MAX_RECONNECT_RETRIES = 10;
    int retry = 0;
    for (int i = 0; i < 20; i++) {
      retry++;
      // put old or new algorithm here
      long timeout = (long) (Math.pow(2, Math.min(retry, 10)) * 10);
      System.out.print(timeout + ", ");
    }
```
  }