### PR TITLE
Add evalLua method in RedisAPI

### DIFF
--- a/src/main/java/io/vertx/redis/client/LuaScript.java
+++ b/src/main/java/io/vertx/redis/client/LuaScript.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.redis.client;
+
+import io.vertx.redis.client.util.Hash;
+
+/**
+ * LuaScript
+ *
+ * Lua script with pre-computed sha hash.
+ */
+public class LuaScript {
+
+  // this lua script
+  private final String lua;
+
+  // pre-computed sha
+  private final String sha;
+
+  // pre-converted string of num of keys
+  private final String numKeys;
+
+  public LuaScript(String lua, int numKeys) {
+    this.lua = lua;
+    this.sha = Hash.sha1(lua);
+    this.numKeys = String.valueOf(numKeys);
+  }
+
+  /**
+   * @return the lua
+   */
+  public String getLua() {
+    return lua;
+  }
+
+  /**
+   * @return the sha
+   */
+  public String getSha() {
+    return sha;
+  }
+
+  /**
+   * @return the numKeys
+   */
+  public String getNumKeys() {
+    return numKeys;
+  }
+}

--- a/src/main/java/io/vertx/redis/client/LuaScript.java
+++ b/src/main/java/io/vertx/redis/client/LuaScript.java
@@ -20,7 +20,7 @@ import io.vertx.redis.client.util.Hash;
 /**
  * LuaScript
  *
- * Lua script with pre-computed sha hash.
+ * <p>Lua script with pre-computed sha hash.
  */
 public class LuaScript {
 
@@ -30,13 +30,9 @@ public class LuaScript {
   // pre-computed sha
   private final String sha;
 
-  // pre-converted string of num of keys
-  private final String numKeys;
-
-  public LuaScript(String lua, int numKeys) {
+  public LuaScript(String lua) {
     this.lua = lua;
     this.sha = Hash.sha1(lua);
-    this.numKeys = String.valueOf(numKeys);
   }
 
   /**
@@ -51,12 +47,5 @@ public class LuaScript {
    */
   public String getSha() {
     return sha;
-  }
-
-  /**
-   * @return the numKeys
-   */
-  public String getNumKeys() {
-    return numKeys;
   }
 }

--- a/src/main/java/io/vertx/redis/client/RedisAPI.java
+++ b/src/main/java/io/vertx/redis/client/RedisAPI.java
@@ -20,9 +20,9 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.redis.client.impl.RedisAPIImpl;
-import io.vertx.redis.client.util.Hash;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
@@ -3169,67 +3169,71 @@ public interface RedisAPI {
   Future<@Nullable Response> send(Command cmd, String... args);
 
   /**
-   * Run redis command with same arguments as eval but will try evalsha first,
-   * if evalsha failed with `NOSCRIPT` error, will retry with the script, so
-   * the next try evalsha will success as script has already been cached.
+   * Run redis command eval lua with arguments but will try evalsha first, if
+   * evalsha failed with `NOSCRIPT` error, will retry with the script, so the
+   * next try evalsha will success as script has already been cached.
    *
+   * Example:
+   * {@code
+   * final static LuaScript luaScript = new LuaScript("return ARGV[1]", 0);
+   * ... some codes ...
+   * evalLua(luaScript, Arrays.asList("hello"));
+   * }
+   *
+   * @param luaScript lua script with pre-computed sha hash
    * @return Future response.
    */
-  default Future<Response> evalLua(List<String> args) {
-    List<String> shaArgs = new ArrayList<>(args);
-    shaArgs.set(0, Hash.sha1(shaArgs.get(0)));
+  @GenIgnore
+  default Future<Response> evalLua(LuaScript luaScript, List<String> args) {
+    // pass empty args if no args to avoid null check on args
+    List<String> redisArgs = new ArrayList<>(args.size() + 2);
+    redisArgs.add(luaScript.getSha());
+    redisArgs.add(luaScript.getNumKeys());
+    redisArgs.addAll(args);
 
-    return evalsha(shaArgs)
-      .compose(
-        // directly use result when succeeded
-        result -> Future.succeededFuture(result),
-        t -> {
-          // load script and try ONCE again when failed cause script missing
-          if (t.getMessage().startsWith("NOSCRIPT")) {
-            // directly eval script and then script will be cached in redis, so
-            // evalhash will success next time
-            return eval(args);
-          }
+    return evalsha(redisArgs)
+        .compose(
+            // directly use result when succeeded
+            result -> Future.succeededFuture(result),
+            t -> {
+              // load script and try ONCE again when failed cause script missing
+              if (t.getMessage().startsWith("NOSCRIPT")) {
+                // directly eval script and then script will be cached in redis, so
+                // evalhash will success next time
+                redisArgs.set(0, luaScript.getLua());
+                return eval(redisArgs);
+              }
 
-          // fail when failed cause not script missing
-          return Future.failedFuture(t);
-        });
+              // fail when failed cause not script missing
+              return Future.failedFuture(t);
+            });
   }
 
   /**
-   * evalLua with a specified luaScript argument.
+   * evalLua with no pre-computed sha.
+   *
+   * NOTE: prefer to define a static variable with type of LuaScript and use the
+   * `evalLua(LuaScript, List)`, with this method, sha will always be computed.
    */
-  default Future<Response> evalLua(String luaScript, List<String> args) {
-    List<String> newArgs = new ArrayList<>(args.size() + 1);
+  @GenIgnore
+  default Future<Response> evalLua(String lua, int numkeys, List<String> keys, List<String> args) {
+    LuaScript luaScript = new LuaScript(lua, numkeys);
 
-    newArgs.add(luaScript);
-    newArgs.addAll(args);
-
-    return evalLua(newArgs);
-  }
-
-  /**
-   * evalLua with a specified arguments and with checking on them.
-   */
-  default Future<Response> evalLua(String luaScript, int numkeys, List<String> keys, List<String> args) {
     List<String> allArgs = new ArrayList<>();
+    allArgs.addAll(keys);
+    allArgs.addAll(args);
 
-    allArgs.add(luaScript);
-    allArgs.add(String.valueOf(numkeys));
+    return evalLua(luaScript, allArgs);
+  }
 
-    if ((keys == null && numkeys != 0) || (keys != null && keys.size() != numkeys)) {
-      throw new IllegalArgumentException(
-        "numkeys " + numkeys + " and keys " + keys + " are not match");
-    }
-
-    if (keys != null && keys.size() != 0) {
-      allArgs.addAll(keys);
-    }
-
-    if (args != null && args.size() != 0) {
-      allArgs.addAll(args);
-    }
-
-    return evalLua(allArgs);
+  /**
+   * evalLua with no pre-computed sha.
+   *
+   * NOTE: prefer to define a static variable with type of LuaScript and use the
+   * `evalLua(LuaScript, List)`, with this method, sha will always be computed.
+   */
+  @GenIgnore
+  default Future<Response> evalLua(String lua, int numkeys, String... args) {
+    return evalLua(new LuaScript(lua, numkeys), Arrays.asList(args));
   }
 }

--- a/src/main/java/io/vertx/redis/client/RedisAPI.java
+++ b/src/main/java/io/vertx/redis/client/RedisAPI.java
@@ -3220,8 +3220,12 @@ public interface RedisAPI {
     LuaScript luaScript = new LuaScript(lua, numkeys);
 
     List<String> allArgs = new ArrayList<>();
-    allArgs.addAll(keys);
-    allArgs.addAll(args);
+    if (keys != null && keys.size() != 0) {
+      allArgs.addAll(keys);
+    }
+    if (args != null && args.size() != 0) {
+      allArgs.addAll(args);
+    }
 
     return evalLua(luaScript, allArgs);
   }

--- a/src/main/java/io/vertx/redis/client/util/Hash.java
+++ b/src/main/java/io/vertx/redis/client/util/Hash.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.redis.client.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class Hash {
+
+  private static String bytesToHex(byte[] hash) {
+    StringBuilder hexString = new StringBuilder(2 * hash.length);
+    for (int i = 0; i < hash.length; i++) {
+      String hex = Integer.toHexString(0xff & hash[i]);
+      if (hex.length() == 1) {
+        hexString.append('0');
+      }
+      hexString.append(hex);
+    }
+    return hexString.toString();
+  }
+
+  public static String hash(String input, String name) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance(name);
+      byte[] encodedhash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+      return bytesToHex(encodedhash);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static String sha1(String input) {
+    return hash(input, "SHA-1");
+  }
+}

--- a/src/test/java/io/vertx/redis/client/test/RedisTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisTest.java
@@ -348,7 +348,7 @@ public class RedisTest {
 
         RedisAPI redis = RedisAPI.api(create.result());
 
-          redis.evalLua(lua, 0, "hello", "world").onComplete(should.asyncAssertSuccess(r -> {
+          redis.evalLua(lua, "0", "hello", "world").onComplete(should.asyncAssertSuccess(r -> {
           should.assertNotNull(r);
           should.assertEquals("world", r.toString());
           test.complete();
@@ -359,7 +359,6 @@ public class RedisTest {
   @Test
   public void testEvalLua2(TestContext should) {
     final String script = "return ARGV[3]";
-    final int numKeys = 1;
     final List<String> keys = Arrays.asList("hello");
     final List<String> args = Arrays.asList("1", "22", "333");
     final Async test = should.async();
@@ -373,9 +372,9 @@ public class RedisTest {
         RedisAPI redis = RedisAPI.api(create.result());
 
         redis.script(Arrays.asList("flush"))
-          .compose(_resp -> redis.evalLua(script, numKeys, keys, args))
+          .compose(_resp -> redis.evalLua(script, keys, args))
           .compose(_resp -> redis.script(Arrays.asList("flush")))
-          .compose(_resp -> redis.evalLua(script, numKeys, keys, args))
+          .compose(_resp -> redis.evalLua(script, keys, args))
           .onComplete(should.asyncAssertSuccess(r -> {
             should.assertNotNull(r);
             should.assertEquals("333", r.toString());

--- a/src/test/java/io/vertx/redis/client/test/RedisTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisTest.java
@@ -348,7 +348,7 @@ public class RedisTest {
 
         RedisAPI redis = RedisAPI.api(create.result());
 
-        redis.evalLua(Arrays.asList(lua, "0", "hello", "world")).onComplete(should.asyncAssertSuccess(r -> {
+          redis.evalLua(lua, 0, "hello", "world").onComplete(should.asyncAssertSuccess(r -> {
           should.assertNotNull(r);
           should.assertEquals("world", r.toString());
           test.complete();


### PR DESCRIPTION
Motivation:

Add a convenient method to eval lua script directly, avoid the load-evalsha steps.

Because redis use sha1 to compute script hash, so we can compute it in our client and directly try it wit a `evalsha`. If failed with a NOSCRIPT error, we can retry with `eval` and it will cache script, so next time we try evalsha will success.
