### PR TITLE
Options decomposition

### DIFF
--- a/src/main/generated/io/vertx/redis/client/PoolOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/PoolOptionsConverter.java
@@ -1,0 +1,65 @@
+package io.vertx.redis.client;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.redis.client.PoolOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.redis.client.PoolOptions} original class using Vert.x codegen.
+ */
+public class PoolOptionsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, PoolOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "cleanerInterval":
+          if (member.getValue() instanceof Number) {
+            obj.setCleanerInterval(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "maxSize":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxSize(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "maxWaiting":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxWaiting(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "name":
+          if (member.getValue() instanceof String) {
+            obj.setName((String)member.getValue());
+          }
+          break;
+        case "recycleTimeout":
+          if (member.getValue() instanceof Number) {
+            obj.setRecycleTimeout(((Number)member.getValue()).intValue());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(PoolOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(PoolOptions obj, java.util.Map<String, Object> json) {
+    json.put("cleanerInterval", obj.getCleanerInterval());
+    json.put("maxSize", obj.getMaxSize());
+    json.put("maxWaiting", obj.getMaxWaiting());
+    if (obj.getName() != null) {
+      json.put("name", obj.getName());
+    }
+    json.put("recycleTimeout", obj.getRecycleTimeout());
+  }
+}

--- a/src/main/generated/io/vertx/redis/client/RedisClusterConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisClusterConnectOptionsConverter.java
@@ -1,0 +1,41 @@
+package io.vertx.redis.client;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.redis.client.RedisClusterConnectOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.redis.client.RedisClusterConnectOptions} original class using Vert.x codegen.
+ */
+public class RedisClusterConnectOptionsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, RedisClusterConnectOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "useReplicas":
+          if (member.getValue() instanceof String) {
+            obj.setUseReplicas(io.vertx.redis.client.RedisReplicas.valueOf((String)member.getValue()));
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(RedisClusterConnectOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(RedisClusterConnectOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getUseReplicas() != null) {
+      json.put("useReplicas", obj.getUseReplicas().name());
+    }
+  }
+}

--- a/src/main/generated/io/vertx/redis/client/RedisConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisConnectOptionsConverter.java
@@ -1,0 +1,92 @@
+package io.vertx.redis.client;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.redis.client.RedisConnectOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.redis.client.RedisConnectOptions} original class using Vert.x codegen.
+ */
+public class RedisConnectOptionsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, RedisConnectOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "connectionString":
+          if (member.getValue() instanceof String) {
+            obj.setConnectionString((String)member.getValue());
+          }
+          break;
+        case "connectionStrings":
+          if (member.getValue() instanceof JsonArray) {
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                obj.addConnectionString((String)item);
+            });
+          }
+          break;
+        case "endpoint":
+          break;
+        case "endpoints":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                list.add((String)item);
+            });
+            obj.setEndpoints(list);
+          }
+          break;
+        case "maxNestedArrays":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxNestedArrays(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "maxWaitingHandlers":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxWaitingHandlers(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "password":
+          if (member.getValue() instanceof String) {
+            obj.setPassword((String)member.getValue());
+          }
+          break;
+        case "protocolNegotiation":
+          if (member.getValue() instanceof Boolean) {
+            obj.setProtocolNegotiation((Boolean)member.getValue());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(RedisConnectOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(RedisConnectOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getEndpoint() != null) {
+      json.put("endpoint", obj.getEndpoint());
+    }
+    if (obj.getEndpoints() != null) {
+      JsonArray array = new JsonArray();
+      obj.getEndpoints().forEach(item -> array.add(item));
+      json.put("endpoints", array);
+    }
+    json.put("maxNestedArrays", obj.getMaxNestedArrays());
+    json.put("maxWaitingHandlers", obj.getMaxWaitingHandlers());
+    if (obj.getPassword() != null) {
+      json.put("password", obj.getPassword());
+    }
+    json.put("protocolNegotiation", obj.isProtocolNegotiation());
+  }
+}

--- a/src/main/generated/io/vertx/redis/client/RedisSentinelConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisSentinelConnectOptionsConverter.java
@@ -1,0 +1,49 @@
+package io.vertx.redis.client;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.redis.client.RedisSentinelConnectOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.redis.client.RedisSentinelConnectOptions} original class using Vert.x codegen.
+ */
+public class RedisSentinelConnectOptionsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, RedisSentinelConnectOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "masterName":
+          if (member.getValue() instanceof String) {
+            obj.setMasterName((String)member.getValue());
+          }
+          break;
+        case "role":
+          if (member.getValue() instanceof String) {
+            obj.setRole(io.vertx.redis.client.RedisRole.valueOf((String)member.getValue()));
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(RedisSentinelConnectOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(RedisSentinelConnectOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getMasterName() != null) {
+      json.put("masterName", obj.getMasterName());
+    }
+    if (obj.getRole() != null) {
+      json.put("role", obj.getRole().name());
+    }
+  }
+}

--- a/src/main/generated/io/vertx/redis/client/RedisStandaloneConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisStandaloneConnectOptionsConverter.java
@@ -1,0 +1,33 @@
+package io.vertx.redis.client;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.redis.client.RedisStandaloneConnectOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.redis.client.RedisStandaloneConnectOptions} original class using Vert.x codegen.
+ */
+public class RedisStandaloneConnectOptionsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, RedisStandaloneConnectOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+      }
+    }
+  }
+
+  public static void toJson(RedisStandaloneConnectOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(RedisStandaloneConnectOptions obj, java.util.Map<String, Object> json) {
+  }
+}

