### PR TITLE
Clean up wording, regarding slavery

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -60,8 +60,8 @@ Set the role name (only considered in HA mode).
 |[[type]]`@type`|`link:enums.html#RedisClientType[RedisClientType]`|+++
 Set the desired client type to be created.
 +++
-|[[useSlave]]`@useSlave`|`link:enums.html#RedisSlaves[RedisSlaves]`|+++
-Set whether or not to use slave nodes (only considered in Cluster mode).
+|[[useReplica]]`@useReplica`|`link:enums.html#RedisReplicas[RedisReplicas]`|+++
+Set whether or not to use replica nodes (only considered in Cluster mode).
 +++
 |===
 

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -60,7 +60,7 @@ Set the role name (only considered in HA mode).
 |[[type]]`@type`|`link:enums.html#RedisClientType[RedisClientType]`|+++
 Set the desired client type to be created.
 +++
-|[[useReplica]]`@useReplica`|`link:enums.html#RedisReplicas[RedisReplicas]`|+++
+|[[useReplicas]]`@useReplicas`|`link:enums.html#RedisReplicas[RedisReplicas]`|+++
 Set whether or not to use replica nodes (only considered in Cluster mode).
 +++
 |===

--- a/src/main/asciidoc/enums.adoc
+++ b/src/main/asciidoc/enums.adoc
@@ -22,8 +22,31 @@ The client should work in sentinel mode. When this mode is active
 +++
 |[[CLUSTER]]`CLUSTER`|+++
 The client should work in cluster mode. When this mode is active
- use the link to define when slave nodes can be used
- for read only queries.
+ use the link to define when replica nodes can be
+ used for read only queries.
++++
+|===
+
+[[RedisReplicas]]
+== RedisReplicas
+
+++++
+ When should Redis replica nodes be used for queries.
+++++
+'''
+
+[cols=">25%,75%"]
+[frame="topbot"]
+|===
+^|Name | Description
+|[[NEVER]]`NEVER`|+++
+Never use REPLICA, queries are always run on a MASTER node.
++++
+|[[SHARE]]`SHARE`|+++
+Queries can be randomly run on both MASTER and REPLICA nodes.
++++
+|[[ALWAYS]]`ALWAYS`|+++
+Queries are always run on REPLICA nodes (never on MASTER node).
 +++
 |===
 
@@ -47,29 +70,6 @@ Use a SLAVE node connection.
 +++
 |[[SENTINEL]]`SENTINEL`|+++
 Use a SENTINEL node connection.
-+++
-|===
-
-[[RedisSlaves]]
-== RedisSlaves
-
-++++
- When should Redis Slave nodes be used for queries.
-++++
-'''
-
-[cols=">25%,75%"]
-[frame="topbot"]
-|===
-^|Name | Description
-|[[NEVER]]`NEVER`|+++
-Never use SLAVES, queries are always run on a MASTER node.
-+++
-|[[SHARE]]`SHARE`|+++
-Queries can be randomly run on both MASTER and SLAVE nodes.
-+++
-|[[ALWAYS]]`ALWAYS`|+++
-Queries are always run on SLAVE nodes (never on MASTER node).
 +++
 |===
 

--- a/src/main/asciidoc/enums.adoc
+++ b/src/main/asciidoc/enums.adoc
@@ -65,8 +65,8 @@ Queries are always run on REPLICA nodes (never on MASTER node).
 |[[MASTER]]`MASTER`|+++
 Use a MASTER node connection.
 +++
-|[[SLAVE]]`SLAVE`|+++
-Use a SLAVE node connection.
+|[[REPLICA]]`REPLICA`|+++
+Use a REPLICA node connection.
 +++
 |[[SENTINEL]]`SENTINEL`|+++
 Use a SENTINEL node connection.

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -62,7 +62,7 @@ initialized with the following values:
 * `endpoint`: default is `redis://localhost:6379`
 * `masterName`: default is `mymaster`
 * `role` default is `MASTER`
-* `slaves` default is `NEVER`
+* `useReplicas` default is `NEVER`
 
 In order to obtain a connection use the following code:
 

--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -99,9 +99,9 @@ public class RedisOptionsConverter {
             obj.setType(io.vertx.redis.client.RedisClientType.valueOf((String)member.getValue()));
           }
           break;
-        case "useSlave":
+        case "useReplicas":
           if (member.getValue() instanceof String) {
-            obj.setUseSlave(io.vertx.redis.client.RedisSlaves.valueOf((String)member.getValue()));
+            obj.setUseReplicas(io.vertx.redis.client.RedisReplicas.valueOf((String)member.getValue()));
           }
           break;
       }
