### PR TITLE
fix RedisOptions copy constructor

### DIFF
--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -84,6 +84,8 @@ public class RedisOptions {
     this.useReplicas = other.useReplicas;
     this.password = other.password;
     this.protocolNegotiation = other.protocolNegotiation;
+    this.maxWaitingHandlers = other.maxWaitingHandlers;
+    this.tracingPolicy = other.tracingPolicy;
   }
 
   /**

--- a/src/test/java/io/vertx/redis/client/test/RedisOptionsTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisOptionsTest.java
@@ -1,6 +1,10 @@
 package io.vertx.redis.client.test;
 
+import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.RedisRole;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -14,5 +18,25 @@ public class RedisOptionsTest {
     assertEquals(6, new RedisOptions().getMaxPoolSize());
     assertEquals("redis://localhost:6379", new RedisOptions().getEndpoint());
     assertEquals(Collections.singletonList("redis://localhost:6379"), new RedisOptions().getEndpoints());
+  }
+
+  @Test
+  public void testOptionsCopy() {
+    List<String> endpoints = new ArrayList<>(3);
+    endpoints.add("redis://localhost:123");
+    endpoints.add("redis://localhost:124");
+    endpoints.add("redis://localhost:125");
+
+    // Set values for which there is no default to ensure they are copied correctly
+    RedisOptions original = new RedisOptions()
+      .setEndpoints(endpoints)
+      .setMasterName("someOtherMaster")
+      .setRole(RedisRole.SENTINEL)
+      .setPassword("myPassword")
+      .setTracingPolicy(TracingPolicy.ALWAYS);
+
+    RedisOptions copy = new RedisOptions(original);
+
+    assertEquals(original.toJson(), copy.toJson());
   }
 }


### PR DESCRIPTION
Motivation:

I kept running into `Redis waiting Queue is full` exceptions. After debugging, I found that when I copied the options during my setup, the `maxWaitingHandlers` was not copied and therefore got set to `0`.

Looks like this was inadvertently dropped when the options were decomposed into specific pool/connect options:
https://github.com/vert-x3/vertx-redis-client/pull/395/files#diff-c7335b2f2f7228ced4e9f5842327edab03b17586a270d7479f15df7eeb50f334L95

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
