### PR TITLE
Move blocking random UUID generation to executor thread to keep pipeline reactive

### DIFF
--- a/src/main/java/io/vertx/redis/client/PoolOptions.java
+++ b/src/main/java/io/vertx/redis/client/PoolOptions.java
@@ -19,6 +19,8 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @DataObject(generateConverter = true)
 public class PoolOptions {
@@ -28,9 +30,12 @@ public class PoolOptions {
   private int maxSize;
   private int maxWaiting;
   private int recycleTimeout;
+  private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
   public PoolOptions() {
-    name = UUID.randomUUID().toString();
+    executor.execute(() -> {
+      name = UUID.randomUUID().toString();
+    });
     // thumb guess based on web browser defaults
     cleanerInterval = 30_000;
     maxSize = 6;


### PR DESCRIPTION
Hi! 👋 
Apparently the PoolOptions class has a blocking operation in its constructor that blocks the vertx event loop (as detected by BlockHound):
<img width="905" alt="Screen Shot 2023-07-16 at 5 49 04 PM" src="https://github.com/vert-x3/vertx-redis-client/assets/56495631/eeb1447d-1769-4320-a710-902a7ab6dc48">
This PR fixes the blocking code to ensure the event loop remains non-blocking.
