### PR TITLE
Expose more Command create arguments

### DIFF
--- a/src/main/java/io/vertx/redis/client/Command.java
+++ b/src/main/java/io/vertx/redis/client/Command.java
@@ -416,4 +416,8 @@ public interface Command {
   static Command create(String command) {
     return new CommandImpl(command, -1, null, false, true);
   }
+  
+  static Command create(String command, int arity, Boolean readOnly, boolean pubsub, boolean needGetKeys) {
+    return new CommandImpl(command, arity, readOnly, pubsub, needGetKeys);
+  }
 }


### PR DESCRIPTION
Motivation:

Expose more Command create arguments to let user create custom command.

Or further, do you think we should a this? Please:
```
  static Command create(String command, int arity, Boolean readOnly, boolean pubsub, boolean needGetKeys, KeyLocator... keyLocators) {
    return new CommandImpl(command, arity, readOnly, pubsub, needGetKeys, keyLocators);
  }
```
In this case, maybe we should change package `io.vertx.redis.client.impl.keys` to `io.vertx.redis.client.keys`.