### PR TITLE
Azure redis hello command is broken, we need to avoid it

### DIFF
--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -44,6 +44,11 @@ public class RedisOptionsConverter {
             obj.setEndpoints(list);
           }
           break;
+        case "handshakeProtocolNegotiation":
+          if (member.getValue() instanceof Boolean) {
+            obj.setHandshakeProtocolNegotiation((Boolean)member.getValue());
+          }
+          break;
         case "masterName":
           if (member.getValue() instanceof String) {
             obj.setMasterName((String)member.getValue());
@@ -72,11 +77,6 @@ public class RedisOptionsConverter {
         case "netClientOptions":
           if (member.getValue() instanceof JsonObject) {
             obj.setNetClientOptions(new io.vertx.core.net.NetClientOptions((io.vertx.core.json.JsonObject)member.getValue()));
-          }
-          break;
-        case "noHello":
-          if (member.getValue() instanceof Boolean) {
-            obj.setNoHello((Boolean)member.getValue());
           }
           break;
         case "password":
@@ -126,6 +126,7 @@ public class RedisOptionsConverter {
       obj.getEndpoints().forEach(item -> array.add(item));
       json.put("endpoints", array);
     }
+    json.put("handshakeProtocolNegotiation", obj.isHandshakeProtocolNegotiation());
     if (obj.getMasterName() != null) {
       json.put("masterName", obj.getMasterName());
     }
@@ -136,7 +137,6 @@ public class RedisOptionsConverter {
     if (obj.getNetClientOptions() != null) {
       json.put("netClientOptions", obj.getNetClientOptions().toJson());
     }
-    json.put("noHello", obj.isNoHello());
     if (obj.getPassword() != null) {
       json.put("password", obj.getPassword());
     }

--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -74,6 +74,11 @@ public class RedisOptionsConverter {
             obj.setNetClientOptions(new io.vertx.core.net.NetClientOptions((io.vertx.core.json.JsonObject)member.getValue()));
           }
           break;
+        case "noHello":
+          if (member.getValue() instanceof Boolean) {
+            obj.setNoHello((Boolean)member.getValue());
+          }
+          break;
         case "password":
           if (member.getValue() instanceof String) {
             obj.setPassword((String)member.getValue());
@@ -131,6 +136,7 @@ public class RedisOptionsConverter {
     if (obj.getNetClientOptions() != null) {
       json.put("netClientOptions", obj.getNetClientOptions().toJson());
     }
+    json.put("noHello", obj.isNoHello());
     if (obj.getPassword() != null) {
       json.put("password", obj.getPassword());
     }

--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -2,6 +2,9 @@ package io.vertx.redis.client;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Converter and mapper for {@link io.vertx.redis.client.RedisOptions}.
@@ -39,11 +42,6 @@ public class RedisOptionsConverter {
                 list.add((String)item);
             });
             obj.setEndpoints(list);
-          }
-          break;
-        case "handshakeProtocolNegotiation":
-          if (member.getValue() instanceof Boolean) {
-            obj.setProtocolNegotiation((Boolean)member.getValue());
           }
           break;
         case "masterName":
@@ -86,9 +84,19 @@ public class RedisOptionsConverter {
             obj.setPoolCleanerInterval(((Number)member.getValue()).intValue());
           }
           break;
+        case "poolName":
+          if (member.getValue() instanceof String) {
+            obj.setPoolName((String)member.getValue());
+          }
+          break;
         case "poolRecycleTimeout":
           if (member.getValue() instanceof Number) {
             obj.setPoolRecycleTimeout(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "protocolNegotiation":
+          if (member.getValue() instanceof Boolean) {
+            obj.setProtocolNegotiation((Boolean)member.getValue());
           }
           break;
         case "role":
@@ -123,7 +131,6 @@ public class RedisOptionsConverter {
       obj.getEndpoints().forEach(item -> array.add(item));
       json.put("endpoints", array);
     }
-    json.put("handshakeProtocolNegotiation", obj.isProtocolNegotiation());
     if (obj.getMasterName() != null) {
       json.put("masterName", obj.getMasterName());
     }
@@ -138,7 +145,11 @@ public class RedisOptionsConverter {
       json.put("password", obj.getPassword());
     }
     json.put("poolCleanerInterval", obj.getPoolCleanerInterval());
+    if (obj.getPoolName() != null) {
+      json.put("poolName", obj.getPoolName());
+    }
     json.put("poolRecycleTimeout", obj.getPoolRecycleTimeout());
+    json.put("protocolNegotiation", obj.isProtocolNegotiation());
     if (obj.getRole() != null) {
       json.put("role", obj.getRole().name());
     }

--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -2,9 +2,6 @@ package io.vertx.redis.client;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.impl.JsonUtil;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Converter and mapper for {@link io.vertx.redis.client.RedisOptions}.
@@ -46,7 +43,7 @@ public class RedisOptionsConverter {
           break;
         case "handshakeProtocolNegotiation":
           if (member.getValue() instanceof Boolean) {
-            obj.setHandshakeProtocolNegotiation((Boolean)member.getValue());
+            obj.setProtocolNegotiation((Boolean)member.getValue());
           }
           break;
         case "masterName":
@@ -126,7 +123,7 @@ public class RedisOptionsConverter {
       obj.getEndpoints().forEach(item -> array.add(item));
       json.put("endpoints", array);
     }
-    json.put("handshakeProtocolNegotiation", obj.isHandshakeProtocolNegotiation());
+    json.put("handshakeProtocolNegotiation", obj.isProtocolNegotiation());
     if (obj.getMasterName() != null) {
       json.put("masterName", obj.getMasterName());
     }

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -47,7 +47,7 @@ public class RedisOptions {
   private RedisRole role;
   private RedisReplicas useReplicas;
   private volatile String password;
-  private boolean noHello;
+  private boolean handshakeProtocolNegotiation;
 
   // pool related options
   private String poolName;
@@ -62,6 +62,7 @@ public class RedisOptions {
         .setTcpKeepAlive(true)
         .setTcpNoDelay(true);
 
+    handshakeProtocolNegotiation = true;
     maxWaitingHandlers = 2048;
     maxNestedArrays = 32;
     masterName = "mymaster";
@@ -104,6 +105,7 @@ public class RedisOptions {
     this.maxPoolWaiting = other.maxPoolWaiting;
     this.poolRecycleTimeout = other.poolRecycleTimeout;
     this.password = other.password;
+    this.handshakeProtocolNegotiation = other.handshakeProtocolNegotiation;
   }
 
   /**
@@ -487,25 +489,28 @@ public class RedisOptions {
   }
 
   /**
-   * Read the flag to disable the HELLO command during connection handshake.
-   * @return true if HELLO is not to be used.
+   * Should the client perform {@code REST} protocol negotiation during the connection acquire.
+   * By default this is {@code true}, but there are situations when using broken servers it may
+   * be useful to skip this and always fallback to {@code RESP2} without using the {@code HELLO}
+   * command.
+   *
+   * @return true to allow negotiation.
    */
-  public boolean isNoHello() {
-    return noHello;
+  public boolean isHandshakeProtocolNegotiation() {
+    return handshakeProtocolNegotiation;
   }
 
   /**
-   * There are well know broken server implementations deployed on the cloud. Azure is one of these cases.
-   * These servers report the wrong number of keys to the hello response, rendering the client unusable.
+   * Should the client perform {@code REST} protocol negotiation during the connection acquire.
+   * By default this is {@code true}, but there are situations when using broken servers it may
+   * be useful to skip this and always fallback to {@code RESP2} without using the {@code HELLO}
+   * command.
    *
-   * Disabling the hello command during the handshake will force the protocol to be downgraded and keep
-   * the client working.
-   *
-   * @param noHello true to disable hello (not recommended) unless reasons...
+   * @param handshakeProtocolNegotiation false to disable {@code HELLO} (not recommended) unless reasons...
    * @return fluent self
    */
-  public RedisOptions setNoHello(boolean noHello) {
-    this.noHello = noHello;
+  public RedisOptions setHandshakeProtocolNegotiation(boolean handshakeProtocolNegotiation) {
+    this.handshakeProtocolNegotiation = handshakeProtocolNegotiation;
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -47,6 +47,7 @@ public class RedisOptions {
   private RedisRole role;
   private RedisReplicas useReplicas;
   private volatile String password;
+  private boolean noHello;
 
   // pool related options
   private String poolName;
@@ -482,6 +483,29 @@ public class RedisOptions {
    */
   public RedisOptions setPassword(String password) {
     this.password = password;
+    return this;
+  }
+
+  /**
+   * Read the flag to disable the HELLO command during connection handshake.
+   * @return true if HELLO is not to be used.
+   */
+  public boolean isNoHello() {
+    return noHello;
+  }
+
+  /**
+   * There are well know broken server implementations deployed on the cloud. Azure is one of these cases.
+   * These servers report the wrong number of keys to the hello response, rendering the client unusable.
+   *
+   * Disabling the hello command during the handshake will force the protocol to be downgraded and keep
+   * the client working.
+   *
+   * @param noHello true to disable hello (not recommended) unless reasons...
+   * @return fluent self
+   */
+  public RedisOptions setNoHello(boolean noHello) {
+    this.noHello = noHello;
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -47,7 +47,7 @@ public class RedisOptions {
   private RedisRole role;
   private RedisReplicas useReplicas;
   private volatile String password;
-  private boolean handshakeProtocolNegotiation;
+  private boolean protocolNegotiation;
 
   // pool related options
   private String poolName;
@@ -62,7 +62,7 @@ public class RedisOptions {
         .setTcpKeepAlive(true)
         .setTcpNoDelay(true);
 
-    handshakeProtocolNegotiation = true;
+    protocolNegotiation = true;
     maxWaitingHandlers = 2048;
     maxNestedArrays = 32;
     masterName = "mymaster";
@@ -105,7 +105,7 @@ public class RedisOptions {
     this.maxPoolWaiting = other.maxPoolWaiting;
     this.poolRecycleTimeout = other.poolRecycleTimeout;
     this.password = other.password;
-    this.handshakeProtocolNegotiation = other.handshakeProtocolNegotiation;
+    this.protocolNegotiation = other.protocolNegotiation;
   }
 
   /**
@@ -489,15 +489,15 @@ public class RedisOptions {
   }
 
   /**
-   * Should the client perform {@code REST} protocol negotiation during the connection acquire.
+   * Should the client perform {@code RESP} protocol negotiation during the connection handshake.
    * By default this is {@code true}, but there are situations when using broken servers it may
    * be useful to skip this and always fallback to {@code RESP2} without using the {@code HELLO}
    * command.
    *
-   * @return true to allow negotiation.
+   * @return true to perform negotiation.
    */
-  public boolean isHandshakeProtocolNegotiation() {
-    return handshakeProtocolNegotiation;
+  public boolean isProtocolNegotiation() {
+    return protocolNegotiation;
   }
 
   /**
@@ -506,11 +506,11 @@ public class RedisOptions {
    * be useful to skip this and always fallback to {@code RESP2} without using the {@code HELLO}
    * command.
    *
-   * @param handshakeProtocolNegotiation false to disable {@code HELLO} (not recommended) unless reasons...
+   * @param protocolNegotiation false to disable {@code HELLO} (not recommended) unless reasons...
    * @return fluent self
    */
-  public RedisOptions setHandshakeProtocolNegotiation(boolean handshakeProtocolNegotiation) {
-    this.handshakeProtocolNegotiation = handshakeProtocolNegotiation;
+  public RedisOptions setProtocolNegotiation(boolean protocolNegotiation) {
+    this.protocolNegotiation = protocolNegotiation;
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
@@ -206,7 +206,7 @@ class RedisConnectionManager {
     }
 
     private void hello(ContextInternal ctx, RedisConnection connection, RedisURI redisURI, Handler<AsyncResult<Void>> handler) {
-      if (options.isNoHello()) {
+      if (!options.isHandshakeProtocolNegotiation()) {
         ping(ctx, connection, handler);
       } else {
         Request hello = Request.cmd(Command.HELLO).arg(RESPParser.VERSION);

--- a/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
@@ -206,7 +206,7 @@ class RedisConnectionManager {
     }
 
     private void hello(ContextInternal ctx, RedisConnection connection, RedisURI redisURI, Handler<AsyncResult<Void>> handler) {
-      if (!options.isHandshakeProtocolNegotiation()) {
+      if (!options.isProtocolNegotiation()) {
         ping(ctx, connection, handler);
       } else {
         Request hello = Request.cmd(Command.HELLO).arg(RESPParser.VERSION);

--- a/src/test/java/io/vertx/redis/client/impl/ReplyParserTest.java
+++ b/src/test/java/io/vertx/redis/client/impl/ReplyParserTest.java
@@ -8,10 +8,12 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.redis.client.Response;
 import io.vertx.redis.client.impl.types.BulkType;
 import io.vertx.redis.client.impl.types.MultiType;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Base64;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @RunWith(VertxUnitRunner.class)
@@ -427,29 +429,61 @@ public class ReplyParserTest {
 
     parser.handle(Buffer.buffer(
       "+OK\r\n" +
-      "+OK\r\n" +
-      "$1\r\n" +
-      "1\r\n" +
-      "+OK\r\n" +
-      "+OK\r\n" +
-      "+OK\r\n" +
-      "$5\r\n" +
-      "91600\r\n" +
-      "$6\r\n" +
-      "104099\r\n" +
-      "+OK\r\n" +
-      "$6\r\n" +
-      "104099\r\n" +
-      "$6\r\n" +
-      "104099\r\n" +
-      "+OK\r\n" +
-      "+OK\r\n" +
-      "+OK\r\n" +
-      "$5\r\n" +
-      "77347\r\n" +
-      "$5\r\n" +
-      "91600\r\n" +
-      "$5\r\n" +
-      "91600\r\n"));
+        "+OK\r\n" +
+        "$1\r\n" +
+        "1\r\n" +
+        "+OK\r\n" +
+        "+OK\r\n" +
+        "+OK\r\n" +
+        "$5\r\n" +
+        "91600\r\n" +
+        "$6\r\n" +
+        "104099\r\n" +
+        "+OK\r\n" +
+        "$6\r\n" +
+        "104099\r\n" +
+        "$6\r\n" +
+        "104099\r\n" +
+        "+OK\r\n" +
+        "+OK\r\n" +
+        "+OK\r\n" +
+        "$5\r\n" +
+        "77347\r\n" +
+        "$5\r\n" +
+        "91600\r\n" +
+        "$5\r\n" +
+        "91600\r\n"));
+  }
+
+  @Test
+  @Ignore("Broken Azure output")
+  public void parseAzureHello(TestContext should) {
+    final Async test = should.async();
+
+    final AtomicInteger counter = new AtomicInteger();
+
+    final RESPParser parser = new RESPParser(new ParserHandler() {
+      @Override
+      public void handle(Response response) {
+        System.out.println(response);
+        if (counter.incrementAndGet() == 17) {
+          test.complete();
+        }
+      }
+
+      @Override
+      public void fatal(Throwable t) {
+        should.fail(t);
+      }
+
+      @Override
+      public void fail(Throwable t) {
+        should.fail(t);
+      }
+    }, 16);
+
+    byte[] hello = Base64.getDecoder().decode("JTcNCiQ2DQpzZXJ2ZXINCiQ1DQpyZWRpcw0KJDcNCnZlcnNpb24NCiQ1DQo2LjAuMw0KJDUNCnByb3RvDQo6Mw0KJDINCmlkDQo6MzIxMDUNCiQ0DQptb2RlDQokMTANCnN0YW5kYWxvbmUNCiQ0DQpyb2xlDQokNg0KbWFzdGVyDQo=");
+
+    parser.handle(Buffer.buffer(hello));
   }
 }

--- a/src/test/java/io/vertx/test/redis/RedisClientIT.java
+++ b/src/test/java/io/vertx/test/redis/RedisClientIT.java
@@ -29,7 +29,7 @@ public class RedisClientIT {
     Redis client = Redis.createClient(
       rule.vertx(),
       new RedisOptions()
-        .setNoHello(true)
+        .setHandshakeProtocolNegotiation(false)
         .setPassword(cachekey)
         .setConnectionString("redis://" + cacheHostname + ":6380"));
 

--- a/src/test/java/io/vertx/test/redis/RedisClientIT.java
+++ b/src/test/java/io/vertx/test/redis/RedisClientIT.java
@@ -29,7 +29,7 @@ public class RedisClientIT {
     Redis client = Redis.createClient(
       rule.vertx(),
       new RedisOptions()
-        .setHandshakeProtocolNegotiation(false)
+        .setProtocolNegotiation(false)
         .setPassword(cachekey)
         .setConnectionString("redis://" + cacheHostname + ":6380"));
 

--- a/src/test/java/io/vertx/test/redis/RedisClientIT.java
+++ b/src/test/java/io/vertx/test/redis/RedisClientIT.java
@@ -1,0 +1,47 @@
+package io.vertx.test.redis;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisOptions;
+import org.junit.*;
+import org.junit.runner.RunWith;
+
+import static io.vertx.redis.client.Command.*;
+import static io.vertx.redis.client.Request.cmd;
+
+@RunWith(VertxUnitRunner.class)
+public class RedisClientIT {
+
+  @Rule
+  public final RunTestOnContext rule = new RunTestOnContext();
+
+  @Test
+  @Ignore("This requires a proper Azure account")
+  public void azureTest(TestContext should) {
+    final Async test = should.async();
+
+    String cacheHostname = System.getenv("REDISCACHEHOSTNAME");
+    String cachekey = System.getenv("REDISCACHEKEY");
+
+    Redis client = Redis.createClient(
+      rule.vertx(),
+      new RedisOptions()
+        .setNoHello(true)
+        .setPassword(cachekey)
+        .setConnectionString("redis://" + cacheHostname + ":6380"));
+
+    client.connect(onConnect -> {
+      should.assertTrue(onConnect.succeeded());
+      onConnect.result()
+        .send(cmd(KEYS).arg("*"))
+        .onFailure(should::fail)
+        .onSuccess(res -> {
+          System.out.println(res);
+          test.complete();
+        });
+    });
+  }
+}


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Azure redis hello response is broken. This means we can't rely on it to perform the protocol negotiation and avoid it completely.

https://docs.microsoft.com/en-us/answers/questions/431238/azure-redis-603-responding-incorrectly-to-hello-3.html

This PR introduces a new option flag to not use hello during handshake to properly work around this limitation.