@@ -142,8 +142,8 @@ public class RedisOptionsConverter {
     if (obj.getType() != null) {
       json.put("type", obj.getType().name());
     }
-    if (obj.getUseSlave() != null) {
-      json.put("useSlave", obj.getUseSlave().name());
+    if (obj.getUseReplicas() != null) {
+      json.put("useReplicas", obj.getUseReplicas().name());
     }
   }
 }

--- a/src/main/java/io/vertx/redis/client/RedisClientType.java
+++ b/src/main/java/io/vertx/redis/client/RedisClientType.java
@@ -37,8 +37,8 @@ public enum RedisClientType {
 
   /**
    * The client should work in cluster mode. When this mode is active
-   * use the {@link RedisSlaves} to define when slave nodes can be used
-   * for read only queries.
+   * use the {@link RedisReplicas} to define when replica nodes can be
+   * used for read only queries.
    */
   CLUSTER
 }

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -43,7 +43,7 @@ public class RedisOptions {
   private int maxNestedArrays;
   private String masterName;
   private RedisRole role;
-  private RedisSlaves slaves;
+  private RedisReplicas useReplicas;
   private String password;
 
   // pool related options
@@ -62,7 +62,7 @@ public class RedisOptions {
     maxNestedArrays = 32;
     masterName = "mymaster";
     role = RedisRole.MASTER;
-    slaves = RedisSlaves.NEVER;
+    useReplicas = RedisReplicas.NEVER;
     type = RedisClientType.STANDALONE;
     poolCleanerInterval = -1;
     // thumb guess based on web browser defaults
@@ -91,7 +91,7 @@ public class RedisOptions {
     this.maxNestedArrays = other.maxNestedArrays;
     this.masterName = other.masterName;
     this.role = other.role;
-    this.slaves = other.slaves;
+    this.useReplicas = other.useReplicas;
     // pool related options
     this.poolCleanerInterval = other.poolCleanerInterval;
     this.maxPoolSize = other.maxPoolSize;
@@ -325,22 +325,22 @@ public class RedisOptions {
   }
 
   /**
-   * Get whether or not to use slave nodes (only considered in Cluster mode).
+   * Get whether or not to use replica nodes (only considered in Cluster mode).
    *
-   * @return the cluster slave mode.
+   * @return the cluster replica node use mode.
    */
-  public RedisSlaves getUseSlave() {
-    return slaves;
+  public RedisReplicas getUseReplicas() {
+    return useReplicas;
   }
 
   /**
-   * Set whether or not to use slave nodes (only considered in Cluster mode).
+   * Set whether or not to use replica nodes (only considered in Cluster mode).
    *
-   * @param slaves the cluster slave mode.
+   * @param useReplicas the cluster replica use mode.
    * @return fluent self.
    */
-  public RedisOptions setUseSlave(RedisSlaves slaves) {
-    this.slaves = slaves;
+  public RedisOptions setUseReplicas(RedisReplicas useReplicas) {
+    this.useReplicas = useReplicas;
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/RedisReplicas.java
+++ b/src/main/java/io/vertx/redis/client/RedisReplicas.java
@@ -18,23 +18,23 @@ package io.vertx.redis.client;
 import io.vertx.codegen.annotations.VertxGen;
 
 /**
- * When should Redis Slave nodes be used for queries.
+ * When should Redis replica nodes be used for queries.
  */
 @VertxGen
-public enum RedisSlaves {
+public enum RedisReplicas {
 
   /**
-   * Never use SLAVES, queries are always run on a MASTER node.
+   * Never use REPLICA, queries are always run on a MASTER node.
    */
   NEVER,
 
   /**
-   * Queries can be randomly run on both MASTER and SLAVE nodes.
+   * Queries can be randomly run on both MASTER and REPLICA nodes.
    */
   SHARE,
 
   /**
-   * Queries are always run on SLAVE nodes (never on MASTER node).
+   * Queries are always run on REPLICA nodes (never on MASTER node).
    */
   ALWAYS
 }

--- a/src/main/java/io/vertx/redis/client/RedisRole.java
+++ b/src/main/java/io/vertx/redis/client/RedisRole.java
@@ -28,9 +28,15 @@ public enum RedisRole {
   MASTER,
 
   /**
-   * Use a SLAVE node connection.
+   * @deprecated use {@link #REPLICA} instead.
    */
+  @Deprecated
   SLAVE,
+
+  /**
+   * Use a REPLICA node connection.
+   */
+  REPLICA,
 
   /**
    * Use a SENTINEL node connection.

--- a/src/main/java/io/vertx/redis/client/RedisRole.java
+++ b/src/main/java/io/vertx/redis/client/RedisRole.java
@@ -28,12 +28,6 @@ public enum RedisRole {
   MASTER,
 
   /**
-   * @deprecated use {@link #REPLICA} instead.
-   */
-  @Deprecated
-  SLAVE,
-
-  /**
    * Use a REPLICA node connection.
    */
   REPLICA,

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -139,7 +139,7 @@ public class RedisClusterClient implements Redis {
       return;
     }
 
-    connectionManager.getConnection(context, endpoints.get(index), RedisSlaves.NEVER != options.getUseSlave() ? cmd(READONLY) : null, getConnection -> {
+    connectionManager.getConnection(context, endpoints.get(index), RedisReplicas.NEVER != options.getUseReplicas() ? cmd(READONLY) : null, getConnection -> {
       if (getConnection.failed()) {
         // failed try with the next endpoint
         connect(endpoints, index + 1, onConnect);
@@ -174,7 +174,7 @@ public class RedisClusterClient implements Redis {
         }
 
         for (String endpoint : slots.endpoints()) {
-          connectionManager.getConnection(context, endpoint, RedisSlaves.NEVER != options.getUseSlave() ? cmd(READONLY) : null, getClusterConnection -> {
+          connectionManager.getConnection(context, endpoint, RedisReplicas.NEVER != options.getUseReplicas() ? cmd(READONLY) : null, getClusterConnection -> {
             if (getClusterConnection.failed()) {
               // failed try with the next endpoint
               failed.set(true);

--- a/src/main/java/io/vertx/redis/client/impl/RedisSentinelClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisSentinelClient.java
@@ -147,13 +147,12 @@ public class RedisSentinelClient implements Redis {
       case SENTINEL:
         resolveClient(this::isSentinelOk, options, createAndConnect);
         break;
-
       case MASTER:
         resolveClient(this::getMasterFromEndpoint, options, createAndConnect);
         break;
-
       case REPLICA:
         resolveClient(this::getReplicaFromEndpoint, options, createAndConnect);
+        break;
     }
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/Slots.java
+++ b/src/main/java/io/vertx/redis/client/impl/Slots.java
@@ -63,7 +63,7 @@ class Slots {
         // size
         s.size() - 2);
 
-      // array of all clients, clients[2] = master, others are slaves
+      // array of all clients, clients[2] = master, others are replicas
       for (int index = 2; index < s.size(); index++) {
         final Response c = s.get(index);
         final String host = c.get(0).toString().contains(":") ? "[" + c.get(0).toString() + "]" : c.get(0).toString();

--- a/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
@@ -32,7 +32,7 @@ public class RedisClusterTest {
   // Server: https://github.com/Grokzen/docker-redis-cluster
   private final RedisOptions options = new RedisOptions()
     .setType(RedisClientType.CLUSTER)
-    .setUseSlave(RedisSlaves.SHARE)
+    .setUseReplicas(RedisReplicas.SHARE)
     // we will flood the redis server
     .setMaxWaitingHandlers(128 * 1024)
     .addConnectionString("redis://127.0.0.1:7000")

--- a/src/test/java/io/vertx/redis/client/test/RedisSentinelTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisSentinelTest.java
@@ -72,7 +72,7 @@ public class RedisSentinelTest {
   }
 
   @Test
-  public void testGetClientToSlave(TestContext should) {
+  public void testGetClientToReplica(TestContext should) {
     final Async test = should.async();
 
     Redis.createClient(
@@ -83,11 +83,11 @@ public class RedisSentinelTest {
         .addConnectionString("redis://localhost:5001")
         .addConnectionString("redis://localhost:5002")
         .setMasterName("sentinel7000")
-        .setRole(RedisRole.SLAVE)
+        .setRole(RedisRole.REPLICA)
         .setMaxPoolSize(4)
         .setMaxPoolWaiting(16))
       .connect(onCreate -> {
-        // get a connection to the slave node
+        // get a connection to the replica node
         if (onCreate.failed()) {
           onCreate.cause().printStackTrace();
         }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Words such as `slave` are offensive but were common on distributed system naming conventions. Redis has started changing the way nodes on a cluster are named for a long period, with a first official release with redis 5.

This PR is following up on their work and adapting the client wording to the official redis convention.