--- a/src/main/java/io/vertx/redis/client/PoolOptions.java
+++ b/src/main/java/io/vertx/redis/client/PoolOptions.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ * <p>
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.redis.client;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.UUID;
+
+@DataObject(generateConverter = true)
+public class PoolOptions {
+
+  private String name;
+  private int cleanerInterval;
+  private int maxSize;
+  private int maxWaiting;
+  private int recycleTimeout;
+
+  public PoolOptions() {
+    name = UUID.randomUUID().toString();
+    // thumb guess based on web browser defaults
+    cleanerInterval = 30_000;
+    maxSize = 6;
+    maxWaiting = 24;
+    recycleTimeout = 180_000;
+  }
+
+  public PoolOptions(PoolOptions other) {
+    this.name = other.name;
+    this.cleanerInterval = other.cleanerInterval;
+    this.maxSize = other.maxSize;
+    this.maxWaiting = other.maxWaiting;
+    this.recycleTimeout = other.recycleTimeout;
+  }
+
+  public PoolOptions(JsonObject json) {
+    this();
+    PoolOptionsConverter.fromJson(json, this);
+  }
+
+  /**
+   * Set a user defined pool name (for metrics reporting).
+   * @param name the user desired pool name.
+   * @return fluent self
+   */
+  public PoolOptions setName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Get the pool name to be used in this client. The default name is a random UUID.
+   * @return pool name.
+   */
+  public String getName() {
+    return this.name;
+  }
+
+  /**
+   * Tune how often in milliseconds should the connection pool cleaner execute.
+   *
+   * @return the cleaning internal
+   */
+  public int getCleanerInterval() {
+    return cleanerInterval;
+  }
+
+  /**
+   * Tune how often in milliseconds should the connection pool cleaner execute.
+   *
+   * For each connection in the pool, connections marked as invalid will be forcibly closed. A connection is marked
+   * invalid if it enters a exception or fatal state.
+   *
+   * @param cleanerInterval the interval in milliseconds (-1 for never)
+   * @return fluent self.
+   */
+  public PoolOptions setCleanerInterval(int cleanerInterval) {
+    this.cleanerInterval = cleanerInterval;
+    return this;
+  }
+
+  /**
+   * Tune the maximum size of the connection pool.
+   *
+   * @return the size.
+   */
+  public int getMaxSize() {
+    return maxSize;
+  }
+
+  /**
+   * Tune the maximum size of the connection pool. When working with cluster or sentinel
+   * this value should be atleast the total number of cluster member (or number of sentinels + 1)
+   *
+   * @param maxSize the max pool size.
+   * @return fluent self.
+   */
+  public PoolOptions setMaxSize(int maxSize) {
+    this.maxSize = maxSize;
+    return this;
+  }
+
+  /**
+   * Tune the maximum waiting requests for a connection from the pool.
+   *
+   * @return the maximum waiting requests.
+   */
+  public int getMaxWaiting() {
+    return maxWaiting;
+  }
+
+  /**
+   * Tune the maximum waiting requests for a connection from the pool.
+   *
+   * @param maxWaiting max waiting requests
+   * @return fluent self.
+   */
+  public PoolOptions setMaxWaiting(int maxWaiting) {
+    this.maxWaiting = maxWaiting;
+    return this;
+  }
+
+  /**
+   * Tune when a connection should be recycled in milliseconds.
+   *
+   * @return the timeout for recycling.
+   */
+  public int getRecycleTimeout() {
+    return recycleTimeout;
+  }
+
+  /**
+   * Tune when a connection should be recycled in milliseconds.
+   *
+   * @param recycleTimeout the timeout for recycling.
+   * @return fluent self.
+   */
+  public PoolOptions setRecycleTimeout(int recycleTimeout) {
+    this.recycleTimeout = recycleTimeout;
+    return this;
+  }
+
+  /**
+   * Converts this object to JSON notation.
+   *
+   * @return JSON
+   */
+  public JsonObject toJson() {
+    final JsonObject json = new JsonObject();
+    PoolOptionsConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/src/main/java/io/vertx/redis/client/Redis.java
+++ b/src/main/java/io/vertx/redis/client/Redis.java
@@ -25,6 +25,8 @@ import io.vertx.redis.client.impl.RedisReplicationClient;
 import io.vertx.redis.client.impl.RedisSentinelClient;
 
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * A simple Redis client.
@@ -61,13 +63,13 @@ public interface Redis {
   static Redis createClient(Vertx vertx, RedisOptions options) {
     switch (options.getType()) {
       case STANDALONE:
-        return new RedisClient(vertx, options);
+        return new RedisClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisStandaloneConnectOptions(options));
       case SENTINEL:
-        return new RedisSentinelClient(vertx, options);
+        return new RedisSentinelClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisSentinelConnectOptions(options));
       case CLUSTER:
-        return new RedisClusterClient(vertx, options);
+        return new RedisClusterClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisClusterConnectOptions(options));
       case REPLICATION:
-        return new RedisReplicationClient(vertx, options);
+        return new RedisReplicationClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisClusterConnectOptions(options));
       default:
         throw new IllegalStateException("Unknown Redis Client type: " + options.getType());
     }

