### PR TITLE
Implement tracing and client metrics

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -185,6 +185,31 @@ NOTE: It is important to remember that the commands `SUBSCRIBE`, `UNSUBSCRIBE`, 
 This means that the result in case of success is `null` not a instance of response.
 All messages are then routed through the handler on the client.
 
+== Tracing commands
+
+The Redis client can trace command execution when Vert.x has tracing enabled.
+
+The client reports a _client_ span with the following details:
+
+* operation name: `Command`
+* tags:
+** `db.user`: the database username, if set
+** `db.instance`: the database number, if known (typically `0`)
+** `db.statement`: the Redis command, without arguments (e.g. `get` or `set`)
+** `db.type`: _redis_
+
+The default tracing policy is {@link io.vertx.core.tracing.TracingPolicy#PROPAGATE}, the client
+will only create a span when involved in an active trace.
+
+You can change the client policy with {@link io.vertx.redis.client.RedisOptions#setTracingPolicy},
+e.g you can set {@link io.vertx.core.tracing.TracingPolicy#ALWAYS} to always report
+a span:
+
+[source,$lang]
+----
+{@link examples.RedisExamples#tracing1}
+----
+
 == Domain Sockets
 
 Most of the examples shown connecting to a TCP sockets, however it is also possible to use Redis connecting to a UNIX domain docket:

--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -108,6 +108,11 @@ public class RedisOptionsConverter {
             obj.setRole(io.vertx.redis.client.RedisRole.valueOf((String)member.getValue()));
           }
           break;
+        case "tracingPolicy":
+          if (member.getValue() instanceof String) {
+            obj.setTracingPolicy(io.vertx.core.tracing.TracingPolicy.valueOf((String)member.getValue()));
+          }
+          break;
         case "type":
           if (member.getValue() instanceof String) {
             obj.setType(io.vertx.redis.client.RedisClientType.valueOf((String)member.getValue()));
@@ -156,6 +161,9 @@ public class RedisOptionsConverter {
     json.put("protocolNegotiation", obj.isProtocolNegotiation());
     if (obj.getRole() != null) {
       json.put("role", obj.getRole().name());
+    }
+    if (obj.getTracingPolicy() != null) {
+      json.put("tracingPolicy", obj.getTracingPolicy().name());
     }
     if (obj.getType() != null) {
       json.put("type", obj.getType().name());

--- a/src/main/java/examples/RedisExamples.java
+++ b/src/main/java/examples/RedisExamples.java
@@ -4,6 +4,7 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.redis.client.*;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -240,5 +241,9 @@ public class RedisExamples {
         // and read operations will end up in the replica nodes if available
         conn.send(Request.cmd(Command.GET).arg("key"));
       });
+  }
+
+  public void tracing1(RedisOptions options) {
+    options.setTracingPolicy(TracingPolicy.ALWAYS);
   }
 }

--- a/src/main/java/io/vertx/redis/client/Redis.java
+++ b/src/main/java/io/vertx/redis/client/Redis.java
@@ -66,13 +66,13 @@ public interface Redis {
   static Redis createClient(Vertx vertx, RedisOptions options) {
     switch (options.getType()) {
       case STANDALONE:
-        return new RedisClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisStandaloneConnectOptions(options));
+        return new RedisClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisStandaloneConnectOptions(options), options.getTracingPolicy());
       case SENTINEL:
-        return new RedisSentinelClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisSentinelConnectOptions(options));
+        return new RedisSentinelClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisSentinelConnectOptions(options), options.getTracingPolicy());
       case CLUSTER:
-        return new RedisClusterClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisClusterConnectOptions(options));
+        return new RedisClusterClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisClusterConnectOptions(options), options.getTracingPolicy());
       case REPLICATION:
-        return new RedisReplicationClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisClusterConnectOptions(options));
+        return new RedisReplicationClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisClusterConnectOptions(options), options.getTracingPolicy());
       default:
         throw new IllegalStateException("Unknown Redis Client type: " + options.getType());
     }

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -19,6 +19,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.redis.client.impl.RedisURI;
 
 import java.util.ArrayList;
