### PR TITLE
Fix to honour address on pub/sub

### DIFF
--- a/src/main/java/io/vertx/redis/impl/RedisClientImpl.java
+++ b/src/main/java/io/vertx/redis/impl/RedisClientImpl.java
@@ -170,7 +170,7 @@ public final class RedisClientImpl implements RedisClient {
     if (!"message".equals(data.getString(0)))
       return;
     String channel = data.getString(1);
-    final String vertxChannel = BASE_ADDRESS + "." + channel;
+    final String vertxChannel = options.getAddress() + "." + channel;
     JsonObject replyMessage = new JsonObject();
     replyMessage.put("status", "ok");
     JsonObject message = new JsonObject();


### PR DESCRIPTION
There is an issue on 3.8 code base.
PubSub is not using the address configured when creating the client, but the DEFAULT_ADDRESS.
This is a breaking error, not present in previous versions.

This commit fixes that.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
