### PR TITLE
Load script on all master nodes in cluster

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -116,6 +116,7 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
         }).sum()));
 
     addMasterOnlyCommand(WAIT);
+    addMasterOnlyCommand(SCRIPT);
 
     addMasterOnlyCommand(SUBSCRIBE);
     addMasterOnlyCommand(PSUBSCRIBE);

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
@@ -141,7 +141,7 @@ public class RedisClusterConnection implements RedisConnection {
         // can run anywhere
         if (REDUCERS.containsKey(cmd)) {
           sendToAllSlots(promise, req, cmd, args, forceMasterEndpoint, REDUCERS.get(cmd));
-        } else if(cmd.equals(SCRIPT) && Arrays.equals(args.get(0), "LOAD".getBytes())) {
+        } else if(cmd.equals(SCRIPT) && "LOAD".equalsIgnoreCase(new String(args.get(0)))) {
           sendToAllSlots(promise, req, cmd, args, forceMasterEndpoint, responses -> {
             // all nodes should compute the same sha
             assert responses.stream().map(Response::toString).collect(Collectors.toSet()).size() == 1;

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
@@ -141,7 +141,7 @@ public class RedisClusterConnection implements RedisConnection {
         // can run anywhere
         if (REDUCERS.containsKey(cmd)) {
           sendToAllSlots(promise, req, cmd, args, forceMasterEndpoint, REDUCERS.get(cmd));
-        } else if(cmd.equals(SCRIPT) && "LOAD".equalsIgnoreCase(new String(args.get(0)))) {
+        } else if (cmd.equals(SCRIPT) && args.size() > 1 && args.get(0).length == 4 && "LOAD".equalsIgnoreCase(new String(args.get(0)))) {
           sendToAllSlots(promise, req, cmd, args, forceMasterEndpoint, responses -> {
             // all nodes should compute the same sha
             assert responses.stream().map(Response::toString).collect(Collectors.toSet()).size() == 1;

--- a/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
@@ -1244,7 +1244,7 @@ public class RedisClusterTest {
       cluster.exceptionHandler(should::fail);
       Future<@Nullable Response> setFuture1 = cluster.send(cmd(SET).arg(key1).arg(argv1));
       Future<@Nullable Response> setFuture2 = cluster.send(cmd(SET).arg(key2).arg(argv2));
-      Future<@Nullable Response> scriptLoadFuture = cluster.send(cmd(SCRIPT).arg("LOAD").arg(script));
+      Future<@Nullable Response> scriptLoadFuture = cluster.send(cmd(SCRIPT).arg("load").arg(script));
 
       return Future.all(setFuture1, setFuture2, scriptLoadFuture)
         .compose(compositeRet -> {

--- a/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
@@ -26,7 +26,7 @@ import static io.vertx.redis.client.Request.cmd;
 public class RedisClusterTest {
 
   @ClassRule
-  public static final GenericContainer<?> redis = new FixedHostPortGenericContainer<>("grokzen/redis-cluster:6.2.0")
+  public static final GenericContainer<?> redis = new FixedHostPortGenericContainer<>("grokzen/redis-cluster:6.2.11")
     .withEnv("IP", "0.0.0.0")
     .withEnv("STANDALONE", "true")
     .withEnv("SENTINEL", "true")


### PR DESCRIPTION
Motivation:

Redis uses command `SCRIPT LOAD` to load script to a script cache. This command should be run on every master node in cluster, otherwise node executing the script with `EVALSHA` fails on nodes that didn't load the script. Currently with clustered client, all `SCRIPT` commands are executed on a random node. My change handles this sub-command differently.

I have also considered a solution to introduce composite keys in `REDUCERS` (command + subcommand) but thought it would be premature abstraction, so I just implemented this directly without touching `REDUCERS`.