@@ -48,6 +49,7 @@ public class RedisOptions {
   private RedisReplicas useReplicas;
   private volatile String password;
   private boolean protocolNegotiation;
+  private TracingPolicy tracingPolicy;
 
   /**
    * Creates a default configuration object using redis server defaults
@@ -345,6 +347,24 @@ public class RedisOptions {
    */
   public RedisOptions setMaxNestedArrays(int maxNestedArrays) {
     this.maxNestedArrays = maxNestedArrays;
+    return this;
+  }
+
+  /**
+   * @return the tracing policy
+   */
+  public TracingPolicy getTracingPolicy() {
+    return tracingPolicy;
+  }
+
+  /**
+   * Set the tracing policy for the client behavior when Vert.x has tracing enabled.
+   *
+   * @param tracingPolicy the tracing policy
+   * @return fluent self.
+   */
+  public RedisOptions setTracingPolicy(TracingPolicy tracingPolicy) {
+    this.tracingPolicy = tracingPolicy;
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/BaseRedisClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/BaseRedisClient.java
@@ -7,6 +7,7 @@ import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.redis.client.*;
 
 import java.util.Collections;
@@ -19,9 +20,9 @@ public abstract class BaseRedisClient implements Redis {
   protected final VertxInternal vertx;
   protected final RedisConnectionManager connectionManager;
 
-  public BaseRedisClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisConnectOptions connectOptions) {
+  public BaseRedisClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisConnectOptions connectOptions, TracingPolicy tracingPolicy) {
     this.vertx = (VertxInternal) vertx;
-    this.connectionManager = new RedisConnectionManager(this.vertx, tcpOptions, poolOptions, connectOptions);
+    this.connectionManager = new RedisConnectionManager(this.vertx, tcpOptions, poolOptions, connectOptions, tracingPolicy);
     this.connectionManager.start();
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/CommandReporter.java
+++ b/src/main/java/io/vertx/redis/client/impl/CommandReporter.java
@@ -1,0 +1,103 @@
+package io.vertx.redis.client.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.core.spi.tracing.SpanKind;
+import io.vertx.core.spi.tracing.TagExtractor;
+import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.tracing.TracingPolicy;
+
+import java.util.function.Function;
+
+class CommandReporter {
+  enum Tags {
+    // Generic
+    PEER_ADDRESS("peer.address", reporter -> reporter.address),
+    SPAN_KIND("span.kind", reporter -> "client"),
+
+    // DB
+    // See https://github.com/opentracing/specification/blob/master/semantic_conventions.md
+
+    DB_USER("db.user", reporter -> reporter.user),
+    DB_INSTANCE("db.instance", reporter -> reporter.database),
+    DB_STATEMENT("db.statement", reporter -> reporter.command),
+    DB_TYPE("db.type", reporter -> "redis");
+
+    final String name;
+    final Function<CommandReporter, String> valueFunction;
+
+    Tags(String name, Function<CommandReporter, String> valueFunction) {
+      this.name = name;
+      this.valueFunction = valueFunction;
+    }
+  }
+
+  private static final TagExtractor<CommandReporter> REQUEST_TAG_EXTRACTOR = new TagExtractor<CommandReporter>() {
+    private final Tags[] TAGS = Tags.values();
+
+    @Override
+    public int len(CommandReporter obj) {
+      return TAGS.length;
+    }
+    @Override
+    public String name(CommandReporter obj, int index) {
+      return TAGS[index].name;
+    }
+    @Override
+    public String value(CommandReporter obj, int index) {
+      return TAGS[index].valueFunction.apply(obj);
+    }
+  };
+
+  private final VertxTracer tracer;
+  private final ClientMetrics metrics;
+  private final Context context;
+  private final TracingPolicy tracingPolicy;
+  private final String command;
+  private final String address;
+  private final String user;
+  private final String database;
+
+  private Object trace;
+  private Object metric;
+
+  CommandReporter(RedisConnectionInternal conn, String command) {
+    VertxInternal vertx = conn.vertx();
+    RedisURI uri = conn.uri();
+    this.tracer = vertx.tracer();
+    this.metrics = conn.metrics();
+    this.context = vertx.getContext();
+    this.tracingPolicy = conn.tracingPolicy();
+    this.command = command;
+    this.address = uri.socketAddress().toString();
+    this.user = uri.user();
+    // the connection doesn't track the current database, so we have to report "unknown" when tainted
+    this.database = conn.isTainted() ? null : (uri.select() == null ? "0" : String.valueOf(uri.select()));
+  }
+
+  public void before() {
+    if (tracer != null) {
+      trace = tracer.sendRequest(context, SpanKind.RPC, tracingPolicy, this, "Command", (k, v) -> {}, REQUEST_TAG_EXTRACTOR);
+    }
+    if (metrics != null) {
+      metric = metrics.requestBegin(command, command);
+      metrics.requestEnd(metric);
+    }
+  }
+
+  public void after(AsyncResult<?> ar) {
+    if (tracer != null) {
+      tracer.receiveResponse(context, ar.succeeded() ? ar.result() : null, trace, ar.failed() ? ar.cause() : null, TagExtractor.empty());
+    }
+    if (metrics != null) {
+      if (ar.succeeded()) {
+        metrics.responseBegin(metric, null);
+        metrics.responseEnd(metric);
+      } else {
+        metrics.requestReset(metric);
+      }
+    }
+  }
+}

--- a/src/main/java/io/vertx/redis/client/impl/PooledRedisConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/PooledRedisConnection.java
@@ -70,12 +70,18 @@ public class PooledRedisConnection implements RedisConnection {
 
   @Override
   public Future<@Nullable Response> send(Request command) {
-    return connection.send(command);
+    CommandReporter reporter = new CommandReporter(connection, command.command().toString());
+    reporter.before();
+    return connection.send(command)
+      .andThen(reporter::after);
   }
 
   @Override
   public Future<List<@Nullable Response>> batch(List<Request> commands) {
-    return connection.batch(commands);
+    CommandReporter reporter = new CommandReporter(connection, "batch");
+    reporter.before();
+    return connection.batch(commands)
+      .andThen(reporter::after);
   }
 
   @Override

--- a/src/main/java/io/vertx/redis/client/impl/PooledRedisConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/PooledRedisConnection.java
@@ -28,7 +28,7 @@ public class PooledRedisConnection implements RedisConnection {
     this.metric = metric;
   }
 
-  public RedisConnection actual() {
+  public RedisConnectionInternal actual() {
     return connection;
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClient.java
@@ -32,7 +32,7 @@ public class RedisClient extends BaseRedisClient implements Redis {
   public Future<RedisConnection> connect() {
     // so that the caller is called back on its original context
     Promise<RedisConnection> promise = vertx.promise();
-    connectionManager.getConnection(defaultAddress, null).onComplete(promise);
+    connectionManager.getConnection(defaultAddress, null).onComplete((Promise) promise);
     return promise.future();
   }
 }

--- a/src/main/java/io/vertx/redis/client/impl/RedisClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClient.java
@@ -17,14 +17,15 @@ package io.vertx.redis.client.impl;
 
 import io.vertx.core.*;
 import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.redis.client.*;
 
 public class RedisClient extends BaseRedisClient implements Redis {
 
   private final String defaultAddress;
 
-  public RedisClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisConnectOptions connectOptions) {
-    super(vertx, tcpOptions, poolOptions, connectOptions);
+  public RedisClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisConnectOptions connectOptions, TracingPolicy tracingPolicy) {
+    super(vertx, tcpOptions, poolOptions, connectOptions, tracingPolicy);
     this.defaultAddress = connectOptions.getEndpoint();
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClient.java
@@ -30,6 +30,9 @@ public class RedisClient extends BaseRedisClient implements Redis {
 
   @Override
   public Future<RedisConnection> connect() {
-    return connectionManager.getConnection(defaultAddress, null);
+    // so that the caller is called back on its original context
+    Promise<RedisConnection> promise = vertx.promise();
+    connectionManager.getConnection(defaultAddress, null).onComplete(promise);
+    return promise.future();
   }
 }

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -170,7 +170,7 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
             // create a cluster connection
             final AtomicBoolean failed = new AtomicBoolean(false);
             final AtomicInteger counter = new AtomicInteger();
-            final Map<String, RedisConnection> connections = new HashMap<>();
+            final Map<String, PooledRedisConnection> connections = new HashMap<>();
 
             // validate if the pool config is valid
             final int totalUniqueEndpoints = slots.endpoints().length;
@@ -201,7 +201,7 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
       });
   }
 
-  private void connectionComplete(AtomicInteger counter, Slots slots, Map<String, RedisConnection> connections, AtomicBoolean failed, Handler<AsyncResult<RedisConnection>> onConnect) {
+  private void connectionComplete(AtomicInteger counter, Slots slots, Map<String, PooledRedisConnection> connections, AtomicBoolean failed, Handler<AsyncResult<RedisConnection>> onConnect) {
     if (counter.incrementAndGet() == slots.endpoints().length) {
       // end condition
       if (failed.get()) {

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -19,6 +19,7 @@ import io.vertx.core.*;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.redis.client.*;
 import io.vertx.redis.client.impl.types.MultiType;
 import io.vertx.redis.client.impl.types.NumberType;
@@ -123,8 +124,8 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
   private final RedisClusterConnectOptions connectOptions;
   private final PoolOptions poolOptions;
 
-  public RedisClusterClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisClusterConnectOptions connectOptions) {
-    super(vertx, tcpOptions, poolOptions, connectOptions);
+  public RedisClusterClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisClusterConnectOptions connectOptions, TracingPolicy tracingPolicy) {
+    super(vertx, tcpOptions, poolOptions, connectOptions, tracingPolicy);
     this.connectOptions = connectOptions;
     this.poolOptions = poolOptions;
     // validate options

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
@@ -43,9 +43,9 @@ public class RedisClusterConnection implements RedisConnection {
   private final VertxInternal vertx;
   private final RedisClusterConnectOptions connectOptions;
   private final Slots slots;
-  private final Map<String, RedisConnection> connections;
+  private final Map<String, PooledRedisConnection> connections;
 
-  RedisClusterConnection(Vertx vertx, RedisClusterConnectOptions connectOptions, Slots slots, Map<String, RedisConnection> connections) {
+  RedisClusterConnection(Vertx vertx, RedisClusterConnectOptions connectOptions, Slots slots, Map<String, PooledRedisConnection> connections) {
     this.vertx = (VertxInternal) vertx;
     this.connectOptions = connectOptions;
     this.slots = slots;
@@ -249,7 +249,7 @@ public class RedisClusterConnection implements RedisConnection {
 
   private void send(String endpoint, int retries, Request command, Handler<AsyncResult<Response>> handler) {
 
-    final RedisConnection connection = connections.get(endpoint);
+    final PooledRedisConnection connection = connections.get(endpoint);
 
     if (connection == null) {
       handler.handle(Future.failedFuture("Missing connection to: " + endpoint));

--- a/src/main/java/io/vertx/redis/client/impl/RedisConnectionInternal.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisConnectionInternal.java
@@ -15,6 +15,9 @@
  */
 package io.vertx.redis.client.impl;
 
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.redis.client.RedisConnection;
 
 public interface RedisConnectionInternal extends RedisConnection {
@@ -27,4 +30,28 @@ public interface RedisConnectionInternal extends RedisConnection {
    * Returns {@code true} is this connection can be reset. This means that the connection didn't enter PubSub mode.
    */
   boolean reset();
+
+  /**
+   * Returns whether this connection is "tainted". A connection is called tainted if it changes the default state,
+   * for example, when a connection enters pub sub mode, or specific features are activated such as changing a database
+   * or different authentication is used.
+   */
+  boolean isTainted();
+
+  VertxInternal vertx();
+
+  /**
+   * Returns the {@linkplain RedisURI URI} of the Redis server to which this connection is connected.
+   */
+  RedisURI uri();
+
+  /**
+   * Returns the {@linkplain ClientMetrics client metrics} for this connection.
+   */
+  ClientMetrics metrics();
+
+  /**
+   * Returns the {@linkplain TracingPolicy tracing policy} configured for this connection.
+   */
+  TracingPolicy tracingPolicy();
 }

--- a/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
@@ -315,7 +315,7 @@ class RedisConnectionManager {
     }
   }
 
-  public Future<RedisConnection> getConnection(String connectionString, Request setup) {
+  public Future<PooledRedisConnection> getConnection(String connectionString, Request setup) {
     final ContextInternal context = vertx.getOrCreateContext();
     final EventLoopContext eventLoopContext;
     if (context instanceof EventLoopContext) {

--- a/src/main/java/io/vertx/redis/client/impl/RedisReplicationClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisReplicationClient.java
@@ -151,7 +151,7 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
 
           for (Node node : nodes) {
             if (!node.online) {
-              LOG.info("Skipping offline node: " + node.ip);
+              LOG.info("Skipping offline node: " + node.ip + ":" + node.port);
               if (counter.incrementAndGet() == nodes.size()) {
                 onConnect.handle(Future.succeededFuture(new RedisReplicationConnection(vertx, connectOptions, conn, connections)));
               }
@@ -161,7 +161,7 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
             connectionManager.getConnection(node.endpoint(), RedisReplicas.NEVER != connectOptions.getUseReplicas() ? cmd(READONLY) : null)
               .onFailure(err -> {
                 // failed try with the next endpoint
-                LOG.warn("Skipping failed node: " + node.ip, err);
+                LOG.warn("Skipping failed node: " + node.ip + ":" + node.port, err);
                 if (counter.incrementAndGet() == nodes.size()) {
                   onConnect.handle(Future.succeededFuture(new RedisReplicationConnection(vertx, connectOptions, conn, connections)));
                 }

--- a/src/main/java/io/vertx/redis/client/impl/RedisReplicationClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisReplicationClient.java
@@ -19,6 +19,7 @@ import io.vertx.core.*;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.redis.client.*;
 
 import java.nio.charset.StandardCharsets;
@@ -90,8 +91,8 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
   private final RedisClusterConnectOptions connectOptions;
   private final PoolOptions poolOptions;
 
-  public RedisReplicationClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisClusterConnectOptions connectOptions) {
-    super(vertx, tcpOptions, poolOptions, connectOptions);
+  public RedisReplicationClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisClusterConnectOptions connectOptions, TracingPolicy tracingPolicy) {
+    super(vertx, tcpOptions, poolOptions, connectOptions, tracingPolicy);
     this.connectOptions = connectOptions;
     this.poolOptions = poolOptions;
     // validate options

--- a/src/main/java/io/vertx/redis/client/impl/RedisReplicationClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisReplicationClient.java
@@ -138,7 +138,7 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
           // create a cluster connection
           final List<Node> nodes = getNodes.result();
           final AtomicInteger counter = new AtomicInteger();
-          final List<RedisConnection> connections = new ArrayList<>();
+          final List<PooledRedisConnection> connections = new ArrayList<>();
 
           // validate if the pool config is valid
           final int totalUniqueEndpoints = nodes.size();

--- a/src/main/java/io/vertx/redis/client/impl/RedisReplicationConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisReplicationConnection.java
@@ -29,10 +29,10 @@ public class RedisReplicationConnection implements RedisConnection {
   }
 
   private final RedisClusterConnectOptions connectOptions;
-  private final RedisConnection master;
-  private final List<RedisConnection> replicas;
+  private final PooledRedisConnection master;
+  private final List<PooledRedisConnection> replicas;
 
-  RedisReplicationConnection(Vertx vertx, RedisClusterConnectOptions connectOptions, RedisConnection master, List<RedisConnection> replicas) {
+  RedisReplicationConnection(Vertx vertx, RedisClusterConnectOptions connectOptions, PooledRedisConnection master, List<PooledRedisConnection> replicas) {
     this.connectOptions = connectOptions;
     this.master = master;
     this.replicas = replicas;
@@ -175,7 +175,7 @@ public class RedisReplicationConnection implements RedisConnection {
     return result;
   }
 
-  private RedisConnection selectMasterOrReplicaEndpoint(boolean read, boolean forceMasterEndpoint) {
+  private PooledRedisConnection selectMasterOrReplicaEndpoint(boolean read, boolean forceMasterEndpoint) {
     if (forceMasterEndpoint) {
       return master;
     }

--- a/src/main/java/io/vertx/redis/client/impl/RedisSentinelClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisSentinelClient.java
@@ -19,6 +19,7 @@ import io.vertx.core.*;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.redis.client.*;
 import io.vertx.redis.client.impl.types.ErrorType;
 
@@ -48,8 +49,8 @@ public class RedisSentinelClient extends BaseRedisClient implements Redis {
 
   private final RedisSentinelConnectOptions connectOptions;
 
-  public RedisSentinelClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisSentinelConnectOptions connectOptions) {
-    super(vertx, tcpOptions, poolOptions, connectOptions);
+  public RedisSentinelClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisSentinelConnectOptions connectOptions, TracingPolicy tracingPolicy) {
+    super(vertx, tcpOptions, poolOptions, connectOptions, tracingPolicy);
     this.connectOptions = connectOptions;
     // validate options
     if (poolOptions.getMaxSize() < 2) {

--- a/src/main/java/io/vertx/redis/client/impl/RedisSentinelConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisSentinelConnection.java
@@ -11,10 +11,10 @@ import java.util.List;
 
 public class RedisSentinelConnection implements RedisConnection {
 
-  private final RedisConnection connection;
-  private final RedisConnection sentinel;
+  private final PooledRedisConnection connection;
+  private final PooledRedisConnection sentinel;
 
-  public RedisSentinelConnection(RedisConnection connection, RedisConnection sentinel) {
+  public RedisSentinelConnection(PooledRedisConnection connection, PooledRedisConnection sentinel) {
     this.connection = connection;
     this.sentinel = sentinel;
   }

--- a/src/test/java/io/vertx/redis/client/test/PreservesContext.java
+++ b/src/test/java/io/vertx/redis/client/test/PreservesContext.java
@@ -1,0 +1,90 @@
+package io.vertx.redis.client.test;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisConnection;
+import io.vertx.redis.client.Request;
+
+import java.util.Collections;
+
+class PreservesContext {
+  static void sendWithoutConnect(Redis client, TestContext test) {
+    Async async = test.async();
+
+    Context context = ContextInternal.current().duplicate();
+    context.runOnContext(ignored -> {
+      client.send(Request.cmd(Command.PING)).onComplete(result -> {
+        test.assertTrue(result.succeeded());
+        test.assertTrue(context == Vertx.currentContext());
+        async.complete();
+      });
+    });
+  }
+
+  static void batchWithoutConnect(Redis client, TestContext test) {
+    Async async = test.async();
+
+    Context context = ContextInternal.current().duplicate();
+    context.runOnContext(ignored -> {
+      client.batch(Collections.singletonList(Request.cmd(Command.PING))).onComplete(result -> {
+        test.assertTrue(result.succeeded());
+        test.assertTrue(context == Vertx.currentContext());
+        async.complete();
+      });
+    });
+  }
+
+  static void connect(Redis client, TestContext test) {
+    Async async = test.async();
+
+    Context context = ContextInternal.current().duplicate();
+    context.runOnContext(ignored -> {
+      client.connect().onComplete(connectResult -> {
+        test.assertTrue(connectResult.succeeded());
+        test.assertTrue(context == Vertx.currentContext());
+        async.complete();
+      });
+    });
+  }
+
+  static void connectThenSend(Redis client, TestContext test) {
+    Async async = test.async();
+
+    Context context = ContextInternal.current().duplicate();
+    context.runOnContext(ignored -> {
+      client.connect().onComplete(connectResult -> {
+        test.assertTrue(connectResult.succeeded());
+
+        RedisConnection connection = connectResult.result();
+        connection.send(Request.cmd(Command.PING)).onComplete(result -> {
+          test.assertTrue(result.succeeded());
+          test.assertTrue(context == Vertx.currentContext());
+          async.complete();
+        });
+      });
+    });
+  }
+
+  static void connectThenBatch(Redis client, TestContext test) {
+    Async async = test.async();
+
+    Context context = ContextInternal.current().duplicate();
+    context.runOnContext(ignored -> {
+      client.connect().onComplete(connectResult -> {
+        test.assertTrue(connectResult.succeeded());
+
+        RedisConnection connection = connectResult.result();
+        connection.batch(Collections.singletonList(Request.cmd(Command.PING))).onComplete(result -> {
+          test.assertTrue(result.succeeded());
+          test.assertTrue(context == Vertx.currentContext());
+          async.complete();
+        });
+      });
+    });
+  }
+}

--- a/src/test/java/io/vertx/redis/client/test/RedisClientMetricsTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClientMetricsTest.java
@@ -1,0 +1,118 @@
+package io.vertx.redis.client.test;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.metrics.MetricsOptions;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.core.spi.metrics.VertxMetrics;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.impl.CommandImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.GenericContainer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(VertxUnitRunner.class)
+public class RedisClientMetricsTest {
+  @ClassRule
+  public static final GenericContainer<?> redis = new GenericContainer<>("redis:7")
+    .withExposedPorts(6379);
+
+  Vertx vertx;
+  ClientMetrics metrics;
+  Redis client;
+
+  @Before
+  public void setup() {
+    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
+      new MetricsOptions().setEnabled(true).setFactory(ignored -> new VertxMetrics() {
+        @Override
+        public ClientMetrics<?, ?, ?, ?> createClientMetrics(SocketAddress remoteAddress, String type, String namespace) {
+          return metrics;
+        }
+      }))
+    );
+    client = Redis.createClient(vertx, new RedisOptions().setConnectionString("redis://" + redis.getHost() + ":" + redis.getFirstMappedPort()));
+  }
+
+  @After
+  public void teardown(TestContext test) {
+    vertx.close().onComplete(test.asyncAssertSuccess());
+  }
+
+  @Test
+  public void success(TestContext test) {
+    testClientMetrics(test, Request.cmd(Command.PING), true);
+  }
+
+  @Test
+  public void failure(TestContext test) {
+    testClientMetrics(test, Request.cmd(new CommandImpl("NONEXISTING COMMAND", 0, true, false, false)), false);
+  }
+
+  private void testClientMetrics(TestContext test, Request request, boolean success) {
+    Async async = test.async();
+
+    Object metric = new Object();
+    List<String> actions = Collections.synchronizedList(new ArrayList<>());
+
+    metrics = new ClientMetrics() {
+      @Override
+      public Object requestBegin(String uri, Object request) {
+        actions.add("requestBegin");
+        return metric;
+      }
+
+      @Override
+      public void requestEnd(Object requestMetric, long bytesWritten) {
+        test.assertTrue(requestMetric == metric);
+        actions.add("requestEnd");
+      }
+
+      @Override
+      public void responseBegin(Object requestMetric, Object response) {
+        test.assertTrue(requestMetric == metric);
+        actions.add("responseBegin");
+      }
+
+      @Override
+      public void responseEnd(Object requestMetric, long bytesRead) {
+        test.assertTrue(requestMetric == metric);
+        actions.add("responseEnd");
+      }
+
+      @Override
+      public void requestReset(Object requestMetric) {
+        test.assertTrue(requestMetric == metric);
+        actions.add("fail");
+      }
+    };
+
+    vertx.runOnContext(ignored -> {
+      client.send(request).onComplete(result -> {
+        if (success) {
+          test.assertTrue(result.succeeded());
+          test.assertEquals(Arrays.asList("requestBegin", "requestEnd", "responseBegin", "responseEnd"), actions);
+        } else {
+          test.assertTrue(result.failed());
+          test.assertEquals(Arrays.asList("requestBegin", "requestEnd", "fail"), actions);
+        }
+        async.complete();
+      });
+    });
+  }
+}

--- a/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
@@ -1213,4 +1213,13 @@ public class RedisClusterTest {
         });
       });
   }
+
+  @Test
+  public void preservesContext(TestContext should) {
+    PreservesContext.sendWithoutConnect(client, should);
+    PreservesContext.batchWithoutConnect(client, should);
+    PreservesContext.connect(client, should);
+    PreservesContext.connectThenSend(client, should);
+    PreservesContext.connectThenBatch(client, should);
+  }
 }

--- a/src/test/java/io/vertx/redis/client/test/RedisPoolMetricsTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisPoolMetricsTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(VertxUnitRunner.class)
-public class RedisMetricsTest {
+public class RedisPoolMetricsTest {
 
   private static final AtomicReference<String> POOL_NAME = new AtomicReference<>();
 

--- a/src/test/java/io/vertx/redis/client/test/RedisReplicationTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisReplicationTest.java
@@ -152,4 +152,15 @@ public class RedisReplicationTest {
         }
       });
   }
+
+  @Test
+  public void preservesContext(TestContext should) {
+    Redis client = Redis.createClient(rule.vertx(), new RedisOptions().setType(RedisClientType.REPLICATION).addConnectionString("redis://localhost:7000"));
+
+    PreservesContext.sendWithoutConnect(client, should);
+    PreservesContext.batchWithoutConnect(client, should);
+    PreservesContext.connect(client, should);
+    PreservesContext.connectThenSend(client, should);
+    PreservesContext.connectThenBatch(client, should);
+  }
 }

--- a/src/test/java/io/vertx/redis/client/test/RedisReplicationTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisReplicationTest.java
@@ -1,5 +1,8 @@
 package io.vertx.redis.client.test;
 
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
@@ -69,43 +72,31 @@ public class RedisReplicationTest {
   public void testGetClientToReplica(TestContext should) {
     final Async test = should.async();
 
-    Redis.createClient(rule.vertx(), "redis://localhost:7000")
-      .send(Request.cmd(Command.INFO).arg("REPLICATION"))
+    Redis client = Redis.createClient(rule.vertx(), "redis://localhost:7000");
+    waitForOnlineReplica(client, 10)
       .onFailure(should::fail)
-      .onSuccess(res -> {
-        String[] lines = res.toString(StandardCharsets.ISO_8859_1).split("\r\n");
-        for (String line : lines) {
-          if (line.startsWith("slave0")) {
-            String[] parts = line.split(",");
-            for (String part : parts) {
-              if (part.startsWith("port=")) {
-                String port = part.substring(5);
-
-                // real start of the test
-                Redis.createClient(
-                    rule.vertx(),
-                    new RedisOptions()
-                      .setType(RedisClientType.REPLICATION)
-                      .setUseReplicas(RedisReplicas.NEVER)
-                      .addConnectionString("redis://localhost:" + port)
-                      .setMaxPoolSize(4)
-                      .setMaxPoolWaiting(16))
-                  .connect().onComplete(onCreate -> {
-                    // get a connection to the master node
-                    should.assertTrue(onCreate.succeeded());
-                    // query the info
-                    onCreate.result()
-                      .send(Request.cmd(Command.INFO)).onComplete(info -> {
-                        should.assertTrue(info.succeeded());
-                        // even though we list the replica node, the main connection happens to the master
-                        should.assertTrue(info.result().toString().contains("tcp_port:7000"));
-                        test.complete();
-                      });
-                  });
-              }
-            }
-          }
-        }
+      .onSuccess(port -> {
+        // real start of the test
+        Redis.createClient(
+            rule.vertx(),
+            new RedisOptions()
+              .setType(RedisClientType.REPLICATION)
+              .setUseReplicas(RedisReplicas.NEVER)
+              .addConnectionString("redis://localhost:" + port)
+              .setMaxPoolSize(4)
+              .setMaxPoolWaiting(16))
+          .connect().onComplete(onCreate -> {
+            // get a connection to the master node
+            should.assertTrue(onCreate.succeeded());
+            // query the info
+            onCreate.result()
+              .send(Request.cmd(Command.INFO)).onComplete(info -> {
+                should.assertTrue(info.succeeded());
+                // even though we list the replica node, the main connection happens to the master
+                should.assertTrue(info.result().toString().contains("tcp_port:7000"));
+                test.complete();
+              });
+          });
       });
   }
 
@@ -113,44 +104,79 @@ public class RedisReplicationTest {
   public void testGetClientToReplicaUseReplicasAlways(TestContext should) {
     final Async test = should.async();
 
-    Redis.createClient(rule.vertx(), "redis://localhost:7000")
-      .send(Request.cmd(Command.INFO).arg("REPLICATION"))
+    Redis client = Redis.createClient(rule.vertx(), "redis://localhost:7000");
+    waitForOnlineReplica(client, 10)
       .onFailure(should::fail)
+      .onSuccess(port -> {
+        // real start of the test
+        Redis.createClient(
+            rule.vertx(),
+            new RedisOptions()
+              .setType(RedisClientType.REPLICATION)
+              .setUseReplicas(RedisReplicas.ALWAYS)
+              .addConnectionString("redis://localhost:" + port)
+              .setMaxPoolSize(4)
+              .setMaxPoolWaiting(16))
+          .connect().onComplete(onCreate -> {
+            // get a connection to the master node
+            should.assertTrue(onCreate.succeeded());
+            // query the info
+            onCreate.result()
+              .send(Request.cmd(Command.INFO)).onComplete(info -> {
+                should.assertTrue(info.succeeded());
+                // we force read commands to go to replicas
+                should.assertTrue(info.result().toString().contains("tcp_port:" + port));
+                test.complete();
+              });
+          });
+      });
+  }
+
+  private Future<String> waitForOnlineReplica(Redis client, int maxRetries) {
+    Vertx vertx = rule.vertx();
+
+    Promise<String> promise = Promise.promise();
+    client
+      .send(Request.cmd(Command.INFO).arg("REPLICATION"))
+      .onFailure(promise::fail)
       .onSuccess(res -> {
         String[] lines = res.toString(StandardCharsets.ISO_8859_1).split("\r\n");
         for (String line : lines) {
           if (line.startsWith("slave0")) {
             String[] parts = line.split(",");
+
+            String port = null;
+            String state = null;
+
             for (String part : parts) {
               if (part.startsWith("port=")) {
-                String port = part.substring(5);
+                port = part.substring(5);
+              } else if (part.startsWith("state=")) {
+                state = part.substring(6);
+              }
+            }
 
-                // real start of the test
-                Redis.createClient(
-                    rule.vertx(),
-                    new RedisOptions()
-                      .setType(RedisClientType.REPLICATION)
-                      .setUseReplicas(RedisReplicas.ALWAYS)
-                      .addConnectionString("redis://localhost:" + port)
-                      .setMaxPoolSize(4)
-                      .setMaxPoolWaiting(16))
-                  .connect().onComplete(onCreate -> {
-                    // get a connection to the master node
-                    should.assertTrue(onCreate.succeeded());
-                    // query the info
-                    onCreate.result()
-                      .send(Request.cmd(Command.INFO)).onComplete(info -> {
-                        should.assertTrue(info.succeeded());
-                        // we force read commands to go to replicas
-                        should.assertTrue(info.result().toString().contains("tcp_port:" + port));
-                        test.complete();
-                      });
+            if ("online".equals(state)) {
+              promise.complete(port);
+            } else {
+              if (maxRetries < 1) {
+                promise.fail("No replica came online in time, sorry");
+              } else {
+                vertx.setTimer(1000, ignored -> {
+                  waitForOnlineReplica(client, maxRetries - 1).onComplete(retryResult -> {
+                    if (retryResult.failed()) {
+                      promise.fail(retryResult.cause());
+                    } else {
+                      promise.complete(retryResult.result());
+                    }
                   });
+                });
               }
             }
           }
         }
       });
+    return promise.future();
   }
 
   @Test

--- a/src/test/java/io/vertx/redis/client/test/RedisSentinelTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisSentinelTest.java
@@ -155,4 +155,21 @@ public class RedisSentinelTest {
           });
       });
   }
+
+  @Test
+  public void preservesContext(TestContext should) {
+    Redis client = Redis.createClient(rule.vertx(), new RedisOptions()
+      .setType(RedisClientType.SENTINEL)
+      .addConnectionString("redis://localhost:5000")
+      .addConnectionString("redis://localhost:5001")
+      .addConnectionString("redis://localhost:5002")
+      .setMasterName("sentinel7000")
+      .setRole(RedisRole.MASTER));
+
+    PreservesContext.sendWithoutConnect(client, should);
+    PreservesContext.batchWithoutConnect(client, should);
+    PreservesContext.connect(client, should);
+    PreservesContext.connectThenSend(client, should);
+    PreservesContext.connectThenBatch(client, should);
+  }
 }

--- a/src/test/java/io/vertx/redis/client/test/RedisTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisTest.java
@@ -333,4 +333,15 @@ public class RedisTest {
       })
       .onSuccess(responses -> should.fail("Commands are wrong"));
   }
+
+  @Test
+  public void preservesContext(TestContext should) {
+    Redis client = Redis.createClient(rule.vertx(), new RedisOptions().setConnectionString("redis://" + redis.getHost() + ":" + redis.getFirstMappedPort()));
+
+    PreservesContext.sendWithoutConnect(client, should);
+    PreservesContext.batchWithoutConnect(client, should);
+    PreservesContext.connect(client, should);
+    PreservesContext.connectThenSend(client, should);
+    PreservesContext.connectThenBatch(client, should);
+  }
 }

--- a/src/test/java/io/vertx/redis/client/test/RedisTracingTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisTracingTest.java
@@ -1,0 +1,114 @@
+package io.vertx.redis.client.test;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.spi.tracing.SpanKind;
+import io.vertx.core.spi.tracing.TagExtractor;
+import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.tracing.TracingOptions;
+import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.impl.CommandImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.GenericContainer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+@RunWith(VertxUnitRunner.class)
+public class RedisTracingTest {
+  @ClassRule
+  public static final GenericContainer<?> redis = new GenericContainer<>("redis:7")
+    .withExposedPorts(6379);
+
+  Vertx vertx;
+  VertxTracer tracer;
+  Redis client;
+
+  @Before
+  public void setup() {
+    vertx = Vertx.vertx(new VertxOptions().setTracingOptions(
+      new TracingOptions().setFactory(ignored -> new VertxTracer() {
+        @Override
+        public Object sendRequest(Context context, SpanKind kind, TracingPolicy tracingPolicy, Object request, String operation, BiConsumer headers, TagExtractor tagExtractor) {
+          return tracer.sendRequest(context, kind, tracingPolicy, request, operation, headers, tagExtractor);
+        }
+        @Override
+        public void receiveResponse(Context context, Object response, Object payload, Throwable failure, TagExtractor tagExtractor) {
+          tracer.receiveResponse(context, response, payload, failure, tagExtractor);
+        }
+      }))
+    );
+    client = Redis.createClient(vertx, new RedisOptions().setConnectionString("redis://" + redis.getHost() + ":" + redis.getFirstMappedPort()));
+  }
+
+  @After
+  public void teardown(TestContext test) {
+    vertx.close().onComplete(test.asyncAssertSuccess());
+  }
+
+  @Test
+  public void success(TestContext test) {
+    testTracing(test, Request.cmd(Command.PING), true);
+  }
+
+  @Test
+  public void failure(TestContext test) {
+    testTracing(test, Request.cmd(new CommandImpl("NONEXISTING COMMAND", 0, true, false, false)), false);
+  }
+
+  private void testTracing(TestContext test, Request clientRequest, boolean success) {
+    Async async = test.async();
+
+    Object trace = new Object();
+    List<String> actions = Collections.synchronizedList(new ArrayList<>());
+
+    tracer = new VertxTracer() {
+      @Override
+      public Object sendRequest(Context context, SpanKind kind, TracingPolicy policy, Object request, String operation, BiConsumer headers, TagExtractor tagExtractor) {
+        Map<String, String> tags = tagExtractor.extract(request);
+        test.assertEquals("client", tags.get("span.kind"));
+        test.assertEquals("redis", tags.get("db.type"));
+        test.assertEquals(clientRequest.command().toString(), tags.get("db.statement"));
+        actions.add("sendRequest");
+        return trace;
+      }
+
+      @Override
+      public void receiveResponse(Context context, Object response, Object payload, Throwable failure, TagExtractor tagExtractor) {
+        test.assertTrue(payload == trace);
+        if (success) {
+          test.assertNotNull(response);
+          test.assertNull(failure);
+        } else {
+          test.assertNull(response);
+          test.assertNotNull(failure);
+        }
+        actions.add("receiveResponse");
+      }
+    };
+
+    vertx.runOnContext(ignored -> {
+      client.send(clientRequest).onComplete(result -> {
+        test.assertEquals(success, result.succeeded());
+        test.assertEquals(Arrays.asList("sendRequest", "receiveResponse"), actions);
+        async.complete();
+      });
+    });
+  }
+}


### PR DESCRIPTION
Motivation:

- make sure that the Redis client calls back on the original context
  - this used to be the case for the clustered clients, but nor for the standalone client, which is fixed here
- make connection pooling explicit in the code
  - the internal structure of connection handling is more obvious by using the `PooledRedisConnection` type explicitly
  - this even revealed a bug in `RedisSentinelClient` which would lead to class cast errors in some failure scenarios
- implement tracing and client metrics
  - this is done similarly to how the Vert.x SQL client does it, which is a little less precise, but easier to understand

Resolves #357