### PR TITLE
Fix wrong connection validation

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
@@ -70,7 +70,7 @@ public class RedisStandaloneConnection implements RedisConnection, ParserHandler
   }
 
   public boolean isValid() {
-    return expirationTimestamp > 0 && System.currentTimeMillis() <= expirationTimestamp;
+    return expirationTimestamp == 0 || System.currentTimeMillis() <= expirationTimestamp;
   }
 
   @Override


### PR DESCRIPTION
Currently, when a connection [is returned to the pool](https://github.com/eclipse-vertx/vert.x/blob/358cee178d9e1754ae57b5f8e95b605a74be22d6/src/main/java/io/vertx/core/net/impl/clientconnection/Pool.java#L304), the validation is always `false` due to the `expirationTimestamp` in `RedisStandaloneConnection` is always 0.

The `recycle` function indicates that if the `expirationTimestamp` should be 0 if we don't want to recycle, therefore, I changed the `isValid()`. However, since `recycle()` is never called, and this client uses a timer to close connections, I wonder it might be better to remove `expirationTimestamp`, `recycle()`, and always return `true` in `isValid()`.
