### PR TITLE
Add Credentials Provider to allow short(er) lived credentials.

### DIFF
--- a/src/main/java/io/vertx/redis/client/RedisCredentials.java
+++ b/src/main/java/io/vertx/redis/client/RedisCredentials.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ * <p>
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.redis.client;
+
+import io.vertx.redis.client.impl.RedisCredentialsImpl;
+
+/**
+ * This interface is providing the username and password used for authentication against a redis server.
+ */
+public interface RedisCredentials {
+
+  /**
+   * Provide the username for authentication. Can be <code>null</code> to use "default".
+   *
+   * @return the username
+   */
+  String getUser();
+
+  /**
+   * Provide the password for authentication. Can be <code>null</code> in case no password is set.
+   *
+   * @return the password
+   */
+  String getPassword();
+
+  /**
+   * Create an empty instance of {@link RedisCredentials}. Username and password are both <code>null</code>.
+   *
+   * @return empty credentials
+   */
+  static RedisCredentials createEmptyCredentials(){
+    return RedisCredentialsImpl.EMPTY_CREDENTIALS;
+  }
+
+  /**
+   * Create {@link RedisCredentials} with "default" username and specified password.
+   *
+   * @param password password for authentication
+   *
+   * @return credentials
+   */
+  static RedisCredentials create(final String password) {
+    return create(null, password);
+  }
+
+  /**
+   * Create {@link RedisCredentials} with specified user and password.
+   *
+   * @param user user for authentication
+   * @param password for authentication
+   *
+   * @return credentials
+   */
+  static RedisCredentials create(final String user, final String password) {
+    return new RedisCredentialsImpl(user, password);
+  }
+}

