### PR TITLE
Backport redis cluster authentication changes

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -148,7 +148,7 @@ public class RedisClusterClient implements Redis {
       final RedisConnection conn = getConnection.result();
 
       // fetch slots from the cluster immediately to ensure slots are correct
-      getSlots(conn, getSlots -> {
+      getSlots(endpoints.get(index), conn, getSlots -> {
         if (getSlots.failed()) {
           // the slots command failed.
           conn.close();
@@ -217,7 +217,7 @@ public class RedisClusterClient implements Redis {
     connectionManager.close();
   }
 
-  private void getSlots(RedisConnection conn, Handler<AsyncResult<Slots>> onGetSlots) {
+  private void getSlots(String endpoint, RedisConnection conn, Handler<AsyncResult<Slots>> onGetSlots) {
 
     conn.send(cmd(CLUSTER).arg("SLOTS"), send -> {
       if (send.failed()) {
@@ -234,7 +234,7 @@ public class RedisClusterClient implements Redis {
         return;
       }
 
-      onGetSlots.handle(Future.succeededFuture(new Slots(reply)));
+      onGetSlots.handle(Future.succeededFuture(new Slots(endpoint, reply)));
     });
   }
 }

--- a/src/main/java/io/vertx/redis/client/impl/Slots.java
+++ b/src/main/java/io/vertx/redis/client/impl/Slots.java
@@ -42,9 +42,11 @@ class Slots {
   private final String[] endpoints;
   private final String[] masterEndpoints;
 
-  Slots(Response reply) {
+  Slots(String connectionString, Response reply) {
     size = reply.size();
     slots = new Slot[size];
+
+    final RedisURI uri = new RedisURI(connectionString);
 
     Set<String> uniqueEndpoints = new HashSet<>();
     final List<String> masterEndpoints = new ArrayList<>();
@@ -64,7 +66,9 @@ class Slots {
       // array of all clients, clients[2] = master, others are slaves
       for (int index = 2; index < s.size(); index++) {
         Response c = s.get(index);
-        final String endpoint = "redis://" + c.get(0).toString() + ":" + c.get(1).toInteger();
+        final String host = c.get(0).toString().contains(":") ? "[" + c.get(0).toString() + "]" : c.get(0).toString();
+
+        final String endpoint = uri.protocol() + "://" + uri.userinfo() + host + ":" + c.get(1).toInteger();
         slots[i].endpoints[index - 2] = endpoint;
         uniqueEndpoints.add(endpoint);
         if (index == 2) {

--- a/src/test/java/io/vertx/redis/client/impl/RedisURITest.java
+++ b/src/test/java/io/vertx/redis/client/impl/RedisURITest.java
@@ -17,7 +17,7 @@ public class RedisURITest {
 
   @Test
   public void testOnlyPasswordGiven() {
-    RedisURI redisURI = new RedisURI("redis://p%40ssw0rd@redis-1234.hosted.com:1234/0");
+    RedisURI redisURI = new RedisURI("redis://:p%40ssw0rd@redis-1234.hosted.com:1234/0");
     Assert.assertEquals("Password is not correct", "p@ssw0rd", redisURI.password());
   }
 
@@ -29,7 +29,7 @@ public class RedisURITest {
 
   @Test
   public void testTwoPasswordsAreGiven() {
-    RedisURI redisURI = new RedisURI("redis://pass@redis-1234.hosted.com:1234/0?password=p%40ssw0rd");
+    RedisURI redisURI = new RedisURI("redis://:pass@redis-1234.hosted.com:1234/0?password=p%40ssw0rd");
     Assert.assertEquals("Password is not correct", "pass", redisURI.password());
   }
 
@@ -75,5 +75,11 @@ public class RedisURITest {
   public void testRedundantQuery() {
     RedisURI redisURI = new RedisURI("unix:///some/file.sock?");
     Assert.assertEquals("UNIX file is not correct", "/some/file.sock", redisURI.socketAddress().path());
+  }
+
+  @Test
+  public void testIPV6() {
+    RedisURI redisURI = new RedisURI("redis://[::1]:1234/0");
+    Assert.assertEquals("[::1]:1234", redisURI.socketAddress().toString());
   }
 }

--- a/src/test/java/io/vertx/redis/client/impl/SlotsTest.java
+++ b/src/test/java/io/vertx/redis/client/impl/SlotsTest.java
@@ -1,0 +1,58 @@
+package io.vertx.redis.client.impl;
+
+import io.vertx.redis.client.Response;
+import io.vertx.redis.client.impl.types.IntegerType;
+import io.vertx.redis.client.impl.types.MultiType;
+import io.vertx.redis.client.impl.types.SimpleStringType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SlotsTest {
+
+  private static final MultiType SLOTS_RESPONSE = MultiType.create(new Response[]{
+    MultiType.create(new Response[]{ // 1st slot
+      IntegerType.create(0L), // slot min
+      IntegerType.create(8191L), // slot max
+      MultiType.create(new Response[]{ // master
+        SimpleStringType.create("redis-0001-001.redis.k9mgrw.euw1.cache.amazonaws.com"),
+        IntegerType.create(7011L)
+      }),
+      MultiType.create(new Response[]{ // replica
+        SimpleStringType.create("redis-0001-002.redis.k9mgrw.euw1.cache.amazonaws.com"),
+        IntegerType.create(7012L)
+      }),
+    }),
+    MultiType.create(new Response[]{ // 2nd slot
+      IntegerType.create(8192L), // slot min
+      IntegerType.create(16383L), // slot max
+      MultiType.create(new Response[]{ // master
+        SimpleStringType.create("redis-0002-001.redis.k9mgrw.euw1.cache.amazonaws.com"),
+        IntegerType.create(7021L)
+      }),
+      MultiType.create(new Response[]{ // replica
+        SimpleStringType.create("redis-0002-002.redis.k9mgrw.euw1.cache.amazonaws.com"),
+        IntegerType.create(7022L)
+      }),
+    })
+  });
+
+  @Test
+  public void testExtractsSlotsWithMastersAndReplicas() {
+    final Slots slots = new Slots("redis://clustercfg.redis.k9mgrw.euw1.cache.amazonaws.com:7000", SLOTS_RESPONSE);
+    Assert.assertEquals(2, slots.size());
+    Assert.assertTrue(slots.contains("redis://redis-0001-001.redis.k9mgrw.euw1.cache.amazonaws.com:7011"));
+    Assert.assertTrue(slots.contains("redis://redis-0001-002.redis.k9mgrw.euw1.cache.amazonaws.com:7012"));
+    Assert.assertTrue(slots.contains("redis://redis-0002-001.redis.k9mgrw.euw1.cache.amazonaws.com:7021"));
+    Assert.assertTrue(slots.contains("redis://redis-0002-002.redis.k9mgrw.euw1.cache.amazonaws.com:7022"));
+  }
+
+  @Test
+  public void shouldPatchExtractedEndpointsWithUserinfo() {
+    final Slots slots = new Slots("redis://:password@clustercfg.redis.k9mgrw.euw1.cache.amazonaws.com:7000", SLOTS_RESPONSE);
+    Assert.assertEquals(2, slots.size());
+    Assert.assertTrue(slots.contains("redis://:password@redis-0001-001.redis.k9mgrw.euw1.cache.amazonaws.com:7011"));
+    Assert.assertTrue(slots.contains("redis://:password@redis-0001-002.redis.k9mgrw.euw1.cache.amazonaws.com:7012"));
+    Assert.assertTrue(slots.contains("redis://:password@redis-0002-001.redis.k9mgrw.euw1.cache.amazonaws.com:7021"));
+    Assert.assertTrue(slots.contains("redis://:password@redis-0002-002.redis.k9mgrw.euw1.cache.amazonaws.com:7022"));
+  }
+}


### PR DESCRIPTION
Motivation:

When connecting to a redis cluster, the client now propagates username
and password from the initial connection to each of the cluster
member connections.

This is a back port of changes to `RedisURI` and `Slots` from the master branch.

Closes #270  

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
