### PR TITLE
Fix: Negative value of cur in class ArrayQueue.

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/ArrayQueue.java
+++ b/src/main/java/io/vertx/redis/client/impl/ArrayQueue.java
@@ -54,6 +54,9 @@ final class ArrayQueue {
    * @throws IndexOutOfBoundsException if the queue is full.
    */
   <T> void offer(T value) {
+    if (value == null) {
+      throw new NullPointerException();
+    }
     if (isFull()) {
       throw new IndexOutOfBoundsException();
     }
@@ -88,6 +91,9 @@ final class ArrayQueue {
    */
   <T> T poll() {
     T e = peek();
+    if (e == null) {
+      return e;
+    }
     queue[front % queue.length] = null; // for garbage collection
     front++;
     if (front == Integer.MAX_VALUE) {


### PR DESCRIPTION
Motivation:

I found a mistake in [poll ](https://github.com/vert-x3/vertx-redis-client/blob/848568ebbeb450229a40623577760874b31a90fd/src/main/java/io/vertx/redis/client/impl/ArrayQueue.java#L89) method  of class [ArrayQueue](https://github.com/vert-x3/vertx-redis-client/blob/848568ebbeb450229a40623577760874b31a90fd/src/main/java/io/vertx/redis/client/impl/ArrayQueue.java).

[`cur--;`](https://github.com/vert-x3/vertx-redis-client/blob/848568ebbeb450229a40623577760874b31a90fd/src/main/java/io/vertx/redis/client/impl/ArrayQueue.java#L97) will execute even if the queue is empty.

Therefore, the following test cases fail.
```java
  @Test
  public void testPoll() {
    ArrayQueue arrayQueue = new ArrayQueue(10);
    arrayQueue.poll();
    arrayQueue.offer("a");
    Assert.assertNotNull(arrayQueue.poll());
  }
```
