### PR TITLE
Adding support for special doubles

### DIFF
--- a/src/main/java/io/vertx/redis/client/Response.java
+++ b/src/main/java/io/vertx/redis/client/Response.java
@@ -93,7 +93,17 @@ public interface Response extends Iterable<Response> {
   default @Nullable Double toDouble() {
     final String msg = toString();
     if (msg != null) {
-      return Double.parseDouble(msg);
+      switch (msg) {
+        case "-nan":
+        case "nan":
+          return Double.NaN;
+        case "inf":
+          return Double.POSITIVE_INFINITY;
+        case "-inf":
+          return Double.NEGATIVE_INFINITY;
+        default:
+          return Double.parseDouble(msg);
+      }
     }
     return null;
   }

--- a/src/main/java/io/vertx/redis/client/impl/ReadableBuffer.java
+++ b/src/main/java/io/vertx/redis/client/impl/ReadableBuffer.java
@@ -117,6 +117,8 @@ final class ReadableBuffer {
               number = Double.NaN;
           } else if (bytes.length == 4 && bytes[0] == '-' && bytes[1] == 'i' && bytes[2] == 'n' && bytes[3] == 'f') {
             number = Double.NEGATIVE_INFINITY;
+          } else if (bytes.length == 4 && bytes[0] == '-' && bytes[1] == 'n' && bytes[2] == 'a' && bytes[3] == 'n') {
+            number = Double.NaN;
           } else {
             number = Double.parseDouble(new String(bytes, StandardCharsets.US_ASCII));
           }

--- a/src/main/java/io/vertx/redis/client/impl/ReadableBuffer.java
+++ b/src/main/java/io/vertx/redis/client/impl/ReadableBuffer.java
@@ -113,6 +113,8 @@ final class ReadableBuffer {
         case DECIMAL:
           if (bytes.length == 3 && bytes[0] == 'i' && bytes[1] == 'n' && bytes[2] == 'f') {
             number = Double.POSITIVE_INFINITY;
+          } else if (bytes.length == 3 && bytes[0] == 'n' && bytes[1] == 'a' && bytes[2] == 'n') {
+              number = Double.NaN;
           } else if (bytes.length == 4 && bytes[0] == '-' && bytes[1] == 'i' && bytes[2] == 'n' && bytes[3] == 'f') {
             number = Double.NEGATIVE_INFINITY;
           } else {

--- a/src/test/java/io/vertx/test/redis/RedisClient7Test.java
+++ b/src/test/java/io/vertx/test/redis/RedisClient7Test.java
@@ -254,4 +254,17 @@ public class RedisClient7Test {
           });
       });
   }
+
+  @Test
+  public void testNaN(TestContext should) {
+    final Async test = should.async();
+    final String key = makeKey();
+
+    client.send(cmd(EVAL).arg("return tostring(0/0)").arg(0))
+      .onFailure(should::fail)
+      .onSuccess(ok -> {
+        should.assertTrue(Double.isNaN(ok.toDouble()));
+        test.complete();
+      });
+  }
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

To handle a few extensions and in preparation to `nan` support in RESP3 protocol this PR will support both native `nan` and String base `nan`