--- a/src/main/java/io/vertx/redis/client/RedisCredentialsProvider.java
+++ b/src/main/java/io/vertx/redis/client/RedisCredentialsProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ * <p>
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.redis.client;
+
+import io.vertx.core.Future;
+
+/**
+ * This interface allows to specify credentials used for authentication. Whenever a new connection is created,
+ * the provider specified in {@link RedisOptions} is called to resolve the credentials.
+ */
+public interface RedisCredentialsProvider {
+
+  /**
+   * Resolve credentials used for connection to redis server.
+   *
+   * @return credentials to use for authentication.
+   */
+  Future<RedisCredentials> resolveCredentials();
+}

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -46,6 +46,7 @@ public class RedisOptions {
   private RedisRole role;
   private RedisReplicas useReplicas;
   private volatile String password;
+  private RedisCredentialsProvider credentialsProvider;
   private boolean protocolNegotiation;
 
   // pool related options
@@ -104,6 +105,7 @@ public class RedisOptions {
     this.maxPoolWaiting = other.maxPoolWaiting;
     this.poolRecycleTimeout = other.poolRecycleTimeout;
     this.password = other.password;
+    this.credentialsProvider = other.credentialsProvider;
     this.protocolNegotiation = other.protocolNegotiation;
   }
 
@@ -484,6 +486,26 @@ public class RedisOptions {
    */
   public RedisOptions setPassword(String password) {
     this.password = password;
+    return this;
+  }
+
+  /**
+   * Get the credentials provider for cluster/sentinel connections. If not set it will return <code>null</code>.
+   *
+   * @return credentials provider
+   */
+  public RedisCredentialsProvider getCredentialsProvider() {
+    return credentialsProvider;
+  }
+
+  /**
+   * Set the credentials provider for cluster/sentinel connections.
+   *
+   * @param credentialsProvider the credentials provider to use
+   * @return fluent self
+   */
+  public RedisOptions setCredentialsProvider(final RedisCredentialsProvider credentialsProvider) {
+    this.credentialsProvider = credentialsProvider;
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisCredentialsImpl.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisCredentialsImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ * <p>
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.redis.client.impl;
+
+import io.vertx.redis.client.RedisCredentials;
+
+public class RedisCredentialsImpl implements RedisCredentials {
+
+  public static final RedisCredentials EMPTY_CREDENTIALS = new RedisCredentialsImpl();
+
+  private final String user;
+  private final String password;
+
+  public RedisCredentialsImpl() {
+    this(null, null);
+  }
+
+  public RedisCredentialsImpl(final String user, final String password) {
+    this.user = user;
+    this.password = password;
+  }
+
+  @Override
+  public String getUser() {
+    return this.user;
+  }
+
+  @Override
+  public String getPassword() {
+    return this.password;
+  }
+}

--- a/src/test/java/io/vertx/test/redis/RedisClientCredentialsProviderTest.java
+++ b/src/test/java/io/vertx/test/redis/RedisClientCredentialsProviderTest.java
@@ -1,0 +1,118 @@
+package io.vertx.test.redis;
+
+import static io.vertx.redis.client.Command.ACL;
+import static io.vertx.redis.client.Command.GET;
+import static io.vertx.redis.client.Command.SET;
+import static io.vertx.redis.client.Request.cmd;
+
+import java.util.UUID;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+
+import io.vertx.core.Future;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisCredentials;
+import io.vertx.redis.client.RedisOptions;
+
+@RunWith(VertxUnitRunner.class)
+public class RedisClientCredentialsProviderTest {
+
+  private static final Network network = Network.newNetwork();
+
+  @Rule
+  public final GenericContainer<?> redis =
+    new GenericContainer<>("redis:7-alpine")
+      .withExposedPorts(6379)
+      .withNetwork(network)
+      .withCommand("redis-server --port 6379 --cluster-enabled no --cluster-config-file nodes.conf --cluster-node-timeout 5000 --appendonly yes --requirepass test");
+
+  @Rule
+  public final RunTestOnContext rule = new RunTestOnContext();
+
+  private Redis createClient(final GenericContainer<?> container, final Future<RedisCredentials> credentials) {
+    return Redis.createClient(rule.vertx(),
+      new RedisOptions().setConnectionString("redis://" + container.getHost() + ":" + container.getFirstMappedPort())
+        .setCredentialsProvider(() -> credentials));
+  }
+
+  @Test(timeout = 10_000L)
+  public void testSimpleAuth(TestContext should) {
+    final Async test = should.async();
+    final String nonexisting = makeKey();
+    final String mykey = makeKey();
+
+    final Redis client = createClient(redis, Future.succeededFuture(RedisCredentials.create("test")));
+
+    client.send(cmd(GET).arg(nonexisting), reply0 -> {
+      should.assertTrue(reply0.succeeded());
+      should.assertNull(reply0.result());
+
+      client.send(cmd(SET).arg(mykey).arg("Hello"), reply1 -> {
+        should.assertTrue(reply1.succeeded());
+        client.send(cmd(GET).arg(mykey), reply2 -> {
+          should.assertTrue(reply2.succeeded());
+          should.assertEquals("Hello", reply2.result().toString());
+          test.complete();
+        });
+      });
+    });
+  }
+
+  @Test(timeout = 10_000L)
+  public void testWithUser(TestContext should) {
+    final Async test = should.async();
+    final String nonexisting = makeKey();
+    final String mykey = makeKey();
+
+    final Redis client = createClient(redis, Future.succeededFuture(RedisCredentials.create(null, "test")));
+
+    client.send(cmd(ACL).arg("SETUSER").arg("alice").arg("on").arg(">p1pp0").arg("~*").arg("+get").arg("+set"))
+      .onFailure(should::fail).onSuccess(ok -> {
+        // create a new client, this time using alice ACL
+        Redis alice = createClient(redis, Future.succeededFuture(RedisCredentials.create("alice", "p1pp0")));
+
+        alice.send(cmd(GET).arg(nonexisting), reply0 -> {
+          should.assertTrue(reply0.succeeded());
+          should.assertNull(reply0.result());
+
+          alice.send(cmd(SET).arg(mykey).arg("Hello"), reply1 -> {
+            should.assertTrue(reply1.succeeded());
+            alice.send(cmd(GET).arg(mykey), reply2 -> {
+              should.assertTrue(reply2.succeeded());
+              should.assertEquals("Hello", reply2.result().toString());
+              test.complete();
+            });
+          });
+        });
+      });
+  }
+
+  @Test(timeout = 10_000L)
+  public void testFailure(TestContext should) {
+    final Async test = should.async();
+    final String nonexisting = makeKey();
+
+    final IllegalStateException failure = new IllegalStateException("Simulate credentials provider failure");
+
+    final Redis client = createClient(redis, Future.failedFuture(failure));
+
+    client.send(cmd(GET).arg(nonexisting), reply0 -> {
+      should.assertTrue(reply0.failed());
+      should.assertNull(reply0.result());
+      should.assertEquals(failure, reply0.cause());
+      test.complete();
+    });
+  }
+
+  private static String makeKey() {
+    return UUID.randomUUID().toString();
+  }
+}


### PR DESCRIPTION
Motivation:

At the moment the implementation only allows one hard coded user and password. In theory it would be possible to override the getPassword method of RedisOptions, but this is pretty hacky and also blocks the thread in case providing the credentials (or here just the password) takes a longer time.

With the provided changes it is possible to dynamically adjust the credentials used for a new connection. The rule is: credentials provider > URI > RedisOptions (if available). This allows to use short lived credentials or allow to rotate credentials and update them without reconfiguration. In the Issues section I saw that somebody asked for AWS credentials. This should be possible here in multiple ways. E.g. using IAM auth added for ElastiCache recently, or extracing credentials from AWS SecretsManager (with rotation), etc.

Questions:
I hope I managed to create some useful tests. I was ok with creating the adjustments for RedisConnectionManager, but I am a bit confused regarding the RedisClusterConnection class. I basically searched for getPassword() usage and these are the only two locations. But the later one is never considering the username. This looks a bit strange to me. I just adjusted it so that it still just considers the username and skips the username information there. 

