### PR TITLE
Adding equals/hashcode to members that compose key for connection pool

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/CommandImpl.java
+++ b/src/main/java/io/vertx/redis/client/impl/CommandImpl.java
@@ -19,9 +19,7 @@ import io.vertx.redis.client.Command;
 import io.vertx.redis.client.impl.keys.KeyConsumer;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 /**
  * Implementation of the command metadata
@@ -138,5 +136,23 @@ public class CommandImpl implements Command {
   @Override
   public String toString() {
     return command;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CommandImpl command1 = (CommandImpl) o;
+    // the command itself must be unique, the remaining properties are not relevant as they are metadata for the command
+    return Objects.equals(command, command1.command);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(command);
   }
 }

--- a/src/main/java/io/vertx/redis/client/impl/RequestImpl.java
+++ b/src/main/java/io/vertx/redis/client/impl/RequestImpl.java
@@ -20,10 +20,7 @@ import io.vertx.redis.client.Command;
 import io.vertx.redis.client.Request;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static io.vertx.redis.client.impl.RESPEncoder.numToBytes;
 
@@ -199,5 +196,22 @@ public final class RequestImpl implements Request {
     } else {
       return -arity <= arglen;
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RequestImpl request = (RequestImpl) o;
+    return Objects.equals(cmd, request.cmd) && Objects.equals(args, request.args);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(cmd, args);
   }
 }

--- a/tools/package.json
+++ b/tools/package.json
@@ -8,7 +8,7 @@
     "redis": "^2.8.0"
   },
   "scripts": {
-    "--prestart": "docker run --rm --net=host redis:latest",
+    "--prestart": "docker run --rm --net=host redis/redis-stack-server:7.0.6-RC8",
     "start": "node commands.js"
   }
 }


### PR DESCRIPTION
Motivation:

Connection pool builds a key based on connection url and setup command, this PR adds equals and hashcode implementation to objects that are used to compose that key to avoid uneeded generation of connections.