### PR TITLE
Pass user to auth Redis command

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/ConnectionManager.java
+++ b/src/main/java/io/vertx/redis/client/impl/ConnectionManager.java
@@ -85,7 +85,7 @@ class ConnectionManager {
           .exceptionHandler(connection::fatal);
 
         // perform authentication
-        authenticate(connection, redisURI.password(), authenticate -> {
+        authenticate(connection, redisURI.user(), redisURI.password(), authenticate -> {
           if (authenticate.failed()) {
             ctx.runOnContext(v -> onConnect.handle(Future.failedFuture(authenticate.cause())));
             return;
@@ -117,13 +117,13 @@ class ConnectionManager {
       });
     }
 
-    private void authenticate(RedisConnection connection, String password, Handler<AsyncResult<Void>> handler) {
+    private void authenticate(RedisConnection connection, String user, String password, Handler<AsyncResult<Void>> handler) {
       if (password == null) {
         handler.handle(Future.succeededFuture());
         return;
       }
       // perform authentication
-      connection.send(Request.cmd(Command.AUTH).arg(password), auth -> {
+      connection.send(Request.cmd(Command.AUTH).arg(user == null ? "default" : user).arg(password), auth -> {
         if (auth.failed()) {
           handler.handle(Future.failedFuture(auth.cause()));
         } else {

--- a/src/test/java/io/vertx/redis/impl/RedisClientImplTest.java
+++ b/src/test/java/io/vertx/redis/impl/RedisClientImplTest.java
@@ -1,12 +1,28 @@
 package io.vertx.redis.impl;
 
+import io.vertx.core.Context;
 import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.redis.RedisOptions;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
 import io.vertx.redis.client.impl.RedisURI;
+import java.util.UUID;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(VertxUnitRunner.class)
 public class RedisClientImplTest {
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
+
+  private Redis client;
 
   @Test
   @SuppressWarnings("deprecation")
@@ -19,5 +35,18 @@ public class RedisClientImplTest {
     RedisURI redisURI = new RedisURI(client.getConnectionString());
     Assert.assertEquals("Password is not correct", auth, redisURI.password());
     vertx.close();
+  }
+
+  @Test
+  public void testUsernameIsNotDefault(TestContext testCxt) {
+
+    final Async before = testCxt.async();
+
+    client = Redis.createClient(rule.vertx(), new io.vertx.redis.client.RedisOptions().setConnectionString("redis://USER_NOT_DEFAULT:pwd@localhost:7002"));
+    client.connect(onConnect -> {
+      testCxt.assertTrue(onConnect.failed());
+      testCxt.assertTrue(onConnect.cause().toString().contains("WRONGPASS invalid username-password"));
+      before.complete();
+    });
   }
 }


### PR DESCRIPTION

ConnectionManager should also have in consideration the username parsed from RedisURI: 

https://github.com/vert-x3/vertx-redis-client/blob/dc2147d76ae3078ae9687ec4789029eac632fee9/src/main/java/io/vertx/redis/client/impl/ConnectionManager.java#L126

Motivation:

Fix for https://github.com/vert-x3/vertx-redis-client/issues/315

