### PR TITLE
Fix #322: correctly handle the uri userinfo

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/RedisURI.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisURI.java
@@ -15,10 +15,13 @@
  */
 package io.vertx.redis.client.impl;
 
+import io.vertx.core.http.impl.HttpUtils;
 import io.vertx.core.net.SocketAddress;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -127,16 +130,16 @@ public final class RedisURI {
           throw new IllegalArgumentException("Unsupported Redis connection string scheme [" + uri.getScheme() + "]");
       }
 
-      String userInfo = uri.getUserInfo();
+      String userInfo = uri.getRawUserInfo();
       if (userInfo != null) {
-        int sep = userInfo.lastIndexOf(':');
+        int sep = userInfo.indexOf(':');
         if (sep != -1) {
           if (sep > 0) {
-            user = userInfo.substring(0, sep);
+            user = urlDecode(userInfo.substring(0, sep));
           } else {
             user = params.getOrDefault("user", null);
           }
-          password = userInfo.substring(sep + 1);
+          password = urlDecode(userInfo.substring(sep + 1));
         } else {
           user = params.getOrDefault("user", null);
           password = params.getOrDefault("password", null);
@@ -148,6 +151,14 @@ public final class RedisURI {
 
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException("Failed to parse the connection string", e);
+    }
+  }
+
+  private static String urlDecode(String raw) {
+    try {
+      return URLDecoder.decode(raw, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisURI.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisURI.java
@@ -15,7 +15,6 @@
  */
 package io.vertx.redis.client.impl;
 
-import io.vertx.core.http.impl.HttpUtils;
 import io.vertx.core.net.SocketAddress;
 
 import java.io.UnsupportedEncodingException;

--- a/src/test/java/io/vertx/redis/client/impl/RedisURITest.java
+++ b/src/test/java/io/vertx/redis/client/impl/RedisURITest.java
@@ -76,4 +76,10 @@ public class RedisURITest {
     RedisURI redisURI = new RedisURI("redis://[::1]:1234/0");
     Assert.assertEquals("[::1]:1234", redisURI.socketAddress().toString());
   }
+
+  @Test
+  public void testColon() {
+    RedisURI redisURI = new RedisURI("redis://:admin%3Aqwer@localhost:6379/1");
+    Assert.assertEquals("admin:qwer", redisURI.password());
+  }
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

userinfo needs to be processed in raw mode, so we can clearly identify the colon that splits user from password.