### PR TITLE
new encode function

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/RequestImpl.java
+++ b/src/main/java/io/vertx/redis/client/impl/RequestImpl.java
@@ -145,6 +145,40 @@ public final class RequestImpl implements Request {
     return this;
   }
 
+  Buffer encode(String[] args) {
+    Buffer buffer = Buffer.buffer();
+
+    buffer
+      // array header
+      .appendByte((byte) '*')
+      .appendBytes(numToBytes(args.length + 1))
+      .appendBytes(EOL)
+      // command
+      .appendBytes(cmd.getBytes());
+
+    for (String arg : args) {
+      if (arg == null) {
+        buffer.appendBytes(NULL_BULK);
+        continue;
+      }
+
+      if (arg.length() == 0) {
+        buffer.appendBytes(EMPTY_BULK);
+        continue;
+      }
+
+      byte[] bytes = arg.getBytes(StandardCharsets.UTF_8);
+      buffer
+        .appendByte((byte) '$')
+        .appendBytes(numToBytes(bytes.length))
+        .appendBytes(EOL)
+        .appendBytes(bytes)
+        .appendBytes(EOL);
+    }
+
+    return buffer;
+  }
+
   Buffer encode() {
     return encode(Buffer.buffer());
   }


### PR DESCRIPTION
[slightly enhancement for encoding]

When I'm using vertx-redis-client, the most commonly used way is:
1. get a RedisAPI instance
2. call the redis command with the RedisAPI Object
something like:
`RedisAPI redisAPI = RedisAPI.create(redis);
Future<Response> responseFuture = redisAPI.get(...) // or set, incr etc`
What I notice is that, when I'm calling commands through RedisAPI, It would finally go to RedisAPI.cmd() function, then I find that, RedisAPI.cmd() function will firstly create a Request Object, with a ArrayList<byte[]> called args created, then put all my args into this List one by one, and then, before sending the request to the redis server, encode the List to a buffer.
So, in my opinion, as it may be the most commonly used way, perhaps it is considerable to directly encode the String array instead of create a ArrayList first, put all the args into the List and then encode it?
I'm not sure if it is a good idea for you so I only wrote the encode function, and I would like to finish the entire job if you accept the point.
Thank you
