### PR TITLE
BUG-264 updating the connection pool creation for the redis client

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
@@ -310,9 +310,9 @@ class RedisConnectionManager {
       pool = new Pool<>(
         ctx,
         connectionProvider,
-        options.getMaxPoolSize(),
-        1,
         options.getMaxPoolWaiting(),
+        1,
+        options.getMaxPoolSize(),
         this::connectionAdded,
         this::connectionRemoved,
         false);


### PR DESCRIPTION
Motivation:

attempting to fix the "bug" described in https://github.com/vert-x3/vertx-redis-client/issues/264