### PR TITLE
Fix NPE when handling errors during "hello" negotiation.

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
@@ -211,7 +211,8 @@ class RedisConnectionManager {
 
         final Throwable err = onSend.cause();
 
-        if (err != null && err.getMessage().startsWith("ERR unknown command")) {
+        if (err != null && err.getMessage() != null && err.getMessage()
+          .startsWith("ERR unknown command")) {
           // chatting to an old server
           authenticate(connection, password, handler);
         } else {


### PR DESCRIPTION
Motivation:

I'm receiving null pointer exceptions (see below) when trying to reconnect with redis in a kubernetes cluster. These errors propogate as unhandled.

```json
{
    "timestamp": 1607029901178,
    "log": {
        "instant": {
            "epochSecond": 1607029901,
            "nanoOfSecond": 177546000
        },
        "thread": "vert.x-eventloop-thread-0",
        "level": "ERROR",
        "loggerName": "io.vertx.core.impl.ContextImpl",
        "message": "Unhandled exception",
        "thrown": {
            "commonElementCount": 0,
            "name": "java.lang.NullPointerException",
            "extendedStackTrace": [
                {
                    "class": "io.vertx.redis.client.impl.RedisConnectionManager$RedisConnectionProvider",
                    "method": "lambda$hello$6",
                    "file": "RedisConnectionManager.java",
                    "line": 214,
                    "exact": false,
                    "location": "service.jar",
                    "version": "?"
                },
                {
                    "class": "io.vertx.core.impl.future.FutureImpl$3",
                    "method": "onFailure",
                    "file": "FutureImpl.java",
                    "line": 129,
                    "exact": false,
                    "location": "service.jar",
                    "version": "?"
                },
                {
                    "class": "io.vertx.core.impl.future.FutureBase",
                    "method": "lambda$emitFailure$1",
                    "file": "FutureBase.java",
                    "line": 70,
                    "exact": false,
                    "location": "service.jar",
                    "version": "?"
                },
                {
                    "class": "io.netty.util.concurrent.AbstractEventExecutor",
                    "method": "safeExecute",
                    "file": "AbstractEventExecutor.java",
                    "line": 164,
                    "exact": true,
                    "location": "service.jar",
                    "version": "?"
                },
                {
                    "class": "io.netty.util.concurrent.SingleThreadEventExecutor",
                    "method": "runAllTasks",
                    "file": "SingleThreadEventExecutor.java",
                    "line": 472,
                    "exact": true,
                    "location": "service.jar",
                    "version": "?"
                },
                {
                    "class": "io.netty.channel.nio.NioEventLoop",
                    "method": "run",
                    "file": "NioEventLoop.java",
                    "line": 497,
                    "exact": true,
                    "location": "service.jar",
                    "version": "?"
                },
                {
                    "class": "io.netty.util.concurrent.SingleThreadEventExecutor$4",
                    "method": "run",
                    "file": "SingleThreadEventExecutor.java",
                    "line": 989,
                    "exact": true,
                    "location": "service.jar",
                    "version": "?"
                },
                {
                    "class": "io.netty.util.internal.ThreadExecutorMap$2",
                    "method": "run",
                    "file": "ThreadExecutorMap.java",
                    "line": 74,
                    "exact": true,
                    "location": "service.jar",
                    "version": "?"
                },
                {
                    "class": "io.netty.util.concurrent.FastThreadLocalRunnable",
                    "method": "run",
                    "file": "FastThreadLocalRunnable.java",
                    "line": 30,
                    "exact": true,
                    "location": "service.jar",
                    "version": "?"
                },
                {
                    "class": "java.lang.Thread",
                    "method": "run",
                    "line": -1,
                    "exact": true,
                    "location": "?",
                    "version": "?"
                }
            ]
        },
        "endOfBatch": false,
        "loggerFqcn": "io.vertx.core.logging.Logger",
        "contextMap": {
        },
        "threadId": 16,
        "threadPriority": 5
    },
    "stream": "stdout",
    "time": "2020-12-03T21:11:41.178182353Z"
}
```

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
