### PR TITLE
Adding and example of client handling credentials - user and password 

### DIFF
--- a/src/main/java/examples/RedisExamples.java
+++ b/src/main/java/examples/RedisExamples.java
@@ -212,4 +212,22 @@ public class RedisExamples {
         conn.send(Request.cmd(Command.GET).arg("key"));
       });
   }
+
+  public void example14(Vertx vertx) {
+    ;
+    Redis.createClient(
+        vertx,
+        // The client handles using credentials - user and password - with
+        // complex non-alphanumerical passwords, when .
+        // when you encode passwords and pass then as part of the connection string,
+        // redis clusters don't decode them back and returns a bad credentials
+        // error
+        new RedisOptions()
+          .addConnectionString("redis://localhost:6379/1?user=redundantName")
+          .setPassword("<password}{}!}}0001"))
+      .connect()
+      .onSuccess(conn -> {
+        // use the connection
+      });
+  }
 }


### PR DESCRIPTION
Adding and example of client handling credentials - user and password 

Motivation:

When you encode passwords and pass then as part of the connection string, redis clusters don't normally decode them back and returns a bad credentials. This example shows how to pass user as query param and password as part of Options.  

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
