### PR TITLE
fix: mget with multiple keys in different slots but first two in the same slot will fail

### DIFF
--- a/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
@@ -1,5 +1,6 @@
 package io.vertx.redis.client.test;
 
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
@@ -8,6 +9,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.redis.client.*;
+import java.util.stream.Collectors;
 import org.junit.*;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
@@ -926,6 +928,90 @@ public class RedisClusterTest {
           });
         });
       });
+  }
+
+  @Test(timeout = 30_000)
+  public void mgetMultiKeyInDifferentSlotsWithFirstTwoInSameSlots(TestContext should) {
+    final Async test = should.async();
+
+    final String key1 = "{hash_tag}.some-key1";
+    final String argv1 = "some-value1";
+    final String key2 = "{hash_tag}.some-key2";
+    final String argv2 = "some-value2";
+
+    final String key3 = "{other_hash_tag}.other-key1";
+    final String argv3 = "other-value1";
+    final String key4 = "{other_hash_tag}.other-key2";
+    final String argv4 = "other-value2";
+
+    client.connect().compose(cluster -> {
+      cluster.exceptionHandler(should::fail);
+      Future<@Nullable Response> setFuture1 = cluster.send(cmd(SET).arg(key1).arg(argv1));
+      Future<@Nullable Response> setFuture2 = cluster.send(cmd(SET).arg(key2).arg(argv2));
+      Future<@Nullable Response> setFuture3 = cluster.send(cmd(SET).arg(key3).arg(argv3));
+      Future<@Nullable Response> setFuture4 = cluster.send(cmd(SET).arg(key4).arg(argv4));
+      return Future.all(setFuture1, setFuture2, setFuture3, setFuture4)
+        .compose(compositeRet -> {
+          System.out.println("set operations successfully");
+          return cluster.send(cmd(MGET).arg(key1).arg(key2).arg(key3).arg(key4));
+        })
+        .compose(mgetResponse -> {
+          System.out.println("mget operation successfully");
+          Set<String> mgetRet = mgetResponse.stream().map(Response::toString)
+            .collect(Collectors.toSet());
+          should.assertTrue(mgetRet.contains(argv1));
+          should.assertTrue(mgetRet.contains(argv2));
+          should.assertTrue(mgetRet.contains(argv3));
+          should.assertTrue(mgetRet.contains(argv4));
+          test.complete();
+          return Future.succeededFuture();
+        });
+    }).onFailure(throwable -> {
+      throwable.printStackTrace();
+      should.fail(throwable);
+    });
+  }
+
+  @Test(timeout = 30_000)
+  public void mgetMultiKeyInDifferentSlotsWithFirstTwoInDifferentSlots(TestContext should) {
+    final Async test = should.async();
+
+    final String key1 = "{hash_tag}.some-key1";
+    final String argv1 = "some-value1";
+    final String key2 = "{hash_tag}.some-key2";
+    final String argv2 = "some-value2";
+
+    final String key3 = "{other_hash_tag}.other-key1";
+    final String argv3 = "other-value1";
+    final String key4 = "{other_hash_tag}.other-key2";
+    final String argv4 = "other-value2";
+
+    client.connect().compose(cluster -> {
+      cluster.exceptionHandler(should::fail);
+      Future<@Nullable Response> setFuture1 = cluster.send(cmd(SET).arg(key1).arg(argv1));
+      Future<@Nullable Response> setFuture2 = cluster.send(cmd(SET).arg(key2).arg(argv2));
+      Future<@Nullable Response> setFuture3 = cluster.send(cmd(SET).arg(key3).arg(argv3));
+      Future<@Nullable Response> setFuture4 = cluster.send(cmd(SET).arg(key4).arg(argv4));
+      return Future.all(setFuture1, setFuture2, setFuture3, setFuture4)
+        .compose(compositeRet -> {
+          System.out.println("set operations successfully");
+          return cluster.send(cmd(MGET).arg(key1).arg(key3).arg(key2).arg(key4));
+        })
+        .compose(mgetResponse -> {
+          System.out.println("mget operation successfully");
+          Set<String> mgetRet = mgetResponse.stream().map(Response::toString)
+            .collect(Collectors.toSet());
+          should.assertTrue(mgetRet.contains(argv1));
+          should.assertTrue(mgetRet.contains(argv2));
+          should.assertTrue(mgetRet.contains(argv3));
+          should.assertTrue(mgetRet.contains(argv4));
+          test.complete();
+          return Future.succeededFuture();
+        });
+    }).onFailure(throwable -> {
+      throwable.printStackTrace();
+      should.fail(throwable);
+    });
   }
 
   @Test(timeout = 30_000)


### PR DESCRIPTION
Motivation:

There are normal cases for `mget` command in clustered redis that will fail to execute with vert.x redis client

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
