### PR TITLE
Add a missing Nullable annotation

### DIFF
--- a/src/main/java/io/vertx/redis/client/RedisConnection.java
+++ b/src/main/java/io/vertx/redis/client/RedisConnection.java
@@ -41,7 +41,7 @@ public interface RedisConnection extends ReadStream<Response> {
    */
   @Fluent
   @Override
-  RedisConnection handler(Handler<Response> handler);
+  RedisConnection handler(@Nullable Handler<Response> handler);
 
   /**
    * {@inheritDoc}


### PR DESCRIPTION
Motivation:

Adds a missing Nullable annotation. I think this is the cause of an "io.vertx.codegen.GenException: Nullable type cannot override non nullable" that I am experiencing when compiling Vert.x modules with a vertx-codegen CodegenProcessor.

I believe that this annotation should be present because it is there on the corresponding method in [ReadStream](https://github.com/eclipse-vertx/vert.x/blob/4.1.0/src/main/java/io/vertx/core/streams/ReadStream.java#L62).