--- a/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ * <p>
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.redis.client;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+
+@DataObject(generateConverter = true)
+public class RedisClusterConnectOptions extends RedisConnectOptions {
+
+  private RedisReplicas useReplicas;
+
+  public RedisClusterConnectOptions(RedisOptions options) {
+    super(options);
+    setUseReplicas(options.getUseReplicas());
+  }
+
+  public RedisClusterConnectOptions() {
+    useReplicas = RedisReplicas.NEVER;
+  }
+
+  public RedisClusterConnectOptions(RedisClusterConnectOptions other) {
+    this.useReplicas = other.useReplicas;
+  }
+
+  public RedisClusterConnectOptions(JsonObject json) {
+    this();
+    RedisConnectOptionsConverter.fromJson(json, this);
+  }
+
+  /**
+   * Get whether or not to use replica nodes (only considered in Cluster mode).
+   *
+   * @return the cluster replica node use mode.
+   */
+  public RedisReplicas getUseReplicas() {
+    return useReplicas;
+  }
+
+  /**
+   * Set whether or not to use replica nodes (only considered in Cluster mode).
+   *
+   * @param useReplicas the cluster replica use mode.
+   * @return fluent self.
+   */
+  public RedisConnectOptions setUseReplicas(RedisReplicas useReplicas) {
+    this.useReplicas = useReplicas;
+    return this;
+  }
+
+  @Override
+  public RedisClusterConnectOptions setMaxNestedArrays(int maxNestedArrays) {
+    return (RedisClusterConnectOptions) super.setMaxNestedArrays(maxNestedArrays);
+  }
+
+  @Override
+  public RedisClusterConnectOptions setProtocolNegotiation(boolean protocolNegotiation) {
+    return (RedisClusterConnectOptions) super.setProtocolNegotiation(protocolNegotiation);
+  }
+
+  @Override
+  public RedisClusterConnectOptions setPassword(String password) {
+    return (RedisClusterConnectOptions) super.setPassword(password);
+  }
+
+  @Override
+  public RedisClusterConnectOptions setEndpoints(List<String> endpoints) {
+    return (RedisClusterConnectOptions) super.setEndpoints(endpoints);
+  }
+
+  @Override
+  public RedisClusterConnectOptions setConnectionString(String connectionString) {
+    return (RedisClusterConnectOptions) super.setConnectionString(connectionString);
+  }
+
+  @Override
+  public RedisClusterConnectOptions setMaxWaitingHandlers(int maxWaitingHandlers) {
+    return (RedisClusterConnectOptions) super.setMaxWaitingHandlers(maxWaitingHandlers);
+  }
+
+  /**
+   * Converts this object to JSON notation.
+   *
+   * @return JSON
+   */
+  public JsonObject toJson() {
+    final JsonObject json = super.toJson();
+    RedisClusterConnectOptionsConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ * <p>
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.redis.client;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@DataObject(generateConverter = true)
+public abstract class RedisConnectOptions {
+
+  private volatile String password;
+  private List<String> endpoints;
+  private int maxNestedArrays;
+  private boolean protocolNegotiation;
+  private int maxWaitingHandlers;
+
+  private void init() {
+    maxNestedArrays = 32;
+    protocolNegotiation = true;
+    maxWaitingHandlers = 2048;
+  }
+
+  public RedisConnectOptions(RedisOptions options) {
+    setEndpoints(new ArrayList<>(options.getEndpoints()));
+    setProtocolNegotiation(options.isProtocolNegotiation());
+    setMaxNestedArrays(options.getMaxNestedArrays());
+    setPassword(options.getPassword());
+    setMaxWaitingHandlers(options.getMaxWaitingHandlers());
+    setMaxNestedArrays(options.getMaxNestedArrays());
+  }
+
+  public RedisConnectOptions() {
+    init();
+  }
+
+  public RedisConnectOptions(RedisConnectOptions other) {
+    init();
+    this.maxNestedArrays = other.maxNestedArrays;
+    this.protocolNegotiation = other.protocolNegotiation;
+    this.password = other.password;
+    this.endpoints = new ArrayList<>(other.endpoints);
+    this.maxWaitingHandlers = other.maxWaitingHandlers;
+  }
+
+  public RedisConnectOptions(JsonObject json) {
+    init();
+    RedisConnectOptionsConverter.fromJson(json, this);
+  }
+
+  /**
+   * Tune how much nested arrays are allowed on a redis response. This affects the parser performance.
+   *
+   * @return the configured max nested arrays allowance.
+   */
+  public int getMaxNestedArrays() {
+    return maxNestedArrays;
+  }
+
+  /**
+   * Tune how much nested arrays are allowed on a redis response. This affects the parser performance.
+   *
+   * @param maxNestedArrays the configured max nested arrays allowance.
+   * @return fluent self.
+   */
+  public RedisConnectOptions setMaxNestedArrays(int maxNestedArrays) {
+    this.maxNestedArrays = maxNestedArrays;
+    return this;
+  }
+
+  /**
+   * Should the client perform {@code RESP} protocol negotiation during the connection handshake.
+   * By default this is {@code true}, but there are situations when using broken servers it may
+   * be useful to skip this and always fallback to {@code RESP2} without using the {@code HELLO}
+   * command.
+   *
+   * @return true to perform negotiation.
+   */
+  public boolean isProtocolNegotiation() {
+    return protocolNegotiation;
+  }
+
+  /**
+   * Should the client perform {@code REST} protocol negotiation during the connection acquire.
+   * By default this is {@code true}, but there are situations when using broken servers it may
+   * be useful to skip this and always fallback to {@code RESP2} without using the {@code HELLO}
+   * command.
+   *
+   * @param protocolNegotiation false to disable {@code HELLO} (not recommended) unless reasons...
+   * @return fluent self
+   */
+  public RedisConnectOptions setProtocolNegotiation(boolean protocolNegotiation) {
+    this.protocolNegotiation = protocolNegotiation;
+    return this;
+  }
+
+  /**
+   * Get the default password for cluster/sentinel connections, if not set it will try to
+   * extract it from the current default endpoint.
+   *
+   * @return password
+   */
+  public String getPassword() {
+    return password;
+  }
+
+  /**
+   * Set the default password for cluster/sentinel connections.
+   *
+   * @param password the default password
+   * @return fluent self
+   */
+  public RedisConnectOptions setPassword(String password) {
+    this.password = password;
+    return this;
+  }
+
+  /**
+   * Gets the list of redis endpoints to use (mostly used while connecting to a cluster)
+   *
+   * @return list of socket addresses.
+   */
+  public List<String> getEndpoints() {
+    if (endpoints == null) {
+      endpoints = new ArrayList<>();
+      endpoints.add(RedisOptions.DEFAULT_ENDPOINT);
+    }
+    return endpoints;
+  }
+
+  /**
+   * Gets the redis endpoint to use
+   *
+   * @return the Redis connection string URI
+   */
+  public String getEndpoint() {
+    if (endpoints == null || endpoints.isEmpty()) {
+      return RedisOptions.DEFAULT_ENDPOINT;
+    }
+
+    return endpoints.get(0);
+  }
+
+  /**
+   * Set the endpoints to use while connecting to the redis server. Only the cluster mode will consider more than
+   * 1 element. If more are provided, they are not considered by the client when in single server mode.
+   *
+   * @param endpoints list of socket addresses.
+   * @return fluent self.
+   */
+  public RedisConnectOptions setEndpoints(List<String> endpoints) {
+    this.endpoints = endpoints;
+    return this;
+  }
+
+  /**
+   * Adds a connection string (endpoint) to use while connecting to the redis server. Only the cluster mode will
+   * consider more than 1 element. If more are provided, they are not considered by the client when in single server mode.
+   *
+   * @param connectionString a string URI following the scheme: redis://[username:password@][host][:port][/database]
+   * @return fluent self.
+   *
+   * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on iana.org</a>
+   */
+  public RedisConnectOptions addConnectionString(String connectionString) {
+    if (endpoints == null) {
+      endpoints = new ArrayList<>();
+    }
+    this.endpoints.add(connectionString);
+    return this;
+  }
+
+  /**
+   * Sets a single connection string (endpoint) to use while connecting to the redis server.
+   * Will replace the previously configured connection strings.
+   *
+   * @param connectionString a string following the scheme: redis://[username:password@][host][:port][/[database].
+   * @return fluent self.
+   * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on iana.org</a>
+   */
+  public RedisConnectOptions setConnectionString(String connectionString) {
+    if (endpoints == null) {
+      endpoints = new ArrayList<>();
+    } else {
+      endpoints.clear();
+    }
+
+    this.endpoints.add(connectionString);
+    return this;
+  }
+
+  /**
+   * The client will always work on pipeline mode, this means that messages can start queueing. You can control how much
+   * backlog you're willing to accept. This methods returns how much handlers is the client willing to queue.
+   *
+   * @return max allowed queued waiting handlers.
+   */
+  public int getMaxWaitingHandlers() {
+    return maxWaitingHandlers;
+  }
+
+  /**
+   * The client will always work on pipeline mode, this means that messages can start queueing. You can control how much
+   * backlog you're willing to accept. This methods sets how much handlers is the client willing to queue.
+   *
+   * @param maxWaitingHandlers max allowed queued waiting handlers.
+   * @return fluent self.
+   */
+  public RedisConnectOptions setMaxWaitingHandlers(int maxWaitingHandlers) {
+    this.maxWaitingHandlers = maxWaitingHandlers;
+    return this;
+  }
+
+  /**
+   * Converts this object to JSON notation.
+   *
+   * @return JSON
+   */
+  public JsonObject toJson() {
+    final JsonObject json = new JsonObject();
+    RedisConnectOptionsConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ * <p>
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.redis.client;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+
+@DataObject(generateConverter = true)
+public class RedisSentinelConnectOptions extends RedisConnectOptions {
+
+  private RedisRole role;
+  private String masterName;
+
+  public RedisSentinelConnectOptions(RedisOptions options) {
+    super(options);
+    setRole(options.getRole());
+    setMasterName(options.getMasterName());
+  }
+
+  public RedisSentinelConnectOptions() {
+    role = RedisRole.MASTER;
+    masterName = "mymaster";
+  }
+
+  public RedisSentinelConnectOptions(RedisSentinelConnectOptions other) {
+    this.role = other.role;
+    this.masterName = other.masterName;
+  }
+
+  public RedisSentinelConnectOptions(JsonObject json) {
+    this();
+    RedisConnectOptionsConverter.fromJson(json, this);
+  }
+
+  /**
+   * Get the role name (only considered in HA mode).
+   *
+   * @return the master name.
+   */
+  public RedisRole getRole() {
+    return role;
+  }
+
+  /**
+   * Set the role name (only considered in HA mode).
+   *
+   * @param role the master name.
+   * @return fluent self.
+   */
+  public RedisConnectOptions setRole(RedisRole role) {
+    this.role = role;
+    return this;
+  }
+
+  /**
+   * Get the master name (only considered in HA mode).
+   *
+   * @return the master name.
+   */
+  public String getMasterName() {
+    return masterName;
+  }
+
+  /**
+   * Set the master name (only considered in HA mode).
+   *
+   * @param masterName the master name.
+   * @return fluent self.
+   */
+  public RedisConnectOptions setMasterName(String masterName) {
+    this.masterName = masterName;
+    return this;
+  }
+
+  @Override
+  public RedisSentinelConnectOptions setMaxNestedArrays(int maxNestedArrays) {
+    return (RedisSentinelConnectOptions) super.setMaxNestedArrays(maxNestedArrays);
+  }
+
+  @Override
+  public RedisSentinelConnectOptions setProtocolNegotiation(boolean protocolNegotiation) {
+    return (RedisSentinelConnectOptions) super.setProtocolNegotiation(protocolNegotiation);
+  }
+
+  @Override
+  public RedisSentinelConnectOptions setPassword(String password) {
+    return (RedisSentinelConnectOptions) super.setPassword(password);
+  }
+
+  @Override
+  public RedisSentinelConnectOptions setEndpoints(List<String> endpoints) {
+    return (RedisSentinelConnectOptions) super.setEndpoints(endpoints);
+  }
+
+  @Override
+  public RedisSentinelConnectOptions setConnectionString(String connectionString) {
+    return (RedisSentinelConnectOptions) super.setConnectionString(connectionString);
+  }
+
+  @Override
+  public RedisSentinelConnectOptions setMaxWaitingHandlers(int maxWaitingHandlers) {
+    return (RedisSentinelConnectOptions) super.setMaxWaitingHandlers(maxWaitingHandlers);
+  }
+
+  /**
+   * Converts this object to JSON notation.
+   *
+   * @return JSON
+   */
+  public JsonObject toJson() {
+    final JsonObject json = super.toJson();
+    RedisSentinelConnectOptionsConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ * <p>
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.redis.client;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+
+@DataObject(generateConverter = true)
+public class RedisStandaloneConnectOptions extends RedisConnectOptions {
+
+  public RedisStandaloneConnectOptions(RedisOptions options) {
+    super(options);
+  }
+
+  public RedisStandaloneConnectOptions() {
+  }
+
+  public RedisStandaloneConnectOptions(RedisStandaloneConnectOptions other) {
+  }
+
+  public RedisStandaloneConnectOptions(JsonObject json) {
+    this();
+    RedisConnectOptionsConverter.fromJson(json, this);
+  }
+
+  @Override
+  public RedisStandaloneConnectOptions setMaxNestedArrays(int maxNestedArrays) {
+    return (RedisStandaloneConnectOptions) super.setMaxNestedArrays(maxNestedArrays);
+  }
+
+  @Override
+  public RedisStandaloneConnectOptions setProtocolNegotiation(boolean protocolNegotiation) {
+    return (RedisStandaloneConnectOptions) super.setProtocolNegotiation(protocolNegotiation);
+  }
+
+  @Override
+  public RedisStandaloneConnectOptions setPassword(String password) {
+    return (RedisStandaloneConnectOptions) super.setPassword(password);
+  }
+
+  @Override
+  public RedisStandaloneConnectOptions setEndpoints(List<String> endpoints) {
+    return (RedisStandaloneConnectOptions) super.setEndpoints(endpoints);
+  }
+
+  @Override
+  public RedisStandaloneConnectOptions setConnectionString(String connectionString) {
+    return (RedisStandaloneConnectOptions) super.setConnectionString(connectionString);
+  }
+
+  @Override
+  public RedisStandaloneConnectOptions setMaxWaitingHandlers(int maxWaitingHandlers) {
+    return (RedisStandaloneConnectOptions) super.setMaxWaitingHandlers(maxWaitingHandlers);
+  }
+
+  /**
+   * Converts this object to JSON notation.
+   *
+   * @return JSON
+   */
+  public JsonObject toJson() {
+    final JsonObject json = super.toJson();
+    RedisStandaloneConnectOptionsConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/src/main/java/io/vertx/redis/client/impl/BaseRedisClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/BaseRedisClient.java
@@ -6,10 +6,8 @@ import io.vertx.core.Vertx;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
-import io.vertx.redis.client.Redis;
-import io.vertx.redis.client.RedisOptions;
-import io.vertx.redis.client.Request;
-import io.vertx.redis.client.Response;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.redis.client.*;
 
 import java.util.Collections;
 import java.util.List;
@@ -21,9 +19,9 @@ public abstract class BaseRedisClient implements Redis {
   protected final VertxInternal vertx;
   protected final RedisConnectionManager connectionManager;
 
-  public BaseRedisClient(Vertx vertx, RedisOptions options) {
+  public BaseRedisClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisConnectOptions connectOptions) {
     this.vertx = (VertxInternal) vertx;
-    this.connectionManager = new RedisConnectionManager(this.vertx, options);
+    this.connectionManager = new RedisConnectionManager(this.vertx, tcpOptions, poolOptions, connectOptions);
     this.connectionManager.start();
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClient.java
@@ -16,15 +16,16 @@
 package io.vertx.redis.client.impl;
 
 import io.vertx.core.*;
+import io.vertx.core.net.NetClientOptions;
 import io.vertx.redis.client.*;
 
 public class RedisClient extends BaseRedisClient implements Redis {
 
   private final String defaultAddress;
 
-  public RedisClient(Vertx vertx, RedisOptions options) {
-    super(vertx, options);
-    this.defaultAddress = options.getEndpoint();
+  public RedisClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisConnectOptions connectOptions) {
+    super(vertx, tcpOptions, poolOptions, connectOptions);
+    this.defaultAddress = connectOptions.getEndpoint();
   }
 
   @Override

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -18,6 +18,7 @@ package io.vertx.redis.client.impl;
 import io.vertx.core.*;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.net.NetClientOptions;
 import io.vertx.redis.client.*;
 import io.vertx.redis.client.impl.types.MultiType;
 import io.vertx.redis.client.impl.types.NumberType;
@@ -119,14 +120,16 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
     addReducer(PUNSUBSCRIBE, list -> SimpleStringType.OK);
   }
 
-  private final RedisOptions options;
+  private final RedisClusterConnectOptions connectOptions;
+  private final PoolOptions poolOptions;
 
-  public RedisClusterClient(Vertx vertx, RedisOptions options) {
-    super(vertx, options);
-    this.options = options;
+  public RedisClusterClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisClusterConnectOptions connectOptions) {
+    super(vertx, tcpOptions, poolOptions, connectOptions);
+    this.connectOptions = connectOptions;
+    this.poolOptions = poolOptions;
     // validate options
-    if (options.getMaxPoolWaiting() < options.getMaxPoolSize()) {
-      throw new IllegalStateException("Invalid options: maxPoolWaiting < maxPoolSize");
+    if (poolOptions.getMaxWaiting() < poolOptions.getMaxSize()) {
+      throw new IllegalStateException("Invalid options: maxWaiting < maxSize");
       // we can't validate the max pool size yet as we need to know the slots first
       // the remaining validation will happen at the connect time
     }
@@ -136,7 +139,7 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
   public Future<RedisConnection> connect() {
     final Promise<RedisConnection> promise = vertx.promise();
     // attempt to load the slots from the first good endpoint
-    connect(options.getEndpoints(), 0, promise);
+    connect(connectOptions.getEndpoints(), 0, promise);
     return promise.future();
   }
 
@@ -147,7 +150,7 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
       return;
     }
 
-    connectionManager.getConnection(endpoints.get(index), RedisReplicas.NEVER != options.getUseReplicas() ? cmd(READONLY) : null)
+    connectionManager.getConnection(endpoints.get(index), RedisReplicas.NEVER != connectOptions.getUseReplicas() ? cmd(READONLY) : null)
       .onFailure(err -> {
         // failed try with the next endpoint
         connect(endpoints, index + 1, onConnect);
@@ -173,14 +176,14 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
 
           // validate if the pool config is valid
           final int totalUniqueEndpoints = slots.endpoints().length;
-          if (options.getMaxPoolSize() < totalUniqueEndpoints) {
+          if (poolOptions.getMaxSize() < totalUniqueEndpoints) {
             // this isn't a valid setup, the connection pool will not accommodate all the required connections
             onConnect.handle(Future.failedFuture("RedisOptions maxPoolSize < Cluster size(" + totalUniqueEndpoints + "): The pool is not able to hold all required connections!"));
             return;
           }
 
           for (String endpoint : slots.endpoints()) {
-            connectionManager.getConnection(endpoint, RedisReplicas.NEVER != options.getUseReplicas() ? cmd(READONLY) : null)
+            connectionManager.getConnection(endpoint, RedisReplicas.NEVER != connectOptions.getUseReplicas() ? cmd(READONLY) : null)
               .onFailure(err -> {
                 // failed try with the next endpoint
                 failed.set(true);
@@ -218,7 +221,7 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
         // return
         onConnect.handle(Future.failedFuture("Failed to connect to all nodes of the cluster"));
       } else {
-        onConnect.handle(Future.succeededFuture(new RedisClusterConnection(vertx, options, slots, connections)));
+        onConnect.handle(Future.succeededFuture(new RedisClusterConnection(vertx, connectOptions, slots, connections)));
       }
     }
   }

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
@@ -41,13 +41,13 @@ public class RedisClusterConnection implements RedisConnection {
   }
 
   private final VertxInternal vertx;
-  private final RedisOptions options;
+  private final RedisClusterConnectOptions connectOptions;
   private final Slots slots;
   private final Map<String, RedisConnection> connections;
 
-  RedisClusterConnection(Vertx vertx, RedisOptions options, Slots slots, Map<String, RedisConnection> connections) {
+  RedisClusterConnection(Vertx vertx, RedisClusterConnectOptions connectOptions, Slots slots, Map<String, RedisConnection> connections) {
     this.vertx = (VertxInternal) vertx;
-    this.options = options;
+    this.connectOptions = connectOptions;
     this.slots = slots;
     this.connections = connections;
   }
@@ -296,9 +296,9 @@ public class RedisClusterConnection implements RedisConnection {
           return;
         }
 
-        if (cause.is("NOAUTH") && options.getPassword() != null) {
+        if (cause.is("NOAUTH") && connectOptions.getPassword() != null) {
           // NOAUTH will try to authenticate
-          connection.send(cmd(AUTH).arg(options.getPassword()), auth -> {
+          connection.send(cmd(AUTH).arg(connectOptions.getPassword()), auth -> {
             if (auth.failed()) {
               handler.handle(Future.failedFuture(auth.cause()));
               return;
@@ -441,9 +441,9 @@ public class RedisClusterConnection implements RedisConnection {
           return;
         }
 
-        if (cause.is("NOAUTH") && options.getPassword() != null) {
+        if (cause.is("NOAUTH") && connectOptions.getPassword() != null) {
           // try to authenticate
-          connection.send(cmd(AUTH).arg(options.getPassword()), auth -> {
+          connection.send(cmd(AUTH).arg(connectOptions.getPassword()), auth -> {
             if (auth.failed()) {
               handler.handle(Future.failedFuture(auth.cause()));
               return;
@@ -502,7 +502,7 @@ public class RedisClusterConnection implements RedisConnection {
 
     // if we haven't got config for this slot, try any connection
     if (endpoints == null || endpoints.length == 0) {
-      return options.getEndpoint();
+      return connectOptions.getEndpoint();
     }
     return selectMasterOrReplicaEndpoint(readOnly, endpoints, forceMasterEndpoint);
   }
@@ -513,7 +513,7 @@ public class RedisClusterConnection implements RedisConnection {
     }
 
     // always, never, share
-    RedisReplicas useReplicas = options.getUseReplicas();
+    RedisReplicas useReplicas = connectOptions.getUseReplicas();
 
     if (readOnly && useReplicas != RedisReplicas.NEVER && endpoints.length > 1) {
       switch (useReplicas) {

--- a/src/main/java/io/vertx/redis/client/impl/RedisReplicationConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisReplicationConnection.java
@@ -23,12 +23,12 @@ public class RedisReplicationConnection implements RedisConnection {
     MASTER_ONLY_COMMANDS.add(command);
   }
 
-  private final RedisOptions options;
+  private final RedisClusterConnectOptions connectOptions;
   private final RedisConnection master;
   private final List<RedisConnection> replicas;
 
-  RedisReplicationConnection(Vertx vertx, RedisOptions options, RedisConnection master, List<RedisConnection> replicas) {
-    this.options = options;
+  RedisReplicationConnection(Vertx vertx, RedisClusterConnectOptions connectOptions, RedisConnection master, List<RedisConnection> replicas) {
+    this.connectOptions = connectOptions;
     this.master = master;
     this.replicas = replicas;
   }
@@ -176,7 +176,7 @@ public class RedisReplicationConnection implements RedisConnection {
     }
 
     // always, never, share
-    RedisReplicas useReplicas = options.getUseReplicas();
+    RedisReplicas useReplicas = connectOptions.getUseReplicas();
 
     if (read && useReplicas != RedisReplicas.NEVER && replicas.size() > 0) {
       switch (useReplicas) {

--- a/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
@@ -48,15 +48,15 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
   private boolean closed = false;
   private boolean tainted = false;
 
-  public RedisStandaloneConnection(VertxInternal vertx, ContextInternal context, PoolConnector.Listener connectionListener, NetSocket netSocket, RedisOptions options) {
+  public RedisStandaloneConnection(VertxInternal vertx, ContextInternal context, PoolConnector.Listener connectionListener, NetSocket netSocket, PoolOptions options, int maxWaitingHandlers) {
     //System.out.println("<ctor>#" + this.hashCode());
     this.vertx = vertx;
     this.context = context;
     this.listener = connectionListener;
     this.eventBus = vertx.eventBus();
     this.netSocket = netSocket;
-    this.waiting = new ArrayQueue(options.getMaxWaitingHandlers());
-    this.expiresAt = options.getPoolRecycleTimeout() == -1 ? -1 : System.currentTimeMillis() + options.getPoolRecycleTimeout();
+    this.waiting = new ArrayQueue(maxWaitingHandlers);
+    this.expiresAt = options.getRecycleTimeout() == -1 ? -1 : System.currentTimeMillis() + options.getRecycleTimeout();
   }
 
   synchronized void setValid() {

--- a/src/main/java/io/vertx/redis/client/impl/Resolver.java
+++ b/src/main/java/io/vertx/redis/client/impl/Resolver.java
@@ -17,10 +17,12 @@ package io.vertx.redis.client.impl;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.redis.client.RedisConnectOptions;
 import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.RedisSentinelConnectOptions;
 
 @FunctionalInterface
 interface Resolver {
 
-  void resolve(String endpoint, RedisOptions parameter, Handler<AsyncResult<RedisURI>> callback);
+  void resolve(String endpoint, RedisSentinelConnectOptions parameter, Handler<AsyncResult<RedisURI>> callback);
 }


### PR DESCRIPTION
Current `RedisOptions` mix connect and pooling options in the same class. If we want to use an options supplier pattern we should distinguish between those.

This PR decompose the `RedisOptions` in `PoolOptions` and a `RedisConnectOptions` hierarchy (for various client types) and keep the `RedisOptions` possible.