### PR TITLE
feat - improve reconnection example code

### DIFF
--- a/src/main/java/examples/RedisExamples.java
+++ b/src/main/java/examples/RedisExamples.java
@@ -121,6 +121,7 @@ public class RedisExamples {
       private static final int MAX_RECONNECT_RETRIES = 16;
 
       private final RedisOptions options = new RedisOptions();
+      private Redis redis;
       private RedisConnection client;
       private final AtomicBoolean CONNECTING = new AtomicBoolean();
 
@@ -139,20 +140,30 @@ public class RedisExamples {
       private Future<RedisConnection> createRedisClient() {
         Promise<RedisConnection> promise = Promise.promise();
 
+        // make sure to invalidate old connection if present
+        if (redis != null) {
+          redis.close();;
+        }
+
         if (CONNECTING.compareAndSet(false, true)) {
-          Redis.createClient(vertx, options)
+          redis = Redis.createClient(vertx, options);
+          redis
             .connect()
             .onSuccess(conn -> {
-
-              // make sure to invalidate old connection if present
-              if (client != null) {
-                client.close();
-              }
+              client = conn;
+              client.close();
 
               // make sure the client is reconnected on error
+              // eg, the underlying TCP connection is closed but the client side doesn't know it yet
+              //     the client tries to use the staled connection to talk to server. An exceptions will be raised
               conn.exceptionHandler(e -> {
-                // attempt to reconnect,
-                // if there is an unrecoverable error
+                attemptReconnect(0);
+              });
+
+              // make sure the client is reconnected on connection close
+              // eg, the underlying TCP connection is closed with normal 4-Way-Handshake
+              //     this handler will be notified instantly
+              conn.endHandler(placeHolder -> {
                 attemptReconnect(0);
               });
 


### PR DESCRIPTION
Motivation:

- fix the connection leak in reconnect example code mentioned in https://github.com/vert-x3/vertx-redis-client/pull/292#issuecomment-1122513218 
- improve reconnection example code with `endHandler` as described in https://github.com/vert-x3/vertx-redis-client/issues/375

