### PR TITLE
[4.x] Redis cluster improvements

### DIFF
--- a/src/main/java/io/vertx/redis/client/Command.java
+++ b/src/main/java/io/vertx/redis/client/Command.java
@@ -304,7 +304,7 @@ public interface Command {
   Command SORT = new CommandImpl("sort", -2, false, false, true, new KeyLocator(true, new BeginSearchIndex(1), new FindKeysRange(0, 1, 0)));
   Command SORT_RO = new CommandImpl("sort_ro", -2, true, false, true, new KeyLocator(true, new BeginSearchIndex(1), new FindKeysRange(0, 1, 0)));
   Command SPOP = new CommandImpl("spop", -2, false, false, false, new KeyLocator(false, new BeginSearchIndex(1), new FindKeysRange(0, 1, 0)));
-  Command SPUBLISH = new CommandImpl("spublish", 3, null, true, false, new KeyLocator(null, new BeginSearchIndex(1), new FindKeysRange(0, 1, 0)));
+  Command SPUBLISH = new CommandImpl("spublish", 3, null, false, false, new KeyLocator(null, new BeginSearchIndex(1), new FindKeysRange(0, 1, 0)));
   Command SRANDMEMBER = new CommandImpl("srandmember", -2, true, false, false, new KeyLocator(true, new BeginSearchIndex(1), new FindKeysRange(0, 1, 0)));
   Command SREM = new CommandImpl("srem", -3, false, false, false, new KeyLocator(false, new BeginSearchIndex(1), new FindKeysRange(0, 1, 0)));
   Command SSCAN = new CommandImpl("sscan", -3, true, false, false, new KeyLocator(true, new BeginSearchIndex(1), new FindKeysRange(0, 1, 0)));

--- a/src/main/java/io/vertx/redis/client/RedisAPI.java
+++ b/src/main/java/io/vertx/redis/client/RedisAPI.java
@@ -48,7 +48,7 @@ public interface RedisAPI {
   void close();
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.ADD">ftAdd</a>.
+   * Redis command <a href="https://redis.io/commands/ft.add/">FT.ADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -58,14 +58,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.ADD">ftAdd</a>.
+   * Redis command <a href="https://redis.io/commands/ft.add/">FT.ADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftAdd(List<String> args) {
     return send(Command.FT_ADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.AGGREGATE">ftAggregate</a>.
+   * Redis command <a href="https://redis.io/commands/ft.aggregate/">FT.AGGREGATE</a>.
    * @return fluent self
    */
   @Fluent
@@ -75,14 +76,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.AGGREGATE">ftAggregate</a>.
+   * Redis command <a href="https://redis.io/commands/ft.aggregate/">FT.AGGREGATE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftAggregate(List<String> args) {
     return send(Command.FT_AGGREGATE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.ALIASADD">ftAliasadd</a>.
+   * Redis command <a href="https://redis.io/commands/ft.aliasadd/">FT.ALIASADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -92,14 +94,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.ALIASADD">ftAliasadd</a>.
+   * Redis command <a href="https://redis.io/commands/ft.aliasadd/">FT.ALIASADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftAliasadd(List<String> args) {
     return send(Command.FT_ALIASADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.ALIASDEL">ftAliasdel</a>.
+   * Redis command <a href="https://redis.io/commands/ft.aliasdel/">FT.ALIASDEL</a>.
    * @return fluent self
    */
   @Fluent
@@ -109,14 +112,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.ALIASDEL">ftAliasdel</a>.
+   * Redis command <a href="https://redis.io/commands/ft.aliasdel/">FT.ALIASDEL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftAliasdel(List<String> args) {
     return send(Command.FT_ALIASDEL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.ALIASUPDATE">ftAliasupdate</a>.
+   * Redis command <a href="https://redis.io/commands/ft.aliasupdate/">FT.ALIASUPDATE</a>.
    * @return fluent self
    */
   @Fluent
@@ -126,14 +130,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.ALIASUPDATE">ftAliasupdate</a>.
+   * Redis command <a href="https://redis.io/commands/ft.aliasupdate/">FT.ALIASUPDATE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftAliasupdate(List<String> args) {
     return send(Command.FT_ALIASUPDATE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.ALTER">ftAlter</a>.
+   * Redis command <a href="https://redis.io/commands/ft.alter/">FT.ALTER</a>.
    * @return fluent self
    */
   @Fluent
@@ -143,14 +148,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.ALTER">ftAlter</a>.
+   * Redis command <a href="https://redis.io/commands/ft.alter/">FT.ALTER</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftAlter(List<String> args) {
     return send(Command.FT_ALTER, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.CONFIG">ftConfig</a>.
+   * Redis command <a href="https://redis.io/commands/ft.config/">FT.CONFIG</a>.
    * @return fluent self
    */
   @Fluent
@@ -160,14 +166,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.CONFIG">ftConfig</a>.
+   * Redis command <a href="https://redis.io/commands/ft.config/">FT.CONFIG</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftConfig(List<String> args) {
     return send(Command.FT_CONFIG, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.CREATE">ftCreate</a>.
+   * Redis command <a href="https://redis.io/commands/ft.create/">FT.CREATE</a>.
    * @return fluent self
    */
   @Fluent
@@ -177,14 +184,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.CREATE">ftCreate</a>.
+   * Redis command <a href="https://redis.io/commands/ft.create/">FT.CREATE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftCreate(List<String> args) {
     return send(Command.FT_CREATE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.CURSOR">ftCursor</a>.
+   * Redis command <a href="https://redis.io/commands/ft.cursor/">FT.CURSOR</a>.
    * @return fluent self
    */
   @Fluent
@@ -194,14 +202,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.CURSOR">ftCursor</a>.
+   * Redis command <a href="https://redis.io/commands/ft.cursor/">FT.CURSOR</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftCursor(List<String> args) {
     return send(Command.FT_CURSOR, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DEBUG">ftDebug</a>.
+   * Redis command <a href="https://redis.io/commands/ft.debug/">FT.DEBUG</a>.
    * @return fluent self
    */
   @Fluent
@@ -211,14 +220,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DEBUG">ftDebug</a>.
+   * Redis command <a href="https://redis.io/commands/ft.debug/">FT.DEBUG</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftDebug(List<String> args) {
     return send(Command.FT_DEBUG, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DEL">ftDel</a>.
+   * Redis command <a href="https://redis.io/commands/ft.del/">FT.DEL</a>.
    * @return fluent self
    */
   @Fluent
@@ -228,14 +238,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DEL">ftDel</a>.
+   * Redis command <a href="https://redis.io/commands/ft.del/">FT.DEL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftDel(List<String> args) {
     return send(Command.FT_DEL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DICTADD">ftDictadd</a>.
+   * Redis command <a href="https://redis.io/commands/ft.dictadd/">FT.DICTADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -245,14 +256,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DICTADD">ftDictadd</a>.
+   * Redis command <a href="https://redis.io/commands/ft.dictadd/">FT.DICTADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftDictadd(List<String> args) {
     return send(Command.FT_DICTADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DICTDEL">ftDictdel</a>.
+   * Redis command <a href="https://redis.io/commands/ft.dictdel/">FT.DICTDEL</a>.
    * @return fluent self
    */
   @Fluent
@@ -262,14 +274,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DICTDEL">ftDictdel</a>.
+   * Redis command <a href="https://redis.io/commands/ft.dictdel/">FT.DICTDEL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftDictdel(List<String> args) {
     return send(Command.FT_DICTDEL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DICTDUMP">ftDictdump</a>.
+   * Redis command <a href="https://redis.io/commands/ft.dictdump/">FT.DICTDUMP</a>.
    * @return fluent self
    */
   @Fluent
@@ -279,14 +292,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DICTDUMP">ftDictdump</a>.
+   * Redis command <a href="https://redis.io/commands/ft.dictdump/">FT.DICTDUMP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftDictdump(List<String> args) {
     return send(Command.FT_DICTDUMP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DROP">ftDrop</a>.
+   * Redis command <a href="https://redis.io/commands/ft.drop/">FT.DROP</a>.
    * @return fluent self
    */
   @Fluent
@@ -296,14 +310,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DROP">ftDrop</a>.
+   * Redis command <a href="https://redis.io/commands/ft.drop/">FT.DROP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftDrop(List<String> args) {
     return send(Command.FT_DROP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DROPINDEX">ftDropindex</a>.
+   * Redis command <a href="https://redis.io/commands/ft.dropindex/">FT.DROPINDEX</a>.
    * @return fluent self
    */
   @Fluent
@@ -313,14 +328,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.DROPINDEX">ftDropindex</a>.
+   * Redis command <a href="https://redis.io/commands/ft.dropindex/">FT.DROPINDEX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftDropindex(List<String> args) {
     return send(Command.FT_DROPINDEX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.EXPLAIN">ftExplain</a>.
+   * Redis command <a href="https://redis.io/commands/ft.explain/">FT.EXPLAIN</a>.
    * @return fluent self
    */
   @Fluent
@@ -330,14 +346,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.EXPLAIN">ftExplain</a>.
+   * Redis command <a href="https://redis.io/commands/ft.explain/">FT.EXPLAIN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftExplain(List<String> args) {
     return send(Command.FT_EXPLAIN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.EXPLAINCLI">ftExplaincli</a>.
+   * Redis command <a href="https://redis.io/commands/ft.explaincli/">FT.EXPLAINCLI</a>.
    * @return fluent self
    */
   @Fluent
@@ -347,14 +364,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.EXPLAINCLI">ftExplaincli</a>.
+   * Redis command <a href="https://redis.io/commands/ft.explaincli/">FT.EXPLAINCLI</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftExplaincli(List<String> args) {
     return send(Command.FT_EXPLAINCLI, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.GET">ftGet</a>.
+   * Redis command <a href="https://redis.io/commands/ft.get/">FT.GET</a>.
    * @return fluent self
    */
   @Fluent
@@ -364,14 +382,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.GET">ftGet</a>.
+   * Redis command <a href="https://redis.io/commands/ft.get/">FT.GET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftGet(List<String> args) {
     return send(Command.FT_GET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.INFO">ftInfo</a>.
+   * Redis command <a href="https://redis.io/commands/ft.info/">FT.INFO</a>.
    * @return fluent self
    */
   @Fluent
@@ -381,14 +400,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.INFO">ftInfo</a>.
+   * Redis command <a href="https://redis.io/commands/ft.info/">FT.INFO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftInfo(List<String> args) {
     return send(Command.FT_INFO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.MGET">ftMget</a>.
+   * Redis command <a href="https://redis.io/commands/ft.mget/">FT.MGET</a>.
    * @return fluent self
    */
   @Fluent
@@ -398,14 +418,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.MGET">ftMget</a>.
+   * Redis command <a href="https://redis.io/commands/ft.mget/">FT.MGET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftMget(List<String> args) {
     return send(Command.FT_MGET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.PROFILE">ftProfile</a>.
+   * Redis command <a href="https://redis.io/commands/ft.profile/">FT.PROFILE</a>.
    * @return fluent self
    */
   @Fluent
@@ -415,14 +436,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.PROFILE">ftProfile</a>.
+   * Redis command <a href="https://redis.io/commands/ft.profile/">FT.PROFILE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftProfile(List<String> args) {
     return send(Command.FT_PROFILE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SAFEADD">ftSafeadd</a>.
+   * Redis command <a href="https://redis.io/commands/ft.safeadd/">FT.SAFEADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -432,14 +454,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SAFEADD">ftSafeadd</a>.
+   * Redis command <a href="https://redis.io/commands/ft.safeadd/">FT.SAFEADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftSafeadd(List<String> args) {
     return send(Command.FT_SAFEADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SEARCH">ftSearch</a>.
+   * Redis command <a href="https://redis.io/commands/ft.search/">FT.SEARCH</a>.
    * @return fluent self
    */
   @Fluent
@@ -449,14 +472,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SEARCH">ftSearch</a>.
+   * Redis command <a href="https://redis.io/commands/ft.search/">FT.SEARCH</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftSearch(List<String> args) {
     return send(Command.FT_SEARCH, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SPELLCHECK">ftSpellcheck</a>.
+   * Redis command <a href="https://redis.io/commands/ft.spellcheck/">FT.SPELLCHECK</a>.
    * @return fluent self
    */
   @Fluent
@@ -466,14 +490,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SPELLCHECK">ftSpellcheck</a>.
+   * Redis command <a href="https://redis.io/commands/ft.spellcheck/">FT.SPELLCHECK</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftSpellcheck(List<String> args) {
     return send(Command.FT_SPELLCHECK, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SUGADD">ftSugadd</a>.
+   * Redis command <a href="https://redis.io/commands/ft.sugadd/">FT.SUGADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -483,14 +508,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SUGADD">ftSugadd</a>.
+   * Redis command <a href="https://redis.io/commands/ft.sugadd/">FT.SUGADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftSugadd(List<String> args) {
     return send(Command.FT_SUGADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SUGDEL">ftSugdel</a>.
+   * Redis command <a href="https://redis.io/commands/ft.sugdel/">FT.SUGDEL</a>.
    * @return fluent self
    */
   @Fluent
@@ -500,14 +526,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SUGDEL">ftSugdel</a>.
+   * Redis command <a href="https://redis.io/commands/ft.sugdel/">FT.SUGDEL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftSugdel(List<String> args) {
     return send(Command.FT_SUGDEL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SUGGET">ftSugget</a>.
+   * Redis command <a href="https://redis.io/commands/ft.sugget/">FT.SUGGET</a>.
    * @return fluent self
    */
   @Fluent
@@ -517,14 +544,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SUGGET">ftSugget</a>.
+   * Redis command <a href="https://redis.io/commands/ft.sugget/">FT.SUGGET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftSugget(List<String> args) {
     return send(Command.FT_SUGGET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SUGLEN">ftSuglen</a>.
+   * Redis command <a href="https://redis.io/commands/ft.suglen/">FT.SUGLEN</a>.
    * @return fluent self
    */
   @Fluent
@@ -534,14 +562,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SUGLEN">ftSuglen</a>.
+   * Redis command <a href="https://redis.io/commands/ft.suglen/">FT.SUGLEN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftSuglen(List<String> args) {
     return send(Command.FT_SUGLEN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SYNADD">ftSynadd</a>.
+   * Redis command <a href="https://redis.io/commands/ft.synadd/">FT.SYNADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -551,14 +580,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SYNADD">ftSynadd</a>.
+   * Redis command <a href="https://redis.io/commands/ft.synadd/">FT.SYNADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftSynadd(List<String> args) {
     return send(Command.FT_SYNADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SYNDUMP">ftSyndump</a>.
+   * Redis command <a href="https://redis.io/commands/ft.syndump/">FT.SYNDUMP</a>.
    * @return fluent self
    */
   @Fluent
@@ -568,14 +598,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SYNDUMP">ftSyndump</a>.
+   * Redis command <a href="https://redis.io/commands/ft.syndump/">FT.SYNDUMP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftSyndump(List<String> args) {
     return send(Command.FT_SYNDUMP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SYNUPDATE">ftSynupdate</a>.
+   * Redis command <a href="https://redis.io/commands/ft.synupdate/">FT.SYNUPDATE</a>.
    * @return fluent self
    */
   @Fluent
@@ -585,14 +616,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.SYNUPDATE">ftSynupdate</a>.
+   * Redis command <a href="https://redis.io/commands/ft.synupdate/">FT.SYNUPDATE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftSynupdate(List<String> args) {
     return send(Command.FT_SYNUPDATE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT.TAGVALS">ftTagvals</a>.
+   * Redis command <a href="https://redis.io/commands/ft.tagvals/">FT.TAGVALS</a>.
    * @return fluent self
    */
   @Fluent
@@ -602,14 +634,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT.TAGVALS">ftTagvals</a>.
+   * Redis command <a href="https://redis.io/commands/ft.tagvals/">FT.TAGVALS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftTagvals(List<String> args) {
     return send(Command.FT_TAGVALS, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT._ALIASADDIFNX">ftAliasaddifnx</a>.
+   * Redis command <a href="https://redis.io/commands/ft._aliasaddifnx/">FT._ALIASADDIFNX</a>.
    * @return fluent self
    */
   @Fluent
@@ -619,14 +652,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT._ALIASADDIFNX">ftAliasaddifnx</a>.
+   * Redis command <a href="https://redis.io/commands/ft._aliasaddifnx/">FT._ALIASADDIFNX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftAliasaddifnx(List<String> args) {
     return send(Command.FT__ALIASADDIFNX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT._ALIASDELIFX">ftAliasdelifx</a>.
+   * Redis command <a href="https://redis.io/commands/ft._aliasdelifx/">FT._ALIASDELIFX</a>.
    * @return fluent self
    */
   @Fluent
@@ -636,14 +670,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT._ALIASDELIFX">ftAliasdelifx</a>.
+   * Redis command <a href="https://redis.io/commands/ft._aliasdelifx/">FT._ALIASDELIFX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftAliasdelifx(List<String> args) {
     return send(Command.FT__ALIASDELIFX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT._ALTERIFNX">ftAlterifnx</a>.
+   * Redis command <a href="https://redis.io/commands/ft._alterifnx/">FT._ALTERIFNX</a>.
    * @return fluent self
    */
   @Fluent
@@ -653,14 +688,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT._ALTERIFNX">ftAlterifnx</a>.
+   * Redis command <a href="https://redis.io/commands/ft._alterifnx/">FT._ALTERIFNX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftAlterifnx(List<String> args) {
     return send(Command.FT__ALTERIFNX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT._CREATEIFNX">ftCreateifnx</a>.
+   * Redis command <a href="https://redis.io/commands/ft._createifnx/">FT._CREATEIFNX</a>.
    * @return fluent self
    */
   @Fluent
@@ -670,14 +706,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT._CREATEIFNX">ftCreateifnx</a>.
+   * Redis command <a href="https://redis.io/commands/ft._createifnx/">FT._CREATEIFNX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftCreateifnx(List<String> args) {
     return send(Command.FT__CREATEIFNX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT._DROPIFX">ftDropifx</a>.
+   * Redis command <a href="https://redis.io/commands/ft._dropifx/">FT._DROPIFX</a>.
    * @return fluent self
    */
   @Fluent
@@ -687,14 +724,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT._DROPIFX">ftDropifx</a>.
+   * Redis command <a href="https://redis.io/commands/ft._dropifx/">FT._DROPIFX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftDropifx(List<String> args) {
     return send(Command.FT__DROPIFX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT._DROPINDEXIFX">ftDropindexifx</a>.
+   * Redis command <a href="https://redis.io/commands/ft._dropindexifx/">FT._DROPINDEXIFX</a>.
    * @return fluent self
    */
   @Fluent
@@ -704,14 +742,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT._DROPINDEXIFX">ftDropindexifx</a>.
+   * Redis command <a href="https://redis.io/commands/ft._dropindexifx/">FT._DROPINDEXIFX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftDropindexifx(List<String> args) {
     return send(Command.FT__DROPINDEXIFX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/FT._LIST">ftList</a>.
+   * Redis command <a href="https://redis.io/commands/ft._list/">FT._LIST</a>.
    * @return fluent self
    */
   @Fluent
@@ -721,14 +760,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/FT._LIST">ftList</a>.
+   * Redis command <a href="https://redis.io/commands/ft._list/">FT._LIST</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ftList(List<String> args) {
     return send(Command.FT__LIST, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/acl">acl</a>.
+   * Redis command <a href="https://redis.io/commands/acl/">ACL</a>.
    * @return fluent self
    */
   @Fluent
@@ -738,14 +778,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/acl">acl</a>.
+   * Redis command <a href="https://redis.io/commands/acl/">ACL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> acl(List<String> args) {
     return send(Command.ACL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/append">append</a>.
+   * Redis command <a href="https://redis.io/commands/append/">APPEND</a>.
    * @return fluent self
    */
   @Fluent
@@ -755,14 +796,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/append">append</a>.
+   * Redis command <a href="https://redis.io/commands/append/">APPEND</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> append(String arg0, String arg1) {
     return send(Command.APPEND, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/asking">asking</a>.
+   * Redis command <a href="https://redis.io/commands/asking/">ASKING</a>.
    * @return fluent self
    */
   @Fluent
@@ -772,14 +814,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/asking">asking</a>.
+   * Redis command <a href="https://redis.io/commands/asking/">ASKING</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> asking() {
     return send(Command.ASKING);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/auth">auth</a>.
+   * Redis command <a href="https://redis.io/commands/auth/">AUTH</a>.
    * @return fluent self
    */
   @Fluent
@@ -789,14 +832,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/auth">auth</a>.
+   * Redis command <a href="https://redis.io/commands/auth/">AUTH</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> auth(List<String> args) {
     return send(Command.AUTH, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bf.add">bfAdd</a>.
+   * Redis command <a href="https://redis.io/commands/bf.add/">BF.ADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -806,14 +850,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bf.add">bfAdd</a>.
+   * Redis command <a href="https://redis.io/commands/bf.add/">BF.ADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bfAdd(List<String> args) {
     return send(Command.BF_ADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bf.card">bfCard</a>.
+   * Redis command <a href="https://redis.io/commands/bf.card/">BF.CARD</a>.
    * @return fluent self
    */
   @Fluent
@@ -823,14 +868,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bf.card">bfCard</a>.
+   * Redis command <a href="https://redis.io/commands/bf.card/">BF.CARD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bfCard(List<String> args) {
     return send(Command.BF_CARD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bf.debug">bfDebug</a>.
+   * Redis command <a href="https://redis.io/commands/bf.debug/">BF.DEBUG</a>.
    * @return fluent self
    */
   @Fluent
@@ -840,14 +886,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bf.debug">bfDebug</a>.
+   * Redis command <a href="https://redis.io/commands/bf.debug/">BF.DEBUG</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bfDebug(List<String> args) {
     return send(Command.BF_DEBUG, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bf.exists">bfExists</a>.
+   * Redis command <a href="https://redis.io/commands/bf.exists/">BF.EXISTS</a>.
    * @return fluent self
    */
   @Fluent
@@ -857,14 +904,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bf.exists">bfExists</a>.
+   * Redis command <a href="https://redis.io/commands/bf.exists/">BF.EXISTS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bfExists(List<String> args) {
     return send(Command.BF_EXISTS, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bf.info">bfInfo</a>.
+   * Redis command <a href="https://redis.io/commands/bf.info/">BF.INFO</a>.
    * @return fluent self
    */
   @Fluent
@@ -874,14 +922,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bf.info">bfInfo</a>.
+   * Redis command <a href="https://redis.io/commands/bf.info/">BF.INFO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bfInfo(List<String> args) {
     return send(Command.BF_INFO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bf.insert">bfInsert</a>.
+   * Redis command <a href="https://redis.io/commands/bf.insert/">BF.INSERT</a>.
    * @return fluent self
    */
   @Fluent
@@ -891,14 +940,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bf.insert">bfInsert</a>.
+   * Redis command <a href="https://redis.io/commands/bf.insert/">BF.INSERT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bfInsert(List<String> args) {
     return send(Command.BF_INSERT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bf.loadchunk">bfLoadchunk</a>.
+   * Redis command <a href="https://redis.io/commands/bf.loadchunk/">BF.LOADCHUNK</a>.
    * @return fluent self
    */
   @Fluent
@@ -908,14 +958,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bf.loadchunk">bfLoadchunk</a>.
+   * Redis command <a href="https://redis.io/commands/bf.loadchunk/">BF.LOADCHUNK</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bfLoadchunk(List<String> args) {
     return send(Command.BF_LOADCHUNK, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bf.madd">bfMadd</a>.
+   * Redis command <a href="https://redis.io/commands/bf.madd/">BF.MADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -925,14 +976,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bf.madd">bfMadd</a>.
+   * Redis command <a href="https://redis.io/commands/bf.madd/">BF.MADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bfMadd(List<String> args) {
     return send(Command.BF_MADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bf.mexists">bfMexists</a>.
+   * Redis command <a href="https://redis.io/commands/bf.mexists/">BF.MEXISTS</a>.
    * @return fluent self
    */
   @Fluent
@@ -942,14 +994,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bf.mexists">bfMexists</a>.
+   * Redis command <a href="https://redis.io/commands/bf.mexists/">BF.MEXISTS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bfMexists(List<String> args) {
     return send(Command.BF_MEXISTS, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bf.reserve">bfReserve</a>.
+   * Redis command <a href="https://redis.io/commands/bf.reserve/">BF.RESERVE</a>.
    * @return fluent self
    */
   @Fluent
@@ -959,14 +1012,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bf.reserve">bfReserve</a>.
+   * Redis command <a href="https://redis.io/commands/bf.reserve/">BF.RESERVE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bfReserve(List<String> args) {
     return send(Command.BF_RESERVE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bf.scandump">bfScandump</a>.
+   * Redis command <a href="https://redis.io/commands/bf.scandump/">BF.SCANDUMP</a>.
    * @return fluent self
    */
   @Fluent
@@ -976,14 +1030,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bf.scandump">bfScandump</a>.
+   * Redis command <a href="https://redis.io/commands/bf.scandump/">BF.SCANDUMP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bfScandump(List<String> args) {
     return send(Command.BF_SCANDUMP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bgrewriteaof">bgrewriteaof</a>.
+   * Redis command <a href="https://redis.io/commands/bgrewriteaof/">BGREWRITEAOF</a>.
    * @return fluent self
    */
   @Fluent
@@ -993,14 +1048,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bgrewriteaof">bgrewriteaof</a>.
+   * Redis command <a href="https://redis.io/commands/bgrewriteaof/">BGREWRITEAOF</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bgrewriteaof() {
     return send(Command.BGREWRITEAOF);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bgsave">bgsave</a>.
+   * Redis command <a href="https://redis.io/commands/bgsave/">BGSAVE</a>.
    * @return fluent self
    */
   @Fluent
@@ -1010,14 +1066,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bgsave">bgsave</a>.
+   * Redis command <a href="https://redis.io/commands/bgsave/">BGSAVE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bgsave(List<String> args) {
     return send(Command.BGSAVE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bitcount">bitcount</a>.
+   * Redis command <a href="https://redis.io/commands/bitcount/">BITCOUNT</a>.
    * @return fluent self
    */
   @Fluent
@@ -1027,14 +1084,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bitcount">bitcount</a>.
+   * Redis command <a href="https://redis.io/commands/bitcount/">BITCOUNT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bitcount(List<String> args) {
     return send(Command.BITCOUNT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bitfield">bitfield</a>.
+   * Redis command <a href="https://redis.io/commands/bitfield/">BITFIELD</a>.
    * @return fluent self
    */
   @Fluent
@@ -1044,14 +1102,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bitfield">bitfield</a>.
+   * Redis command <a href="https://redis.io/commands/bitfield/">BITFIELD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bitfield(List<String> args) {
     return send(Command.BITFIELD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bitfield_ro">bitfieldRo</a>.
+   * Redis command <a href="https://redis.io/commands/bitfield_ro/">BITFIELD_RO</a>.
    * @return fluent self
    */
   @Fluent
@@ -1061,14 +1120,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bitfield_ro">bitfieldRo</a>.
+   * Redis command <a href="https://redis.io/commands/bitfield_ro/">BITFIELD_RO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bitfieldRo(List<String> args) {
     return send(Command.BITFIELD_RO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bitop">bitop</a>.
+   * Redis command <a href="https://redis.io/commands/bitop/">BITOP</a>.
    * @return fluent self
    */
   @Fluent
@@ -1078,14 +1138,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bitop">bitop</a>.
+   * Redis command <a href="https://redis.io/commands/bitop/">BITOP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bitop(List<String> args) {
     return send(Command.BITOP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bitpos">bitpos</a>.
+   * Redis command <a href="https://redis.io/commands/bitpos/">BITPOS</a>.
    * @return fluent self
    */
   @Fluent
@@ -1095,14 +1156,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bitpos">bitpos</a>.
+   * Redis command <a href="https://redis.io/commands/bitpos/">BITPOS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bitpos(List<String> args) {
     return send(Command.BITPOS, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/blmove">blmove</a>.
+   * Redis command <a href="https://redis.io/commands/blmove/">BLMOVE</a>.
    * @return fluent self
    */
   @Fluent
@@ -1112,14 +1174,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/blmove">blmove</a>.
+   * Redis command <a href="https://redis.io/commands/blmove/">BLMOVE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> blmove(String arg0, String arg1, String arg2, String arg3, String arg4) {
     return send(Command.BLMOVE, arg0, arg1, arg2, arg3, arg4);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/blmpop">blmpop</a>.
+   * Redis command <a href="https://redis.io/commands/blmpop/">BLMPOP</a>.
    * @return fluent self
    */
   @Fluent
@@ -1129,14 +1192,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/blmpop">blmpop</a>.
+   * Redis command <a href="https://redis.io/commands/blmpop/">BLMPOP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> blmpop(List<String> args) {
     return send(Command.BLMPOP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/blpop">blpop</a>.
+   * Redis command <a href="https://redis.io/commands/blpop/">BLPOP</a>.
    * @return fluent self
    */
   @Fluent
@@ -1146,14 +1210,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/blpop">blpop</a>.
+   * Redis command <a href="https://redis.io/commands/blpop/">BLPOP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> blpop(List<String> args) {
     return send(Command.BLPOP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/brpop">brpop</a>.
+   * Redis command <a href="https://redis.io/commands/brpop/">BRPOP</a>.
    * @return fluent self
    */
   @Fluent
@@ -1163,14 +1228,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/brpop">brpop</a>.
+   * Redis command <a href="https://redis.io/commands/brpop/">BRPOP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> brpop(List<String> args) {
     return send(Command.BRPOP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/brpoplpush">brpoplpush</a>.
+   * Redis command <a href="https://redis.io/commands/brpoplpush/">BRPOPLPUSH</a>.
    * @return fluent self
    */
   @Fluent
@@ -1180,14 +1246,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/brpoplpush">brpoplpush</a>.
+   * Redis command <a href="https://redis.io/commands/brpoplpush/">BRPOPLPUSH</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> brpoplpush(String arg0, String arg1, String arg2) {
     return send(Command.BRPOPLPUSH, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bzmpop">bzmpop</a>.
+   * Redis command <a href="https://redis.io/commands/bzmpop/">BZMPOP</a>.
    * @return fluent self
    */
   @Fluent
@@ -1197,14 +1264,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bzmpop">bzmpop</a>.
+   * Redis command <a href="https://redis.io/commands/bzmpop/">BZMPOP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bzmpop(List<String> args) {
     return send(Command.BZMPOP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bzpopmax">bzpopmax</a>.
+   * Redis command <a href="https://redis.io/commands/bzpopmax/">BZPOPMAX</a>.
    * @return fluent self
    */
   @Fluent
@@ -1214,14 +1282,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bzpopmax">bzpopmax</a>.
+   * Redis command <a href="https://redis.io/commands/bzpopmax/">BZPOPMAX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bzpopmax(List<String> args) {
     return send(Command.BZPOPMAX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/bzpopmin">bzpopmin</a>.
+   * Redis command <a href="https://redis.io/commands/bzpopmin/">BZPOPMIN</a>.
    * @return fluent self
    */
   @Fluent
@@ -1231,14 +1300,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/bzpopmin">bzpopmin</a>.
+   * Redis command <a href="https://redis.io/commands/bzpopmin/">BZPOPMIN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> bzpopmin(List<String> args) {
     return send(Command.BZPOPMIN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.add">cfAdd</a>.
+   * Redis command <a href="https://redis.io/commands/cf.add/">CF.ADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -1248,14 +1318,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.add">cfAdd</a>.
+   * Redis command <a href="https://redis.io/commands/cf.add/">CF.ADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfAdd(List<String> args) {
     return send(Command.CF_ADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.addnx">cfAddnx</a>.
+   * Redis command <a href="https://redis.io/commands/cf.addnx/">CF.ADDNX</a>.
    * @return fluent self
    */
   @Fluent
@@ -1265,14 +1336,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.addnx">cfAddnx</a>.
+   * Redis command <a href="https://redis.io/commands/cf.addnx/">CF.ADDNX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfAddnx(List<String> args) {
     return send(Command.CF_ADDNX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.compact">cfCompact</a>.
+   * Redis command <a href="https://redis.io/commands/cf.compact/">CF.COMPACT</a>.
    * @return fluent self
    */
   @Fluent
@@ -1282,14 +1354,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.compact">cfCompact</a>.
+   * Redis command <a href="https://redis.io/commands/cf.compact/">CF.COMPACT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfCompact(List<String> args) {
     return send(Command.CF_COMPACT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.count">cfCount</a>.
+   * Redis command <a href="https://redis.io/commands/cf.count/">CF.COUNT</a>.
    * @return fluent self
    */
   @Fluent
@@ -1299,14 +1372,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.count">cfCount</a>.
+   * Redis command <a href="https://redis.io/commands/cf.count/">CF.COUNT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfCount(List<String> args) {
     return send(Command.CF_COUNT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.debug">cfDebug</a>.
+   * Redis command <a href="https://redis.io/commands/cf.debug/">CF.DEBUG</a>.
    * @return fluent self
    */
   @Fluent
@@ -1316,14 +1390,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.debug">cfDebug</a>.
+   * Redis command <a href="https://redis.io/commands/cf.debug/">CF.DEBUG</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfDebug(List<String> args) {
     return send(Command.CF_DEBUG, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.del">cfDel</a>.
+   * Redis command <a href="https://redis.io/commands/cf.del/">CF.DEL</a>.
    * @return fluent self
    */
   @Fluent
@@ -1333,14 +1408,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.del">cfDel</a>.
+   * Redis command <a href="https://redis.io/commands/cf.del/">CF.DEL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfDel(List<String> args) {
     return send(Command.CF_DEL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.exists">cfExists</a>.
+   * Redis command <a href="https://redis.io/commands/cf.exists/">CF.EXISTS</a>.
    * @return fluent self
    */
   @Fluent
@@ -1350,14 +1426,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.exists">cfExists</a>.
+   * Redis command <a href="https://redis.io/commands/cf.exists/">CF.EXISTS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfExists(List<String> args) {
     return send(Command.CF_EXISTS, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.info">cfInfo</a>.
+   * Redis command <a href="https://redis.io/commands/cf.info/">CF.INFO</a>.
    * @return fluent self
    */
   @Fluent
@@ -1367,14 +1444,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.info">cfInfo</a>.
+   * Redis command <a href="https://redis.io/commands/cf.info/">CF.INFO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfInfo(List<String> args) {
     return send(Command.CF_INFO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.insert">cfInsert</a>.
+   * Redis command <a href="https://redis.io/commands/cf.insert/">CF.INSERT</a>.
    * @return fluent self
    */
   @Fluent
@@ -1384,14 +1462,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.insert">cfInsert</a>.
+   * Redis command <a href="https://redis.io/commands/cf.insert/">CF.INSERT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfInsert(List<String> args) {
     return send(Command.CF_INSERT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.insertnx">cfInsertnx</a>.
+   * Redis command <a href="https://redis.io/commands/cf.insertnx/">CF.INSERTNX</a>.
    * @return fluent self
    */
   @Fluent
@@ -1401,14 +1480,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.insertnx">cfInsertnx</a>.
+   * Redis command <a href="https://redis.io/commands/cf.insertnx/">CF.INSERTNX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfInsertnx(List<String> args) {
     return send(Command.CF_INSERTNX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.loadchunk">cfLoadchunk</a>.
+   * Redis command <a href="https://redis.io/commands/cf.loadchunk/">CF.LOADCHUNK</a>.
    * @return fluent self
    */
   @Fluent
@@ -1418,14 +1498,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.loadchunk">cfLoadchunk</a>.
+   * Redis command <a href="https://redis.io/commands/cf.loadchunk/">CF.LOADCHUNK</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfLoadchunk(List<String> args) {
     return send(Command.CF_LOADCHUNK, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.mexists">cfMexists</a>.
+   * Redis command <a href="https://redis.io/commands/cf.mexists/">CF.MEXISTS</a>.
    * @return fluent self
    */
   @Fluent
@@ -1435,14 +1516,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.mexists">cfMexists</a>.
+   * Redis command <a href="https://redis.io/commands/cf.mexists/">CF.MEXISTS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfMexists(List<String> args) {
     return send(Command.CF_MEXISTS, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.reserve">cfReserve</a>.
+   * Redis command <a href="https://redis.io/commands/cf.reserve/">CF.RESERVE</a>.
    * @return fluent self
    */
   @Fluent
@@ -1452,14 +1534,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.reserve">cfReserve</a>.
+   * Redis command <a href="https://redis.io/commands/cf.reserve/">CF.RESERVE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfReserve(List<String> args) {
     return send(Command.CF_RESERVE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cf.scandump">cfScandump</a>.
+   * Redis command <a href="https://redis.io/commands/cf.scandump/">CF.SCANDUMP</a>.
    * @return fluent self
    */
   @Fluent
@@ -1469,14 +1552,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cf.scandump">cfScandump</a>.
+   * Redis command <a href="https://redis.io/commands/cf.scandump/">CF.SCANDUMP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cfScandump(List<String> args) {
     return send(Command.CF_SCANDUMP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/client">client</a>.
+   * Redis command <a href="https://redis.io/commands/client/">CLIENT</a>.
    * @return fluent self
    */
   @Fluent
@@ -1486,14 +1570,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/client">client</a>.
+   * Redis command <a href="https://redis.io/commands/client/">CLIENT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> client(List<String> args) {
     return send(Command.CLIENT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cluster">cluster</a>.
+   * Redis command <a href="https://redis.io/commands/cluster/">CLUSTER</a>.
    * @return fluent self
    */
   @Fluent
@@ -1503,14 +1588,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cluster">cluster</a>.
+   * Redis command <a href="https://redis.io/commands/cluster/">CLUSTER</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cluster(List<String> args) {
     return send(Command.CLUSTER, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cms.incrby">cmsIncrby</a>.
+   * Redis command <a href="https://redis.io/commands/cms.incrby/">CMS.INCRBY</a>.
    * @return fluent self
    */
   @Fluent
@@ -1520,14 +1606,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cms.incrby">cmsIncrby</a>.
+   * Redis command <a href="https://redis.io/commands/cms.incrby/">CMS.INCRBY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cmsIncrby(List<String> args) {
     return send(Command.CMS_INCRBY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cms.info">cmsInfo</a>.
+   * Redis command <a href="https://redis.io/commands/cms.info/">CMS.INFO</a>.
    * @return fluent self
    */
   @Fluent
@@ -1537,14 +1624,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cms.info">cmsInfo</a>.
+   * Redis command <a href="https://redis.io/commands/cms.info/">CMS.INFO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cmsInfo(List<String> args) {
     return send(Command.CMS_INFO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cms.initbydim">cmsInitbydim</a>.
+   * Redis command <a href="https://redis.io/commands/cms.initbydim/">CMS.INITBYDIM</a>.
    * @return fluent self
    */
   @Fluent
@@ -1554,14 +1642,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cms.initbydim">cmsInitbydim</a>.
+   * Redis command <a href="https://redis.io/commands/cms.initbydim/">CMS.INITBYDIM</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cmsInitbydim(List<String> args) {
     return send(Command.CMS_INITBYDIM, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cms.initbyprob">cmsInitbyprob</a>.
+   * Redis command <a href="https://redis.io/commands/cms.initbyprob/">CMS.INITBYPROB</a>.
    * @return fluent self
    */
   @Fluent
@@ -1571,14 +1660,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cms.initbyprob">cmsInitbyprob</a>.
+   * Redis command <a href="https://redis.io/commands/cms.initbyprob/">CMS.INITBYPROB</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cmsInitbyprob(List<String> args) {
     return send(Command.CMS_INITBYPROB, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cms.merge">cmsMerge</a>.
+   * Redis command <a href="https://redis.io/commands/cms.merge/">CMS.MERGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -1588,14 +1678,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cms.merge">cmsMerge</a>.
+   * Redis command <a href="https://redis.io/commands/cms.merge/">CMS.MERGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cmsMerge(List<String> args) {
     return send(Command.CMS_MERGE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/cms.query">cmsQuery</a>.
+   * Redis command <a href="https://redis.io/commands/cms.query/">CMS.QUERY</a>.
    * @return fluent self
    */
   @Fluent
@@ -1605,14 +1696,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/cms.query">cmsQuery</a>.
+   * Redis command <a href="https://redis.io/commands/cms.query/">CMS.QUERY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> cmsQuery(List<String> args) {
     return send(Command.CMS_QUERY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/command">command</a>.
+   * Redis command <a href="https://redis.io/commands/command/">COMMAND</a>.
    * @return fluent self
    */
   @Fluent
@@ -1622,14 +1714,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/command">command</a>.
+   * Redis command <a href="https://redis.io/commands/command/">COMMAND</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> command(List<String> args) {
     return send(Command.COMMAND, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/config">config</a>.
+   * Redis command <a href="https://redis.io/commands/config/">CONFIG</a>.
    * @return fluent self
    */
   @Fluent
@@ -1639,14 +1732,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/config">config</a>.
+   * Redis command <a href="https://redis.io/commands/config/">CONFIG</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> config(List<String> args) {
     return send(Command.CONFIG, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/copy">copy</a>.
+   * Redis command <a href="https://redis.io/commands/copy/">COPY</a>.
    * @return fluent self
    */
   @Fluent
@@ -1656,14 +1750,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/copy">copy</a>.
+   * Redis command <a href="https://redis.io/commands/copy/">COPY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> copy(List<String> args) {
     return send(Command.COPY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/dbsize">dbsize</a>.
+   * Redis command <a href="https://redis.io/commands/dbsize/">DBSIZE</a>.
    * @return fluent self
    */
   @Fluent
@@ -1673,14 +1768,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/dbsize">dbsize</a>.
+   * Redis command <a href="https://redis.io/commands/dbsize/">DBSIZE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> dbsize() {
     return send(Command.DBSIZE);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/debug">debug</a>.
+   * Redis command <a href="https://redis.io/commands/debug/">DEBUG</a>.
    * @return fluent self
    */
   @Fluent
@@ -1690,14 +1786,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/debug">debug</a>.
+   * Redis command <a href="https://redis.io/commands/debug/">DEBUG</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> debug(List<String> args) {
     return send(Command.DEBUG, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/decr">decr</a>.
+   * Redis command <a href="https://redis.io/commands/decr/">DECR</a>.
    * @return fluent self
    */
   @Fluent
@@ -1707,14 +1804,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/decr">decr</a>.
+   * Redis command <a href="https://redis.io/commands/decr/">DECR</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> decr(String arg0) {
     return send(Command.DECR, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/decrby">decrby</a>.
+   * Redis command <a href="https://redis.io/commands/decrby/">DECRBY</a>.
    * @return fluent self
    */
   @Fluent
@@ -1724,14 +1822,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/decrby">decrby</a>.
+   * Redis command <a href="https://redis.io/commands/decrby/">DECRBY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> decrby(String arg0, String arg1) {
     return send(Command.DECRBY, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/del">del</a>.
+   * Redis command <a href="https://redis.io/commands/del/">DEL</a>.
    * @return fluent self
    */
   @Fluent
@@ -1741,14 +1840,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/del">del</a>.
+   * Redis command <a href="https://redis.io/commands/del/">DEL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> del(List<String> args) {
     return send(Command.DEL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/discard">discard</a>.
+   * Redis command <a href="https://redis.io/commands/discard/">DISCARD</a>.
    * @return fluent self
    */
   @Fluent
@@ -1758,14 +1858,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/discard">discard</a>.
+   * Redis command <a href="https://redis.io/commands/discard/">DISCARD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> discard() {
     return send(Command.DISCARD);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/dump">dump</a>.
+   * Redis command <a href="https://redis.io/commands/dump/">DUMP</a>.
    * @return fluent self
    */
   @Fluent
@@ -1775,14 +1876,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/dump">dump</a>.
+   * Redis command <a href="https://redis.io/commands/dump/">DUMP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> dump(String arg0) {
     return send(Command.DUMP, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/echo">echo</a>.
+   * Redis command <a href="https://redis.io/commands/echo/">ECHO</a>.
    * @return fluent self
    */
   @Fluent
@@ -1792,14 +1894,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/echo">echo</a>.
+   * Redis command <a href="https://redis.io/commands/echo/">ECHO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> echo(String arg0) {
     return send(Command.ECHO, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/eval">eval</a>.
+   * Redis command <a href="https://redis.io/commands/eval/">EVAL</a>.
    * @return fluent self
    */
   @Fluent
@@ -1809,14 +1912,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/eval">eval</a>.
+   * Redis command <a href="https://redis.io/commands/eval/">EVAL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> eval(List<String> args) {
     return send(Command.EVAL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/eval_ro">evalRo</a>.
+   * Redis command <a href="https://redis.io/commands/eval_ro/">EVAL_RO</a>.
    * @return fluent self
    */
   @Fluent
@@ -1826,14 +1930,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/eval_ro">evalRo</a>.
+   * Redis command <a href="https://redis.io/commands/eval_ro/">EVAL_RO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> evalRo(List<String> args) {
     return send(Command.EVAL_RO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/evalsha">evalsha</a>.
+   * Redis command <a href="https://redis.io/commands/evalsha/">EVALSHA</a>.
    * @return fluent self
    */
   @Fluent
@@ -1843,14 +1948,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/evalsha">evalsha</a>.
+   * Redis command <a href="https://redis.io/commands/evalsha/">EVALSHA</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> evalsha(List<String> args) {
     return send(Command.EVALSHA, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/evalsha_ro">evalshaRo</a>.
+   * Redis command <a href="https://redis.io/commands/evalsha_ro/">EVALSHA_RO</a>.
    * @return fluent self
    */
   @Fluent
@@ -1860,14 +1966,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/evalsha_ro">evalshaRo</a>.
+   * Redis command <a href="https://redis.io/commands/evalsha_ro/">EVALSHA_RO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> evalshaRo(List<String> args) {
     return send(Command.EVALSHA_RO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/exec">exec</a>.
+   * Redis command <a href="https://redis.io/commands/exec/">EXEC</a>.
    * @return fluent self
    */
   @Fluent
@@ -1877,14 +1984,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/exec">exec</a>.
+   * Redis command <a href="https://redis.io/commands/exec/">EXEC</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> exec() {
     return send(Command.EXEC);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/exists">exists</a>.
+   * Redis command <a href="https://redis.io/commands/exists/">EXISTS</a>.
    * @return fluent self
    */
   @Fluent
@@ -1894,14 +2002,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/exists">exists</a>.
+   * Redis command <a href="https://redis.io/commands/exists/">EXISTS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> exists(List<String> args) {
     return send(Command.EXISTS, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/expire">expire</a>.
+   * Redis command <a href="https://redis.io/commands/expire/">EXPIRE</a>.
    * @return fluent self
    */
   @Fluent
@@ -1911,14 +2020,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/expire">expire</a>.
+   * Redis command <a href="https://redis.io/commands/expire/">EXPIRE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> expire(List<String> args) {
     return send(Command.EXPIRE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/expireat">expireat</a>.
+   * Redis command <a href="https://redis.io/commands/expireat/">EXPIREAT</a>.
    * @return fluent self
    */
   @Fluent
@@ -1928,14 +2038,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/expireat">expireat</a>.
+   * Redis command <a href="https://redis.io/commands/expireat/">EXPIREAT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> expireat(List<String> args) {
     return send(Command.EXPIREAT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/expiretime">expiretime</a>.
+   * Redis command <a href="https://redis.io/commands/expiretime/">EXPIRETIME</a>.
    * @return fluent self
    */
   @Fluent
@@ -1945,14 +2056,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/expiretime">expiretime</a>.
+   * Redis command <a href="https://redis.io/commands/expiretime/">EXPIRETIME</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> expiretime(String arg0) {
     return send(Command.EXPIRETIME, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/failover">failover</a>.
+   * Redis command <a href="https://redis.io/commands/failover/">FAILOVER</a>.
    * @return fluent self
    */
   @Fluent
@@ -1962,14 +2074,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/failover">failover</a>.
+   * Redis command <a href="https://redis.io/commands/failover/">FAILOVER</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> failover(List<String> args) {
     return send(Command.FAILOVER, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/fcall">fcall</a>.
+   * Redis command <a href="https://redis.io/commands/fcall/">FCALL</a>.
    * @return fluent self
    */
   @Fluent
@@ -1979,14 +2092,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/fcall">fcall</a>.
+   * Redis command <a href="https://redis.io/commands/fcall/">FCALL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> fcall(List<String> args) {
     return send(Command.FCALL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/fcall_ro">fcallRo</a>.
+   * Redis command <a href="https://redis.io/commands/fcall_ro/">FCALL_RO</a>.
    * @return fluent self
    */
   @Fluent
@@ -1996,14 +2110,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/fcall_ro">fcallRo</a>.
+   * Redis command <a href="https://redis.io/commands/fcall_ro/">FCALL_RO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> fcallRo(List<String> args) {
     return send(Command.FCALL_RO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/flushall">flushall</a>.
+   * Redis command <a href="https://redis.io/commands/flushall/">FLUSHALL</a>.
    * @return fluent self
    */
   @Fluent
@@ -2013,14 +2128,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/flushall">flushall</a>.
+   * Redis command <a href="https://redis.io/commands/flushall/">FLUSHALL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> flushall(List<String> args) {
     return send(Command.FLUSHALL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/flushdb">flushdb</a>.
+   * Redis command <a href="https://redis.io/commands/flushdb/">FLUSHDB</a>.
    * @return fluent self
    */
   @Fluent
@@ -2030,14 +2146,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/flushdb">flushdb</a>.
+   * Redis command <a href="https://redis.io/commands/flushdb/">FLUSHDB</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> flushdb(List<String> args) {
     return send(Command.FLUSHDB, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/function">function</a>.
+   * Redis command <a href="https://redis.io/commands/function/">FUNCTION</a>.
    * @return fluent self
    */
   @Fluent
@@ -2047,14 +2164,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/function">function</a>.
+   * Redis command <a href="https://redis.io/commands/function/">FUNCTION</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> function(List<String> args) {
     return send(Command.FUNCTION, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/geoadd">geoadd</a>.
+   * Redis command <a href="https://redis.io/commands/geoadd/">GEOADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -2064,14 +2182,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/geoadd">geoadd</a>.
+   * Redis command <a href="https://redis.io/commands/geoadd/">GEOADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> geoadd(List<String> args) {
     return send(Command.GEOADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/geodist">geodist</a>.
+   * Redis command <a href="https://redis.io/commands/geodist/">GEODIST</a>.
    * @return fluent self
    */
   @Fluent
@@ -2081,14 +2200,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/geodist">geodist</a>.
+   * Redis command <a href="https://redis.io/commands/geodist/">GEODIST</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> geodist(List<String> args) {
     return send(Command.GEODIST, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/geohash">geohash</a>.
+   * Redis command <a href="https://redis.io/commands/geohash/">GEOHASH</a>.
    * @return fluent self
    */
   @Fluent
@@ -2098,14 +2218,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/geohash">geohash</a>.
+   * Redis command <a href="https://redis.io/commands/geohash/">GEOHASH</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> geohash(List<String> args) {
     return send(Command.GEOHASH, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/geopos">geopos</a>.
+   * Redis command <a href="https://redis.io/commands/geopos/">GEOPOS</a>.
    * @return fluent self
    */
   @Fluent
@@ -2115,14 +2236,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/geopos">geopos</a>.
+   * Redis command <a href="https://redis.io/commands/geopos/">GEOPOS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> geopos(List<String> args) {
     return send(Command.GEOPOS, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/georadius">georadius</a>.
+   * Redis command <a href="https://redis.io/commands/georadius/">GEORADIUS</a>.
    * @return fluent self
    */
   @Fluent
@@ -2132,14 +2254,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/georadius">georadius</a>.
+   * Redis command <a href="https://redis.io/commands/georadius/">GEORADIUS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> georadius(List<String> args) {
     return send(Command.GEORADIUS, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/georadius_ro">georadiusRo</a>.
+   * Redis command <a href="https://redis.io/commands/georadius_ro/">GEORADIUS_RO</a>.
    * @return fluent self
    */
   @Fluent
@@ -2149,14 +2272,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/georadius_ro">georadiusRo</a>.
+   * Redis command <a href="https://redis.io/commands/georadius_ro/">GEORADIUS_RO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> georadiusRo(List<String> args) {
     return send(Command.GEORADIUS_RO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/georadiusbymember">georadiusbymember</a>.
+   * Redis command <a href="https://redis.io/commands/georadiusbymember/">GEORADIUSBYMEMBER</a>.
    * @return fluent self
    */
   @Fluent
@@ -2166,14 +2290,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/georadiusbymember">georadiusbymember</a>.
+   * Redis command <a href="https://redis.io/commands/georadiusbymember/">GEORADIUSBYMEMBER</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> georadiusbymember(List<String> args) {
     return send(Command.GEORADIUSBYMEMBER, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/georadiusbymember_ro">georadiusbymemberRo</a>.
+   * Redis command <a href="https://redis.io/commands/georadiusbymember_ro/">GEORADIUSBYMEMBER_RO</a>.
    * @return fluent self
    */
   @Fluent
@@ -2183,14 +2308,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/georadiusbymember_ro">georadiusbymemberRo</a>.
+   * Redis command <a href="https://redis.io/commands/georadiusbymember_ro/">GEORADIUSBYMEMBER_RO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> georadiusbymemberRo(List<String> args) {
     return send(Command.GEORADIUSBYMEMBER_RO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/geosearch">geosearch</a>.
+   * Redis command <a href="https://redis.io/commands/geosearch/">GEOSEARCH</a>.
    * @return fluent self
    */
   @Fluent
@@ -2200,14 +2326,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/geosearch">geosearch</a>.
+   * Redis command <a href="https://redis.io/commands/geosearch/">GEOSEARCH</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> geosearch(List<String> args) {
     return send(Command.GEOSEARCH, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/geosearchstore">geosearchstore</a>.
+   * Redis command <a href="https://redis.io/commands/geosearchstore/">GEOSEARCHSTORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -2217,14 +2344,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/geosearchstore">geosearchstore</a>.
+   * Redis command <a href="https://redis.io/commands/geosearchstore/">GEOSEARCHSTORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> geosearchstore(List<String> args) {
     return send(Command.GEOSEARCHSTORE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/get">get</a>.
+   * Redis command <a href="https://redis.io/commands/get/">GET</a>.
    * @return fluent self
    */
   @Fluent
@@ -2234,14 +2362,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/get">get</a>.
+   * Redis command <a href="https://redis.io/commands/get/">GET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> get(String arg0) {
     return send(Command.GET, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/getbit">getbit</a>.
+   * Redis command <a href="https://redis.io/commands/getbit/">GETBIT</a>.
    * @return fluent self
    */
   @Fluent
@@ -2251,14 +2380,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/getbit">getbit</a>.
+   * Redis command <a href="https://redis.io/commands/getbit/">GETBIT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> getbit(String arg0, String arg1) {
     return send(Command.GETBIT, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/getdel">getdel</a>.
+   * Redis command <a href="https://redis.io/commands/getdel/">GETDEL</a>.
    * @return fluent self
    */
   @Fluent
@@ -2268,14 +2398,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/getdel">getdel</a>.
+   * Redis command <a href="https://redis.io/commands/getdel/">GETDEL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> getdel(String arg0) {
     return send(Command.GETDEL, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/getex">getex</a>.
+   * Redis command <a href="https://redis.io/commands/getex/">GETEX</a>.
    * @return fluent self
    */
   @Fluent
@@ -2285,14 +2416,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/getex">getex</a>.
+   * Redis command <a href="https://redis.io/commands/getex/">GETEX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> getex(List<String> args) {
     return send(Command.GETEX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/getrange">getrange</a>.
+   * Redis command <a href="https://redis.io/commands/getrange/">GETRANGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -2302,14 +2434,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/getrange">getrange</a>.
+   * Redis command <a href="https://redis.io/commands/getrange/">GETRANGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> getrange(String arg0, String arg1, String arg2) {
     return send(Command.GETRANGE, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/getset">getset</a>.
+   * Redis command <a href="https://redis.io/commands/getset/">GETSET</a>.
    * @return fluent self
    */
   @Fluent
@@ -2319,14 +2452,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/getset">getset</a>.
+   * Redis command <a href="https://redis.io/commands/getset/">GETSET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> getset(String arg0, String arg1) {
     return send(Command.GETSET, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/graph.BULK">graphBulk</a>.
+   * Redis command <a href="https://redis.io/commands/graph.bulk/">GRAPH.BULK</a>.
    * @return fluent self
    */
   @Fluent
@@ -2336,14 +2470,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/graph.BULK">graphBulk</a>.
+   * Redis command <a href="https://redis.io/commands/graph.bulk/">GRAPH.BULK</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> graphBulk(List<String> args) {
     return send(Command.GRAPH_BULK, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/graph.CONFIG">graphConfig</a>.
+   * Redis command <a href="https://redis.io/commands/graph.config/">GRAPH.CONFIG</a>.
    * @return fluent self
    */
   @Fluent
@@ -2353,14 +2488,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/graph.CONFIG">graphConfig</a>.
+   * Redis command <a href="https://redis.io/commands/graph.config/">GRAPH.CONFIG</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> graphConfig(List<String> args) {
     return send(Command.GRAPH_CONFIG, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/graph.DEBUG">graphDebug</a>.
+   * Redis command <a href="https://redis.io/commands/graph.debug/">GRAPH.DEBUG</a>.
    * @return fluent self
    */
   @Fluent
@@ -2370,14 +2506,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/graph.DEBUG">graphDebug</a>.
+   * Redis command <a href="https://redis.io/commands/graph.debug/">GRAPH.DEBUG</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> graphDebug(List<String> args) {
     return send(Command.GRAPH_DEBUG, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/graph.DELETE">graphDelete</a>.
+   * Redis command <a href="https://redis.io/commands/graph.delete/">GRAPH.DELETE</a>.
    * @return fluent self
    */
   @Fluent
@@ -2387,14 +2524,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/graph.DELETE">graphDelete</a>.
+   * Redis command <a href="https://redis.io/commands/graph.delete/">GRAPH.DELETE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> graphDelete(List<String> args) {
     return send(Command.GRAPH_DELETE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/graph.EXPLAIN">graphExplain</a>.
+   * Redis command <a href="https://redis.io/commands/graph.explain/">GRAPH.EXPLAIN</a>.
    * @return fluent self
    */
   @Fluent
@@ -2404,14 +2542,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/graph.EXPLAIN">graphExplain</a>.
+   * Redis command <a href="https://redis.io/commands/graph.explain/">GRAPH.EXPLAIN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> graphExplain(List<String> args) {
     return send(Command.GRAPH_EXPLAIN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/graph.LIST">graphList</a>.
+   * Redis command <a href="https://redis.io/commands/graph.list/">GRAPH.LIST</a>.
    * @return fluent self
    */
   @Fluent
@@ -2421,14 +2560,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/graph.LIST">graphList</a>.
+   * Redis command <a href="https://redis.io/commands/graph.list/">GRAPH.LIST</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> graphList(List<String> args) {
     return send(Command.GRAPH_LIST, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/graph.PROFILE">graphProfile</a>.
+   * Redis command <a href="https://redis.io/commands/graph.profile/">GRAPH.PROFILE</a>.
    * @return fluent self
    */
   @Fluent
@@ -2438,14 +2578,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/graph.PROFILE">graphProfile</a>.
+   * Redis command <a href="https://redis.io/commands/graph.profile/">GRAPH.PROFILE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> graphProfile(List<String> args) {
     return send(Command.GRAPH_PROFILE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/graph.QUERY">graphQuery</a>.
+   * Redis command <a href="https://redis.io/commands/graph.query/">GRAPH.QUERY</a>.
    * @return fluent self
    */
   @Fluent
@@ -2455,14 +2596,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/graph.QUERY">graphQuery</a>.
+   * Redis command <a href="https://redis.io/commands/graph.query/">GRAPH.QUERY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> graphQuery(List<String> args) {
     return send(Command.GRAPH_QUERY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/graph.RO_QUERY">graphRoQuery</a>.
+   * Redis command <a href="https://redis.io/commands/graph.ro_query/">GRAPH.RO_QUERY</a>.
    * @return fluent self
    */
   @Fluent
@@ -2472,14 +2614,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/graph.RO_QUERY">graphRoQuery</a>.
+   * Redis command <a href="https://redis.io/commands/graph.ro_query/">GRAPH.RO_QUERY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> graphRoQuery(List<String> args) {
     return send(Command.GRAPH_RO_QUERY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/graph.SLOWLOG">graphSlowlog</a>.
+   * Redis command <a href="https://redis.io/commands/graph.slowlog/">GRAPH.SLOWLOG</a>.
    * @return fluent self
    */
   @Fluent
@@ -2489,14 +2632,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/graph.SLOWLOG">graphSlowlog</a>.
+   * Redis command <a href="https://redis.io/commands/graph.slowlog/">GRAPH.SLOWLOG</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> graphSlowlog(List<String> args) {
     return send(Command.GRAPH_SLOWLOG, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hdel">hdel</a>.
+   * Redis command <a href="https://redis.io/commands/hdel/">HDEL</a>.
    * @return fluent self
    */
   @Fluent
@@ -2506,14 +2650,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hdel">hdel</a>.
+   * Redis command <a href="https://redis.io/commands/hdel/">HDEL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hdel(List<String> args) {
     return send(Command.HDEL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hello">hello</a>.
+   * Redis command <a href="https://redis.io/commands/hello/">HELLO</a>.
    * @return fluent self
    */
   @Fluent
@@ -2523,14 +2668,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hello">hello</a>.
+   * Redis command <a href="https://redis.io/commands/hello/">HELLO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hello(List<String> args) {
     return send(Command.HELLO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hexists">hexists</a>.
+   * Redis command <a href="https://redis.io/commands/hexists/">HEXISTS</a>.
    * @return fluent self
    */
   @Fluent
@@ -2540,14 +2686,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hexists">hexists</a>.
+   * Redis command <a href="https://redis.io/commands/hexists/">HEXISTS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hexists(String arg0, String arg1) {
     return send(Command.HEXISTS, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hget">hget</a>.
+   * Redis command <a href="https://redis.io/commands/hget/">HGET</a>.
    * @return fluent self
    */
   @Fluent
@@ -2557,14 +2704,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hget">hget</a>.
+   * Redis command <a href="https://redis.io/commands/hget/">HGET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hget(String arg0, String arg1) {
     return send(Command.HGET, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hgetall">hgetall</a>.
+   * Redis command <a href="https://redis.io/commands/hgetall/">HGETALL</a>.
    * @return fluent self
    */
   @Fluent
@@ -2574,14 +2722,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hgetall">hgetall</a>.
+   * Redis command <a href="https://redis.io/commands/hgetall/">HGETALL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hgetall(String arg0) {
     return send(Command.HGETALL, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hincrby">hincrby</a>.
+   * Redis command <a href="https://redis.io/commands/hincrby/">HINCRBY</a>.
    * @return fluent self
    */
   @Fluent
@@ -2591,14 +2740,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hincrby">hincrby</a>.
+   * Redis command <a href="https://redis.io/commands/hincrby/">HINCRBY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hincrby(String arg0, String arg1, String arg2) {
     return send(Command.HINCRBY, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hincrbyfloat">hincrbyfloat</a>.
+   * Redis command <a href="https://redis.io/commands/hincrbyfloat/">HINCRBYFLOAT</a>.
    * @return fluent self
    */
   @Fluent
@@ -2608,14 +2758,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hincrbyfloat">hincrbyfloat</a>.
+   * Redis command <a href="https://redis.io/commands/hincrbyfloat/">HINCRBYFLOAT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hincrbyfloat(String arg0, String arg1, String arg2) {
     return send(Command.HINCRBYFLOAT, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hkeys">hkeys</a>.
+   * Redis command <a href="https://redis.io/commands/hkeys/">HKEYS</a>.
    * @return fluent self
    */
   @Fluent
@@ -2625,14 +2776,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hkeys">hkeys</a>.
+   * Redis command <a href="https://redis.io/commands/hkeys/">HKEYS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hkeys(String arg0) {
     return send(Command.HKEYS, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hlen">hlen</a>.
+   * Redis command <a href="https://redis.io/commands/hlen/">HLEN</a>.
    * @return fluent self
    */
   @Fluent
@@ -2642,14 +2794,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hlen">hlen</a>.
+   * Redis command <a href="https://redis.io/commands/hlen/">HLEN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hlen(String arg0) {
     return send(Command.HLEN, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hmget">hmget</a>.
+   * Redis command <a href="https://redis.io/commands/hmget/">HMGET</a>.
    * @return fluent self
    */
   @Fluent
@@ -2659,14 +2812,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hmget">hmget</a>.
+   * Redis command <a href="https://redis.io/commands/hmget/">HMGET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hmget(List<String> args) {
     return send(Command.HMGET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hmset">hmset</a>.
+   * Redis command <a href="https://redis.io/commands/hmset/">HMSET</a>.
    * @return fluent self
    */
   @Fluent
@@ -2676,14 +2830,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hmset">hmset</a>.
+   * Redis command <a href="https://redis.io/commands/hmset/">HMSET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hmset(List<String> args) {
     return send(Command.HMSET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hrandfield">hrandfield</a>.
+   * Redis command <a href="https://redis.io/commands/hrandfield/">HRANDFIELD</a>.
    * @return fluent self
    */
   @Fluent
@@ -2693,14 +2848,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hrandfield">hrandfield</a>.
+   * Redis command <a href="https://redis.io/commands/hrandfield/">HRANDFIELD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hrandfield(List<String> args) {
     return send(Command.HRANDFIELD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hscan">hscan</a>.
+   * Redis command <a href="https://redis.io/commands/hscan/">HSCAN</a>.
    * @return fluent self
    */
   @Fluent
@@ -2710,14 +2866,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hscan">hscan</a>.
+   * Redis command <a href="https://redis.io/commands/hscan/">HSCAN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hscan(List<String> args) {
     return send(Command.HSCAN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hset">hset</a>.
+   * Redis command <a href="https://redis.io/commands/hset/">HSET</a>.
    * @return fluent self
    */
   @Fluent
@@ -2727,14 +2884,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hset">hset</a>.
+   * Redis command <a href="https://redis.io/commands/hset/">HSET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hset(List<String> args) {
     return send(Command.HSET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hsetnx">hsetnx</a>.
+   * Redis command <a href="https://redis.io/commands/hsetnx/">HSETNX</a>.
    * @return fluent self
    */
   @Fluent
@@ -2744,14 +2902,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hsetnx">hsetnx</a>.
+   * Redis command <a href="https://redis.io/commands/hsetnx/">HSETNX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hsetnx(String arg0, String arg1, String arg2) {
     return send(Command.HSETNX, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hstrlen">hstrlen</a>.
+   * Redis command <a href="https://redis.io/commands/hstrlen/">HSTRLEN</a>.
    * @return fluent self
    */
   @Fluent
@@ -2761,14 +2920,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hstrlen">hstrlen</a>.
+   * Redis command <a href="https://redis.io/commands/hstrlen/">HSTRLEN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hstrlen(String arg0, String arg1) {
     return send(Command.HSTRLEN, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/hvals">hvals</a>.
+   * Redis command <a href="https://redis.io/commands/hvals/">HVALS</a>.
    * @return fluent self
    */
   @Fluent
@@ -2778,14 +2938,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/hvals">hvals</a>.
+   * Redis command <a href="https://redis.io/commands/hvals/">HVALS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> hvals(String arg0) {
     return send(Command.HVALS, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/incr">incr</a>.
+   * Redis command <a href="https://redis.io/commands/incr/">INCR</a>.
    * @return fluent self
    */
   @Fluent
@@ -2795,14 +2956,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/incr">incr</a>.
+   * Redis command <a href="https://redis.io/commands/incr/">INCR</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> incr(String arg0) {
     return send(Command.INCR, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/incrby">incrby</a>.
+   * Redis command <a href="https://redis.io/commands/incrby/">INCRBY</a>.
    * @return fluent self
    */
   @Fluent
@@ -2812,14 +2974,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/incrby">incrby</a>.
+   * Redis command <a href="https://redis.io/commands/incrby/">INCRBY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> incrby(String arg0, String arg1) {
     return send(Command.INCRBY, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/incrbyfloat">incrbyfloat</a>.
+   * Redis command <a href="https://redis.io/commands/incrbyfloat/">INCRBYFLOAT</a>.
    * @return fluent self
    */
   @Fluent
@@ -2829,14 +2992,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/incrbyfloat">incrbyfloat</a>.
+   * Redis command <a href="https://redis.io/commands/incrbyfloat/">INCRBYFLOAT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> incrbyfloat(String arg0, String arg1) {
     return send(Command.INCRBYFLOAT, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/info">info</a>.
+   * Redis command <a href="https://redis.io/commands/info/">INFO</a>.
    * @return fluent self
    */
   @Fluent
@@ -2846,14 +3010,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/info">info</a>.
+   * Redis command <a href="https://redis.io/commands/info/">INFO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> info(List<String> args) {
     return send(Command.INFO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.arrappend">jsonArrappend</a>.
+   * Redis command <a href="https://redis.io/commands/json.arrappend/">JSON.ARRAPPEND</a>.
    * @return fluent self
    */
   @Fluent
@@ -2863,14 +3028,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.arrappend">jsonArrappend</a>.
+   * Redis command <a href="https://redis.io/commands/json.arrappend/">JSON.ARRAPPEND</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonArrappend(List<String> args) {
     return send(Command.JSON_ARRAPPEND, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.arrindex">jsonArrindex</a>.
+   * Redis command <a href="https://redis.io/commands/json.arrindex/">JSON.ARRINDEX</a>.
    * @return fluent self
    */
   @Fluent
@@ -2880,14 +3046,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.arrindex">jsonArrindex</a>.
+   * Redis command <a href="https://redis.io/commands/json.arrindex/">JSON.ARRINDEX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonArrindex(List<String> args) {
     return send(Command.JSON_ARRINDEX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.arrinsert">jsonArrinsert</a>.
+   * Redis command <a href="https://redis.io/commands/json.arrinsert/">JSON.ARRINSERT</a>.
    * @return fluent self
    */
   @Fluent
@@ -2897,14 +3064,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.arrinsert">jsonArrinsert</a>.
+   * Redis command <a href="https://redis.io/commands/json.arrinsert/">JSON.ARRINSERT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonArrinsert(List<String> args) {
     return send(Command.JSON_ARRINSERT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.arrlen">jsonArrlen</a>.
+   * Redis command <a href="https://redis.io/commands/json.arrlen/">JSON.ARRLEN</a>.
    * @return fluent self
    */
   @Fluent
@@ -2914,14 +3082,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.arrlen">jsonArrlen</a>.
+   * Redis command <a href="https://redis.io/commands/json.arrlen/">JSON.ARRLEN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonArrlen(List<String> args) {
     return send(Command.JSON_ARRLEN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.arrpop">jsonArrpop</a>.
+   * Redis command <a href="https://redis.io/commands/json.arrpop/">JSON.ARRPOP</a>.
    * @return fluent self
    */
   @Fluent
@@ -2931,14 +3100,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.arrpop">jsonArrpop</a>.
+   * Redis command <a href="https://redis.io/commands/json.arrpop/">JSON.ARRPOP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonArrpop(List<String> args) {
     return send(Command.JSON_ARRPOP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.arrtrim">jsonArrtrim</a>.
+   * Redis command <a href="https://redis.io/commands/json.arrtrim/">JSON.ARRTRIM</a>.
    * @return fluent self
    */
   @Fluent
@@ -2948,14 +3118,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.arrtrim">jsonArrtrim</a>.
+   * Redis command <a href="https://redis.io/commands/json.arrtrim/">JSON.ARRTRIM</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonArrtrim(List<String> args) {
     return send(Command.JSON_ARRTRIM, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.clear">jsonClear</a>.
+   * Redis command <a href="https://redis.io/commands/json.clear/">JSON.CLEAR</a>.
    * @return fluent self
    */
   @Fluent
@@ -2965,14 +3136,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.clear">jsonClear</a>.
+   * Redis command <a href="https://redis.io/commands/json.clear/">JSON.CLEAR</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonClear(List<String> args) {
     return send(Command.JSON_CLEAR, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.debug">jsonDebug</a>.
+   * Redis command <a href="https://redis.io/commands/json.debug/">JSON.DEBUG</a>.
    * @return fluent self
    */
   @Fluent
@@ -2982,14 +3154,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.debug">jsonDebug</a>.
+   * Redis command <a href="https://redis.io/commands/json.debug/">JSON.DEBUG</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonDebug(List<String> args) {
     return send(Command.JSON_DEBUG, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.del">jsonDel</a>.
+   * Redis command <a href="https://redis.io/commands/json.del/">JSON.DEL</a>.
    * @return fluent self
    */
   @Fluent
@@ -2999,14 +3172,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.del">jsonDel</a>.
+   * Redis command <a href="https://redis.io/commands/json.del/">JSON.DEL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonDel(List<String> args) {
     return send(Command.JSON_DEL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.forget">jsonForget</a>.
+   * Redis command <a href="https://redis.io/commands/json.forget/">JSON.FORGET</a>.
    * @return fluent self
    */
   @Fluent
@@ -3016,14 +3190,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.forget">jsonForget</a>.
+   * Redis command <a href="https://redis.io/commands/json.forget/">JSON.FORGET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonForget(List<String> args) {
     return send(Command.JSON_FORGET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.get">jsonGet</a>.
+   * Redis command <a href="https://redis.io/commands/json.get/">JSON.GET</a>.
    * @return fluent self
    */
   @Fluent
@@ -3033,14 +3208,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.get">jsonGet</a>.
+   * Redis command <a href="https://redis.io/commands/json.get/">JSON.GET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonGet(List<String> args) {
     return send(Command.JSON_GET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.mget">jsonMget</a>.
+   * Redis command <a href="https://redis.io/commands/json.mget/">JSON.MGET</a>.
    * @return fluent self
    */
   @Fluent
@@ -3050,14 +3226,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.mget">jsonMget</a>.
+   * Redis command <a href="https://redis.io/commands/json.mget/">JSON.MGET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonMget(List<String> args) {
     return send(Command.JSON_MGET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.numincrby">jsonNumincrby</a>.
+   * Redis command <a href="https://redis.io/commands/json.numincrby/">JSON.NUMINCRBY</a>.
    * @return fluent self
    */
   @Fluent
@@ -3067,14 +3244,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.numincrby">jsonNumincrby</a>.
+   * Redis command <a href="https://redis.io/commands/json.numincrby/">JSON.NUMINCRBY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonNumincrby(List<String> args) {
     return send(Command.JSON_NUMINCRBY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.nummultby">jsonNummultby</a>.
+   * Redis command <a href="https://redis.io/commands/json.nummultby/">JSON.NUMMULTBY</a>.
    * @return fluent self
    */
   @Fluent
@@ -3084,14 +3262,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.nummultby">jsonNummultby</a>.
+   * Redis command <a href="https://redis.io/commands/json.nummultby/">JSON.NUMMULTBY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonNummultby(List<String> args) {
     return send(Command.JSON_NUMMULTBY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.numpowby">jsonNumpowby</a>.
+   * Redis command <a href="https://redis.io/commands/json.numpowby/">JSON.NUMPOWBY</a>.
    * @return fluent self
    */
   @Fluent
@@ -3101,14 +3280,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.numpowby">jsonNumpowby</a>.
+   * Redis command <a href="https://redis.io/commands/json.numpowby/">JSON.NUMPOWBY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonNumpowby(List<String> args) {
     return send(Command.JSON_NUMPOWBY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.objkeys">jsonObjkeys</a>.
+   * Redis command <a href="https://redis.io/commands/json.objkeys/">JSON.OBJKEYS</a>.
    * @return fluent self
    */
   @Fluent
@@ -3118,14 +3298,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.objkeys">jsonObjkeys</a>.
+   * Redis command <a href="https://redis.io/commands/json.objkeys/">JSON.OBJKEYS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonObjkeys(List<String> args) {
     return send(Command.JSON_OBJKEYS, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.objlen">jsonObjlen</a>.
+   * Redis command <a href="https://redis.io/commands/json.objlen/">JSON.OBJLEN</a>.
    * @return fluent self
    */
   @Fluent
@@ -3135,14 +3316,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.objlen">jsonObjlen</a>.
+   * Redis command <a href="https://redis.io/commands/json.objlen/">JSON.OBJLEN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonObjlen(List<String> args) {
     return send(Command.JSON_OBJLEN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.resp">jsonResp</a>.
+   * Redis command <a href="https://redis.io/commands/json.resp/">JSON.RESP</a>.
    * @return fluent self
    */
   @Fluent
@@ -3152,14 +3334,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.resp">jsonResp</a>.
+   * Redis command <a href="https://redis.io/commands/json.resp/">JSON.RESP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonResp(List<String> args) {
     return send(Command.JSON_RESP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.set">jsonSet</a>.
+   * Redis command <a href="https://redis.io/commands/json.set/">JSON.SET</a>.
    * @return fluent self
    */
   @Fluent
@@ -3169,14 +3352,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.set">jsonSet</a>.
+   * Redis command <a href="https://redis.io/commands/json.set/">JSON.SET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonSet(List<String> args) {
     return send(Command.JSON_SET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.strappend">jsonStrappend</a>.
+   * Redis command <a href="https://redis.io/commands/json.strappend/">JSON.STRAPPEND</a>.
    * @return fluent self
    */
   @Fluent
@@ -3186,14 +3370,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.strappend">jsonStrappend</a>.
+   * Redis command <a href="https://redis.io/commands/json.strappend/">JSON.STRAPPEND</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonStrappend(List<String> args) {
     return send(Command.JSON_STRAPPEND, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.strlen">jsonStrlen</a>.
+   * Redis command <a href="https://redis.io/commands/json.strlen/">JSON.STRLEN</a>.
    * @return fluent self
    */
   @Fluent
@@ -3203,14 +3388,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.strlen">jsonStrlen</a>.
+   * Redis command <a href="https://redis.io/commands/json.strlen/">JSON.STRLEN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonStrlen(List<String> args) {
     return send(Command.JSON_STRLEN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.toggle">jsonToggle</a>.
+   * Redis command <a href="https://redis.io/commands/json.toggle/">JSON.TOGGLE</a>.
    * @return fluent self
    */
   @Fluent
@@ -3220,14 +3406,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.toggle">jsonToggle</a>.
+   * Redis command <a href="https://redis.io/commands/json.toggle/">JSON.TOGGLE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonToggle(List<String> args) {
     return send(Command.JSON_TOGGLE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/json.type">jsonType</a>.
+   * Redis command <a href="https://redis.io/commands/json.type/">JSON.TYPE</a>.
    * @return fluent self
    */
   @Fluent
@@ -3237,14 +3424,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/json.type">jsonType</a>.
+   * Redis command <a href="https://redis.io/commands/json.type/">JSON.TYPE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> jsonType(List<String> args) {
     return send(Command.JSON_TYPE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/keys">keys</a>.
+   * Redis command <a href="https://redis.io/commands/keys/">KEYS</a>.
    * @return fluent self
    */
   @Fluent
@@ -3254,14 +3442,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/keys">keys</a>.
+   * Redis command <a href="https://redis.io/commands/keys/">KEYS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> keys(String arg0) {
     return send(Command.KEYS, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/lastsave">lastsave</a>.
+   * Redis command <a href="https://redis.io/commands/lastsave/">LASTSAVE</a>.
    * @return fluent self
    */
   @Fluent
@@ -3271,14 +3460,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/lastsave">lastsave</a>.
+   * Redis command <a href="https://redis.io/commands/lastsave/">LASTSAVE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> lastsave() {
     return send(Command.LASTSAVE);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/latency">latency</a>.
+   * Redis command <a href="https://redis.io/commands/latency/">LATENCY</a>.
    * @return fluent self
    */
   @Fluent
@@ -3288,14 +3478,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/latency">latency</a>.
+   * Redis command <a href="https://redis.io/commands/latency/">LATENCY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> latency(List<String> args) {
     return send(Command.LATENCY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/lcs">lcs</a>.
+   * Redis command <a href="https://redis.io/commands/lcs/">LCS</a>.
    * @return fluent self
    */
   @Fluent
@@ -3305,14 +3496,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/lcs">lcs</a>.
+   * Redis command <a href="https://redis.io/commands/lcs/">LCS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> lcs(List<String> args) {
     return send(Command.LCS, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/lindex">lindex</a>.
+   * Redis command <a href="https://redis.io/commands/lindex/">LINDEX</a>.
    * @return fluent self
    */
   @Fluent
@@ -3322,14 +3514,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/lindex">lindex</a>.
+   * Redis command <a href="https://redis.io/commands/lindex/">LINDEX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> lindex(String arg0, String arg1) {
     return send(Command.LINDEX, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/linsert">linsert</a>.
+   * Redis command <a href="https://redis.io/commands/linsert/">LINSERT</a>.
    * @return fluent self
    */
   @Fluent
@@ -3339,14 +3532,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/linsert">linsert</a>.
+   * Redis command <a href="https://redis.io/commands/linsert/">LINSERT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> linsert(String arg0, String arg1, String arg2, String arg3) {
     return send(Command.LINSERT, arg0, arg1, arg2, arg3);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/llen">llen</a>.
+   * Redis command <a href="https://redis.io/commands/llen/">LLEN</a>.
    * @return fluent self
    */
   @Fluent
@@ -3356,14 +3550,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/llen">llen</a>.
+   * Redis command <a href="https://redis.io/commands/llen/">LLEN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> llen(String arg0) {
     return send(Command.LLEN, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/lmove">lmove</a>.
+   * Redis command <a href="https://redis.io/commands/lmove/">LMOVE</a>.
    * @return fluent self
    */
   @Fluent
@@ -3373,14 +3568,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/lmove">lmove</a>.
+   * Redis command <a href="https://redis.io/commands/lmove/">LMOVE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> lmove(String arg0, String arg1, String arg2, String arg3) {
     return send(Command.LMOVE, arg0, arg1, arg2, arg3);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/lmpop">lmpop</a>.
+   * Redis command <a href="https://redis.io/commands/lmpop/">LMPOP</a>.
    * @return fluent self
    */
   @Fluent
@@ -3390,14 +3586,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/lmpop">lmpop</a>.
+   * Redis command <a href="https://redis.io/commands/lmpop/">LMPOP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> lmpop(List<String> args) {
     return send(Command.LMPOP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/lolwut">lolwut</a>.
+   * Redis command <a href="https://redis.io/commands/lolwut/">LOLWUT</a>.
    * @return fluent self
    */
   @Fluent
@@ -3407,14 +3604,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/lolwut">lolwut</a>.
+   * Redis command <a href="https://redis.io/commands/lolwut/">LOLWUT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> lolwut(List<String> args) {
     return send(Command.LOLWUT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/lpop">lpop</a>.
+   * Redis command <a href="https://redis.io/commands/lpop/">LPOP</a>.
    * @return fluent self
    */
   @Fluent
@@ -3424,14 +3622,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/lpop">lpop</a>.
+   * Redis command <a href="https://redis.io/commands/lpop/">LPOP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> lpop(List<String> args) {
     return send(Command.LPOP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/lpos">lpos</a>.
+   * Redis command <a href="https://redis.io/commands/lpos/">LPOS</a>.
    * @return fluent self
    */
   @Fluent
@@ -3441,14 +3640,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/lpos">lpos</a>.
+   * Redis command <a href="https://redis.io/commands/lpos/">LPOS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> lpos(List<String> args) {
     return send(Command.LPOS, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/lpush">lpush</a>.
+   * Redis command <a href="https://redis.io/commands/lpush/">LPUSH</a>.
    * @return fluent self
    */
   @Fluent
@@ -3458,14 +3658,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/lpush">lpush</a>.
+   * Redis command <a href="https://redis.io/commands/lpush/">LPUSH</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> lpush(List<String> args) {
     return send(Command.LPUSH, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/lpushx">lpushx</a>.
+   * Redis command <a href="https://redis.io/commands/lpushx/">LPUSHX</a>.
    * @return fluent self
    */
   @Fluent
@@ -3475,14 +3676,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/lpushx">lpushx</a>.
+   * Redis command <a href="https://redis.io/commands/lpushx/">LPUSHX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> lpushx(List<String> args) {
     return send(Command.LPUSHX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/lrange">lrange</a>.
+   * Redis command <a href="https://redis.io/commands/lrange/">LRANGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -3492,14 +3694,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/lrange">lrange</a>.
+   * Redis command <a href="https://redis.io/commands/lrange/">LRANGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> lrange(String arg0, String arg1, String arg2) {
     return send(Command.LRANGE, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/lrem">lrem</a>.
+   * Redis command <a href="https://redis.io/commands/lrem/">LREM</a>.
    * @return fluent self
    */
   @Fluent
@@ -3509,14 +3712,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/lrem">lrem</a>.
+   * Redis command <a href="https://redis.io/commands/lrem/">LREM</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> lrem(String arg0, String arg1, String arg2) {
     return send(Command.LREM, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/lset">lset</a>.
+   * Redis command <a href="https://redis.io/commands/lset/">LSET</a>.
    * @return fluent self
    */
   @Fluent
@@ -3526,14 +3730,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/lset">lset</a>.
+   * Redis command <a href="https://redis.io/commands/lset/">LSET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> lset(String arg0, String arg1, String arg2) {
     return send(Command.LSET, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ltrim">ltrim</a>.
+   * Redis command <a href="https://redis.io/commands/ltrim/">LTRIM</a>.
    * @return fluent self
    */
   @Fluent
@@ -3543,14 +3748,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ltrim">ltrim</a>.
+   * Redis command <a href="https://redis.io/commands/ltrim/">LTRIM</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ltrim(String arg0, String arg1, String arg2) {
     return send(Command.LTRIM, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/memory">memory</a>.
+   * Redis command <a href="https://redis.io/commands/memory/">MEMORY</a>.
    * @return fluent self
    */
   @Fluent
@@ -3560,14 +3766,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/memory">memory</a>.
+   * Redis command <a href="https://redis.io/commands/memory/">MEMORY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> memory(List<String> args) {
     return send(Command.MEMORY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/mget">mget</a>.
+   * Redis command <a href="https://redis.io/commands/mget/">MGET</a>.
    * @return fluent self
    */
   @Fluent
@@ -3577,14 +3784,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/mget">mget</a>.
+   * Redis command <a href="https://redis.io/commands/mget/">MGET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> mget(List<String> args) {
     return send(Command.MGET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/migrate">migrate</a>.
+   * Redis command <a href="https://redis.io/commands/migrate/">MIGRATE</a>.
    * @return fluent self
    */
   @Fluent
@@ -3594,14 +3802,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/migrate">migrate</a>.
+   * Redis command <a href="https://redis.io/commands/migrate/">MIGRATE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> migrate(List<String> args) {
     return send(Command.MIGRATE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/module">module</a>.
+   * Redis command <a href="https://redis.io/commands/module/">MODULE</a>.
    * @return fluent self
    */
   @Fluent
@@ -3611,14 +3820,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/module">module</a>.
+   * Redis command <a href="https://redis.io/commands/module/">MODULE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> module(List<String> args) {
     return send(Command.MODULE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/monitor">monitor</a>.
+   * Redis command <a href="https://redis.io/commands/monitor/">MONITOR</a>.
    * @return fluent self
    */
   @Fluent
@@ -3628,14 +3838,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/monitor">monitor</a>.
+   * Redis command <a href="https://redis.io/commands/monitor/">MONITOR</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> monitor() {
     return send(Command.MONITOR);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/move">move</a>.
+   * Redis command <a href="https://redis.io/commands/move/">MOVE</a>.
    * @return fluent self
    */
   @Fluent
@@ -3645,14 +3856,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/move">move</a>.
+   * Redis command <a href="https://redis.io/commands/move/">MOVE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> move(String arg0, String arg1) {
     return send(Command.MOVE, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/mset">mset</a>.
+   * Redis command <a href="https://redis.io/commands/mset/">MSET</a>.
    * @return fluent self
    */
   @Fluent
@@ -3662,14 +3874,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/mset">mset</a>.
+   * Redis command <a href="https://redis.io/commands/mset/">MSET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> mset(List<String> args) {
     return send(Command.MSET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/msetnx">msetnx</a>.
+   * Redis command <a href="https://redis.io/commands/msetnx/">MSETNX</a>.
    * @return fluent self
    */
   @Fluent
@@ -3679,14 +3892,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/msetnx">msetnx</a>.
+   * Redis command <a href="https://redis.io/commands/msetnx/">MSETNX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> msetnx(List<String> args) {
     return send(Command.MSETNX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/multi">multi</a>.
+   * Redis command <a href="https://redis.io/commands/multi/">MULTI</a>.
    * @return fluent self
    */
   @Fluent
@@ -3696,14 +3910,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/multi">multi</a>.
+   * Redis command <a href="https://redis.io/commands/multi/">MULTI</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> multi() {
     return send(Command.MULTI);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/object">object</a>.
+   * Redis command <a href="https://redis.io/commands/object/">OBJECT</a>.
    * @return fluent self
    */
   @Fluent
@@ -3713,14 +3928,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/object">object</a>.
+   * Redis command <a href="https://redis.io/commands/object/">OBJECT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> object(List<String> args) {
     return send(Command.OBJECT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/persist">persist</a>.
+   * Redis command <a href="https://redis.io/commands/persist/">PERSIST</a>.
    * @return fluent self
    */
   @Fluent
@@ -3730,14 +3946,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/persist">persist</a>.
+   * Redis command <a href="https://redis.io/commands/persist/">PERSIST</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> persist(String arg0) {
     return send(Command.PERSIST, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/pexpire">pexpire</a>.
+   * Redis command <a href="https://redis.io/commands/pexpire/">PEXPIRE</a>.
    * @return fluent self
    */
   @Fluent
@@ -3747,14 +3964,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/pexpire">pexpire</a>.
+   * Redis command <a href="https://redis.io/commands/pexpire/">PEXPIRE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> pexpire(List<String> args) {
     return send(Command.PEXPIRE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/pexpireat">pexpireat</a>.
+   * Redis command <a href="https://redis.io/commands/pexpireat/">PEXPIREAT</a>.
    * @return fluent self
    */
   @Fluent
@@ -3764,14 +3982,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/pexpireat">pexpireat</a>.
+   * Redis command <a href="https://redis.io/commands/pexpireat/">PEXPIREAT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> pexpireat(List<String> args) {
     return send(Command.PEXPIREAT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/pexpiretime">pexpiretime</a>.
+   * Redis command <a href="https://redis.io/commands/pexpiretime/">PEXPIRETIME</a>.
    * @return fluent self
    */
   @Fluent
@@ -3781,14 +4000,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/pexpiretime">pexpiretime</a>.
+   * Redis command <a href="https://redis.io/commands/pexpiretime/">PEXPIRETIME</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> pexpiretime(String arg0) {
     return send(Command.PEXPIRETIME, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/pfadd">pfadd</a>.
+   * Redis command <a href="https://redis.io/commands/pfadd/">PFADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -3798,14 +4018,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/pfadd">pfadd</a>.
+   * Redis command <a href="https://redis.io/commands/pfadd/">PFADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> pfadd(List<String> args) {
     return send(Command.PFADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/pfcount">pfcount</a>.
+   * Redis command <a href="https://redis.io/commands/pfcount/">PFCOUNT</a>.
    * @return fluent self
    */
   @Fluent
@@ -3815,31 +4036,33 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/pfcount">pfcount</a>.
+   * Redis command <a href="https://redis.io/commands/pfcount/">PFCOUNT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> pfcount(List<String> args) {
     return send(Command.PFCOUNT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/pfdebug">pfdebug</a>.
+   * Redis command <a href="https://redis.io/commands/pfdebug/">PFDEBUG</a>.
    * @return fluent self
    */
   @Fluent
-  default RedisAPI pfdebug(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
-    send(Command.PFDEBUG, args.toArray(new String[0])).onComplete(handler);
+  default RedisAPI pfdebug(String arg0, String arg1, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.PFDEBUG, arg0, arg1).onComplete(handler);
     return this;
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/pfdebug">pfdebug</a>.
+   * Redis command <a href="https://redis.io/commands/pfdebug/">PFDEBUG</a>.
    * @return Future response.
    */
-  default Future<@Nullable Response> pfdebug(List<String> args) {
-    return send(Command.PFDEBUG, args.toArray(new String[0]));
+  default Future<@Nullable Response> pfdebug(String arg0, String arg1) {
+    return send(Command.PFDEBUG, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/pfmerge">pfmerge</a>.
+   * Redis command <a href="https://redis.io/commands/pfmerge/">PFMERGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -3849,14 +4072,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/pfmerge">pfmerge</a>.
+   * Redis command <a href="https://redis.io/commands/pfmerge/">PFMERGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> pfmerge(List<String> args) {
     return send(Command.PFMERGE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/pfselftest">pfselftest</a>.
+   * Redis command <a href="https://redis.io/commands/pfselftest/">PFSELFTEST</a>.
    * @return fluent self
    */
   @Fluent
@@ -3866,14 +4090,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/pfselftest">pfselftest</a>.
+   * Redis command <a href="https://redis.io/commands/pfselftest/">PFSELFTEST</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> pfselftest() {
     return send(Command.PFSELFTEST);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ping">ping</a>.
+   * Redis command <a href="https://redis.io/commands/ping/">PING</a>.
    * @return fluent self
    */
   @Fluent
@@ -3883,14 +4108,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ping">ping</a>.
+   * Redis command <a href="https://redis.io/commands/ping/">PING</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ping(List<String> args) {
     return send(Command.PING, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/psetex">psetex</a>.
+   * Redis command <a href="https://redis.io/commands/psetex/">PSETEX</a>.
    * @return fluent self
    */
   @Fluent
@@ -3900,14 +4126,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/psetex">psetex</a>.
+   * Redis command <a href="https://redis.io/commands/psetex/">PSETEX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> psetex(String arg0, String arg1, String arg2) {
     return send(Command.PSETEX, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/psubscribe">psubscribe</a>.
+   * Redis command <a href="https://redis.io/commands/psubscribe/">PSUBSCRIBE</a>.
    * @return fluent self
    */
   @Fluent
@@ -3917,14 +4144,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/psubscribe">psubscribe</a>.
+   * Redis command <a href="https://redis.io/commands/psubscribe/">PSUBSCRIBE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> psubscribe(List<String> args) {
     return send(Command.PSUBSCRIBE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/psync">psync</a>.
+   * Redis command <a href="https://redis.io/commands/psync/">PSYNC</a>.
    * @return fluent self
    */
   @Fluent
@@ -3934,14 +4162,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/psync">psync</a>.
+   * Redis command <a href="https://redis.io/commands/psync/">PSYNC</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> psync(List<String> args) {
     return send(Command.PSYNC, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/pttl">pttl</a>.
+   * Redis command <a href="https://redis.io/commands/pttl/">PTTL</a>.
    * @return fluent self
    */
   @Fluent
@@ -3951,14 +4180,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/pttl">pttl</a>.
+   * Redis command <a href="https://redis.io/commands/pttl/">PTTL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> pttl(String arg0) {
     return send(Command.PTTL, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/publish">publish</a>.
+   * Redis command <a href="https://redis.io/commands/publish/">PUBLISH</a>.
    * @return fluent self
    */
   @Fluent
@@ -3968,14 +4198,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/publish">publish</a>.
+   * Redis command <a href="https://redis.io/commands/publish/">PUBLISH</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> publish(String arg0, String arg1) {
     return send(Command.PUBLISH, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/pubsub">pubsub</a>.
+   * Redis command <a href="https://redis.io/commands/pubsub/">PUBSUB</a>.
    * @return fluent self
    */
   @Fluent
@@ -3985,14 +4216,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/pubsub">pubsub</a>.
+   * Redis command <a href="https://redis.io/commands/pubsub/">PUBSUB</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> pubsub(List<String> args) {
     return send(Command.PUBSUB, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/punsubscribe">punsubscribe</a>.
+   * Redis command <a href="https://redis.io/commands/punsubscribe/">PUNSUBSCRIBE</a>.
    * @return fluent self
    */
   @Fluent
@@ -4002,14 +4234,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/punsubscribe">punsubscribe</a>.
+   * Redis command <a href="https://redis.io/commands/punsubscribe/">PUNSUBSCRIBE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> punsubscribe(List<String> args) {
     return send(Command.PUNSUBSCRIBE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/quit">quit</a>.
+   * Redis command <a href="https://redis.io/commands/quit/">QUIT</a>.
    * @return fluent self
    */
   @Fluent
@@ -4019,14 +4252,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/quit">quit</a>.
+   * Redis command <a href="https://redis.io/commands/quit/">QUIT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> quit(List<String> args) {
     return send(Command.QUIT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/randomkey">randomkey</a>.
+   * Redis command <a href="https://redis.io/commands/randomkey/">RANDOMKEY</a>.
    * @return fluent self
    */
   @Fluent
@@ -4036,14 +4270,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/randomkey">randomkey</a>.
+   * Redis command <a href="https://redis.io/commands/randomkey/">RANDOMKEY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> randomkey() {
     return send(Command.RANDOMKEY);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/readonly">readonly</a>.
+   * Redis command <a href="https://redis.io/commands/readonly/">READONLY</a>.
    * @return fluent self
    */
   @Fluent
@@ -4053,14 +4288,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/readonly">readonly</a>.
+   * Redis command <a href="https://redis.io/commands/readonly/">READONLY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> readonly() {
     return send(Command.READONLY);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/readwrite">readwrite</a>.
+   * Redis command <a href="https://redis.io/commands/readwrite/">READWRITE</a>.
    * @return fluent self
    */
   @Fluent
@@ -4070,14 +4306,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/readwrite">readwrite</a>.
+   * Redis command <a href="https://redis.io/commands/readwrite/">READWRITE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> readwrite() {
     return send(Command.READWRITE);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/rename">rename</a>.
+   * Redis command <a href="https://redis.io/commands/rename/">RENAME</a>.
    * @return fluent self
    */
   @Fluent
@@ -4087,14 +4324,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/rename">rename</a>.
+   * Redis command <a href="https://redis.io/commands/rename/">RENAME</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> rename(String arg0, String arg1) {
     return send(Command.RENAME, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/renamenx">renamenx</a>.
+   * Redis command <a href="https://redis.io/commands/renamenx/">RENAMENX</a>.
    * @return fluent self
    */
   @Fluent
@@ -4104,14 +4342,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/renamenx">renamenx</a>.
+   * Redis command <a href="https://redis.io/commands/renamenx/">RENAMENX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> renamenx(String arg0, String arg1) {
     return send(Command.RENAMENX, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/replconf">replconf</a>.
+   * Redis command <a href="https://redis.io/commands/replconf/">REPLCONF</a>.
    * @return fluent self
    */
   @Fluent
@@ -4121,14 +4360,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/replconf">replconf</a>.
+   * Redis command <a href="https://redis.io/commands/replconf/">REPLCONF</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> replconf(List<String> args) {
     return send(Command.REPLCONF, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/replicaof">replicaof</a>.
+   * Redis command <a href="https://redis.io/commands/replicaof/">REPLICAOF</a>.
    * @return fluent self
    */
   @Fluent
@@ -4138,14 +4378,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/replicaof">replicaof</a>.
+   * Redis command <a href="https://redis.io/commands/replicaof/">REPLICAOF</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> replicaof(String arg0, String arg1) {
     return send(Command.REPLICAOF, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/reset">reset</a>.
+   * Redis command <a href="https://redis.io/commands/reset/">RESET</a>.
    * @return fluent self
    */
   @Fluent
@@ -4155,14 +4396,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/reset">reset</a>.
+   * Redis command <a href="https://redis.io/commands/reset/">RESET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> reset() {
     return send(Command.RESET);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/restore">restore</a>.
+   * Redis command <a href="https://redis.io/commands/restore/">RESTORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -4172,14 +4414,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/restore">restore</a>.
+   * Redis command <a href="https://redis.io/commands/restore/">RESTORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> restore(List<String> args) {
     return send(Command.RESTORE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/restore-asking">restoreAsking</a>.
+   * Redis command <a href="https://redis.io/commands/restore asking/">RESTORE-ASKING</a>.
    * @return fluent self
    */
   @Fluent
@@ -4189,14 +4432,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/restore-asking">restoreAsking</a>.
+   * Redis command <a href="https://redis.io/commands/restore asking/">RESTORE-ASKING</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> restoreAsking(List<String> args) {
     return send(Command.RESTORE_ASKING, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/role">role</a>.
+   * Redis command <a href="https://redis.io/commands/role/">ROLE</a>.
    * @return fluent self
    */
   @Fluent
@@ -4206,14 +4450,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/role">role</a>.
+   * Redis command <a href="https://redis.io/commands/role/">ROLE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> role() {
     return send(Command.ROLE);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/rpop">rpop</a>.
+   * Redis command <a href="https://redis.io/commands/rpop/">RPOP</a>.
    * @return fluent self
    */
   @Fluent
@@ -4223,14 +4468,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/rpop">rpop</a>.
+   * Redis command <a href="https://redis.io/commands/rpop/">RPOP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> rpop(List<String> args) {
     return send(Command.RPOP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/rpoplpush">rpoplpush</a>.
+   * Redis command <a href="https://redis.io/commands/rpoplpush/">RPOPLPUSH</a>.
    * @return fluent self
    */
   @Fluent
@@ -4240,14 +4486,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/rpoplpush">rpoplpush</a>.
+   * Redis command <a href="https://redis.io/commands/rpoplpush/">RPOPLPUSH</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> rpoplpush(String arg0, String arg1) {
     return send(Command.RPOPLPUSH, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/rpush">rpush</a>.
+   * Redis command <a href="https://redis.io/commands/rpush/">RPUSH</a>.
    * @return fluent self
    */
   @Fluent
@@ -4257,14 +4504,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/rpush">rpush</a>.
+   * Redis command <a href="https://redis.io/commands/rpush/">RPUSH</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> rpush(List<String> args) {
     return send(Command.RPUSH, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/rpushx">rpushx</a>.
+   * Redis command <a href="https://redis.io/commands/rpushx/">RPUSHX</a>.
    * @return fluent self
    */
   @Fluent
@@ -4274,14 +4522,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/rpushx">rpushx</a>.
+   * Redis command <a href="https://redis.io/commands/rpushx/">RPUSHX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> rpushx(List<String> args) {
     return send(Command.RPUSHX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sadd">sadd</a>.
+   * Redis command <a href="https://redis.io/commands/sadd/">SADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -4291,14 +4540,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sadd">sadd</a>.
+   * Redis command <a href="https://redis.io/commands/sadd/">SADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sadd(List<String> args) {
     return send(Command.SADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/save">save</a>.
+   * Redis command <a href="https://redis.io/commands/save/">SAVE</a>.
    * @return fluent self
    */
   @Fluent
@@ -4308,14 +4558,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/save">save</a>.
+   * Redis command <a href="https://redis.io/commands/save/">SAVE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> save() {
     return send(Command.SAVE);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/scan">scan</a>.
+   * Redis command <a href="https://redis.io/commands/scan/">SCAN</a>.
    * @return fluent self
    */
   @Fluent
@@ -4325,14 +4576,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/scan">scan</a>.
+   * Redis command <a href="https://redis.io/commands/scan/">SCAN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> scan(List<String> args) {
     return send(Command.SCAN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/scard">scard</a>.
+   * Redis command <a href="https://redis.io/commands/scard/">SCARD</a>.
    * @return fluent self
    */
   @Fluent
@@ -4342,14 +4594,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/scard">scard</a>.
+   * Redis command <a href="https://redis.io/commands/scard/">SCARD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> scard(String arg0) {
     return send(Command.SCARD, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/script">script</a>.
+   * Redis command <a href="https://redis.io/commands/script/">SCRIPT</a>.
    * @return fluent self
    */
   @Fluent
@@ -4359,14 +4612,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/script">script</a>.
+   * Redis command <a href="https://redis.io/commands/script/">SCRIPT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> script(List<String> args) {
     return send(Command.SCRIPT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sdiff">sdiff</a>.
+   * Redis command <a href="https://redis.io/commands/sdiff/">SDIFF</a>.
    * @return fluent self
    */
   @Fluent
@@ -4376,14 +4630,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sdiff">sdiff</a>.
+   * Redis command <a href="https://redis.io/commands/sdiff/">SDIFF</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sdiff(List<String> args) {
     return send(Command.SDIFF, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sdiffstore">sdiffstore</a>.
+   * Redis command <a href="https://redis.io/commands/sdiffstore/">SDIFFSTORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -4393,14 +4648,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sdiffstore">sdiffstore</a>.
+   * Redis command <a href="https://redis.io/commands/sdiffstore/">SDIFFSTORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sdiffstore(List<String> args) {
     return send(Command.SDIFFSTORE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/select">select</a>.
+   * Redis command <a href="https://redis.io/commands/select/">SELECT</a>.
    * @return fluent self
    */
   @Fluent
@@ -4410,14 +4666,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/select">select</a>.
+   * Redis command <a href="https://redis.io/commands/select/">SELECT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> select(String arg0) {
     return send(Command.SELECT, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/set">set</a>.
+   * Redis command <a href="https://redis.io/commands/set/">SET</a>.
    * @return fluent self
    */
   @Fluent
@@ -4427,14 +4684,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/set">set</a>.
+   * Redis command <a href="https://redis.io/commands/set/">SET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> set(List<String> args) {
     return send(Command.SET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/setbit">setbit</a>.
+   * Redis command <a href="https://redis.io/commands/setbit/">SETBIT</a>.
    * @return fluent self
    */
   @Fluent
@@ -4444,14 +4702,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/setbit">setbit</a>.
+   * Redis command <a href="https://redis.io/commands/setbit/">SETBIT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> setbit(String arg0, String arg1, String arg2) {
     return send(Command.SETBIT, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/setex">setex</a>.
+   * Redis command <a href="https://redis.io/commands/setex/">SETEX</a>.
    * @return fluent self
    */
   @Fluent
@@ -4461,14 +4720,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/setex">setex</a>.
+   * Redis command <a href="https://redis.io/commands/setex/">SETEX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> setex(String arg0, String arg1, String arg2) {
     return send(Command.SETEX, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/setnx">setnx</a>.
+   * Redis command <a href="https://redis.io/commands/setnx/">SETNX</a>.
    * @return fluent self
    */
   @Fluent
@@ -4478,14 +4738,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/setnx">setnx</a>.
+   * Redis command <a href="https://redis.io/commands/setnx/">SETNX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> setnx(String arg0, String arg1) {
     return send(Command.SETNX, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/setrange">setrange</a>.
+   * Redis command <a href="https://redis.io/commands/setrange/">SETRANGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -4495,14 +4756,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/setrange">setrange</a>.
+   * Redis command <a href="https://redis.io/commands/setrange/">SETRANGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> setrange(String arg0, String arg1, String arg2) {
     return send(Command.SETRANGE, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/shutdown">shutdown</a>.
+   * Redis command <a href="https://redis.io/commands/shutdown/">SHUTDOWN</a>.
    * @return fluent self
    */
   @Fluent
@@ -4512,14 +4774,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/shutdown">shutdown</a>.
+   * Redis command <a href="https://redis.io/commands/shutdown/">SHUTDOWN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> shutdown(List<String> args) {
     return send(Command.SHUTDOWN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sinter">sinter</a>.
+   * Redis command <a href="https://redis.io/commands/sinter/">SINTER</a>.
    * @return fluent self
    */
   @Fluent
@@ -4529,14 +4792,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sinter">sinter</a>.
+   * Redis command <a href="https://redis.io/commands/sinter/">SINTER</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sinter(List<String> args) {
     return send(Command.SINTER, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sintercard">sintercard</a>.
+   * Redis command <a href="https://redis.io/commands/sintercard/">SINTERCARD</a>.
    * @return fluent self
    */
   @Fluent
@@ -4546,14 +4810,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sintercard">sintercard</a>.
+   * Redis command <a href="https://redis.io/commands/sintercard/">SINTERCARD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sintercard(List<String> args) {
     return send(Command.SINTERCARD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sinterstore">sinterstore</a>.
+   * Redis command <a href="https://redis.io/commands/sinterstore/">SINTERSTORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -4563,14 +4828,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sinterstore">sinterstore</a>.
+   * Redis command <a href="https://redis.io/commands/sinterstore/">SINTERSTORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sinterstore(List<String> args) {
     return send(Command.SINTERSTORE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sismember">sismember</a>.
+   * Redis command <a href="https://redis.io/commands/sismember/">SISMEMBER</a>.
    * @return fluent self
    */
   @Fluent
@@ -4580,14 +4846,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sismember">sismember</a>.
+   * Redis command <a href="https://redis.io/commands/sismember/">SISMEMBER</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sismember(String arg0, String arg1) {
     return send(Command.SISMEMBER, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/slaveof">slaveof</a>.
+   * Redis command <a href="https://redis.io/commands/slaveof/">SLAVEOF</a>.
    * @return fluent self
    */
   @Fluent
@@ -4597,14 +4864,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/slaveof">slaveof</a>.
+   * Redis command <a href="https://redis.io/commands/slaveof/">SLAVEOF</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> slaveof(String arg0, String arg1) {
     return send(Command.SLAVEOF, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/slowlog">slowlog</a>.
+   * Redis command <a href="https://redis.io/commands/slowlog/">SLOWLOG</a>.
    * @return fluent self
    */
   @Fluent
@@ -4614,14 +4882,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/slowlog">slowlog</a>.
+   * Redis command <a href="https://redis.io/commands/slowlog/">SLOWLOG</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> slowlog(List<String> args) {
     return send(Command.SLOWLOG, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/smembers">smembers</a>.
+   * Redis command <a href="https://redis.io/commands/smembers/">SMEMBERS</a>.
    * @return fluent self
    */
   @Fluent
@@ -4631,14 +4900,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/smembers">smembers</a>.
+   * Redis command <a href="https://redis.io/commands/smembers/">SMEMBERS</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> smembers(String arg0) {
     return send(Command.SMEMBERS, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/smismember">smismember</a>.
+   * Redis command <a href="https://redis.io/commands/smismember/">SMISMEMBER</a>.
    * @return fluent self
    */
   @Fluent
@@ -4648,14 +4918,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/smismember">smismember</a>.
+   * Redis command <a href="https://redis.io/commands/smismember/">SMISMEMBER</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> smismember(List<String> args) {
     return send(Command.SMISMEMBER, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/smove">smove</a>.
+   * Redis command <a href="https://redis.io/commands/smove/">SMOVE</a>.
    * @return fluent self
    */
   @Fluent
@@ -4665,14 +4936,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/smove">smove</a>.
+   * Redis command <a href="https://redis.io/commands/smove/">SMOVE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> smove(String arg0, String arg1, String arg2) {
     return send(Command.SMOVE, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sort">sort</a>.
+   * Redis command <a href="https://redis.io/commands/sort/">SORT</a>.
    * @return fluent self
    */
   @Fluent
@@ -4682,14 +4954,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sort">sort</a>.
+   * Redis command <a href="https://redis.io/commands/sort/">SORT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sort(List<String> args) {
     return send(Command.SORT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sort_ro">sortRo</a>.
+   * Redis command <a href="https://redis.io/commands/sort_ro/">SORT_RO</a>.
    * @return fluent self
    */
   @Fluent
@@ -4699,14 +4972,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sort_ro">sortRo</a>.
+   * Redis command <a href="https://redis.io/commands/sort_ro/">SORT_RO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sortRo(List<String> args) {
     return send(Command.SORT_RO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/spop">spop</a>.
+   * Redis command <a href="https://redis.io/commands/spop/">SPOP</a>.
    * @return fluent self
    */
   @Fluent
@@ -4716,14 +4990,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/spop">spop</a>.
+   * Redis command <a href="https://redis.io/commands/spop/">SPOP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> spop(List<String> args) {
     return send(Command.SPOP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/spublish">spublish</a>.
+   * Redis command <a href="https://redis.io/commands/spublish/">SPUBLISH</a>.
    * @return fluent self
    */
   @Fluent
@@ -4733,14 +5008,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/spublish">spublish</a>.
+   * Redis command <a href="https://redis.io/commands/spublish/">SPUBLISH</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> spublish(String arg0, String arg1) {
     return send(Command.SPUBLISH, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/srandmember">srandmember</a>.
+   * Redis command <a href="https://redis.io/commands/srandmember/">SRANDMEMBER</a>.
    * @return fluent self
    */
   @Fluent
@@ -4750,14 +5026,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/srandmember">srandmember</a>.
+   * Redis command <a href="https://redis.io/commands/srandmember/">SRANDMEMBER</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> srandmember(List<String> args) {
     return send(Command.SRANDMEMBER, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/srem">srem</a>.
+   * Redis command <a href="https://redis.io/commands/srem/">SREM</a>.
    * @return fluent self
    */
   @Fluent
@@ -4767,14 +5044,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/srem">srem</a>.
+   * Redis command <a href="https://redis.io/commands/srem/">SREM</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> srem(List<String> args) {
     return send(Command.SREM, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sscan">sscan</a>.
+   * Redis command <a href="https://redis.io/commands/sscan/">SSCAN</a>.
    * @return fluent self
    */
   @Fluent
@@ -4784,14 +5062,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sscan">sscan</a>.
+   * Redis command <a href="https://redis.io/commands/sscan/">SSCAN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sscan(List<String> args) {
     return send(Command.SSCAN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ssubscribe">ssubscribe</a>.
+   * Redis command <a href="https://redis.io/commands/ssubscribe/">SSUBSCRIBE</a>.
    * @return fluent self
    */
   @Fluent
@@ -4801,14 +5080,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ssubscribe">ssubscribe</a>.
+   * Redis command <a href="https://redis.io/commands/ssubscribe/">SSUBSCRIBE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ssubscribe(List<String> args) {
     return send(Command.SSUBSCRIBE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/strlen">strlen</a>.
+   * Redis command <a href="https://redis.io/commands/strlen/">STRLEN</a>.
    * @return fluent self
    */
   @Fluent
@@ -4818,14 +5098,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/strlen">strlen</a>.
+   * Redis command <a href="https://redis.io/commands/strlen/">STRLEN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> strlen(String arg0) {
     return send(Command.STRLEN, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/subscribe">subscribe</a>.
+   * Redis command <a href="https://redis.io/commands/subscribe/">SUBSCRIBE</a>.
    * @return fluent self
    */
   @Fluent
@@ -4835,14 +5116,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/subscribe">subscribe</a>.
+   * Redis command <a href="https://redis.io/commands/subscribe/">SUBSCRIBE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> subscribe(List<String> args) {
     return send(Command.SUBSCRIBE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/substr">substr</a>.
+   * Redis command <a href="https://redis.io/commands/substr/">SUBSTR</a>.
    * @return fluent self
    */
   @Fluent
@@ -4852,14 +5134,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/substr">substr</a>.
+   * Redis command <a href="https://redis.io/commands/substr/">SUBSTR</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> substr(String arg0, String arg1, String arg2) {
     return send(Command.SUBSTR, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sunion">sunion</a>.
+   * Redis command <a href="https://redis.io/commands/sunion/">SUNION</a>.
    * @return fluent self
    */
   @Fluent
@@ -4869,14 +5152,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sunion">sunion</a>.
+   * Redis command <a href="https://redis.io/commands/sunion/">SUNION</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sunion(List<String> args) {
     return send(Command.SUNION, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sunionstore">sunionstore</a>.
+   * Redis command <a href="https://redis.io/commands/sunionstore/">SUNIONSTORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -4886,14 +5170,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sunionstore">sunionstore</a>.
+   * Redis command <a href="https://redis.io/commands/sunionstore/">SUNIONSTORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sunionstore(List<String> args) {
     return send(Command.SUNIONSTORE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sunsubscribe">sunsubscribe</a>.
+   * Redis command <a href="https://redis.io/commands/sunsubscribe/">SUNSUBSCRIBE</a>.
    * @return fluent self
    */
   @Fluent
@@ -4903,14 +5188,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sunsubscribe">sunsubscribe</a>.
+   * Redis command <a href="https://redis.io/commands/sunsubscribe/">SUNSUBSCRIBE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sunsubscribe(List<String> args) {
     return send(Command.SUNSUBSCRIBE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/swapdb">swapdb</a>.
+   * Redis command <a href="https://redis.io/commands/swapdb/">SWAPDB</a>.
    * @return fluent self
    */
   @Fluent
@@ -4920,14 +5206,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/swapdb">swapdb</a>.
+   * Redis command <a href="https://redis.io/commands/swapdb/">SWAPDB</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> swapdb(String arg0, String arg1) {
     return send(Command.SWAPDB, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/sync">sync</a>.
+   * Redis command <a href="https://redis.io/commands/sync/">SYNC</a>.
    * @return fluent self
    */
   @Fluent
@@ -4937,14 +5224,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/sync">sync</a>.
+   * Redis command <a href="https://redis.io/commands/sync/">SYNC</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> sync() {
     return send(Command.SYNC);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.add">tdigestAdd</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.add/">TDIGEST.ADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -4954,14 +5242,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.add">tdigestAdd</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.add/">TDIGEST.ADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestAdd(List<String> args) {
     return send(Command.TDIGEST_ADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.byrank">tdigestByrank</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.byrank/">TDIGEST.BYRANK</a>.
    * @return fluent self
    */
   @Fluent
@@ -4971,14 +5260,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.byrank">tdigestByrank</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.byrank/">TDIGEST.BYRANK</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestByrank(List<String> args) {
     return send(Command.TDIGEST_BYRANK, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.byrevrank">tdigestByrevrank</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.byrevrank/">TDIGEST.BYREVRANK</a>.
    * @return fluent self
    */
   @Fluent
@@ -4988,14 +5278,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.byrevrank">tdigestByrevrank</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.byrevrank/">TDIGEST.BYREVRANK</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestByrevrank(List<String> args) {
     return send(Command.TDIGEST_BYREVRANK, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.cdf">tdigestCdf</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.cdf/">TDIGEST.CDF</a>.
    * @return fluent self
    */
   @Fluent
@@ -5005,14 +5296,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.cdf">tdigestCdf</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.cdf/">TDIGEST.CDF</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestCdf(List<String> args) {
     return send(Command.TDIGEST_CDF, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.create">tdigestCreate</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.create/">TDIGEST.CREATE</a>.
    * @return fluent self
    */
   @Fluent
@@ -5022,14 +5314,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.create">tdigestCreate</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.create/">TDIGEST.CREATE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestCreate(List<String> args) {
     return send(Command.TDIGEST_CREATE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.info">tdigestInfo</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.info/">TDIGEST.INFO</a>.
    * @return fluent self
    */
   @Fluent
@@ -5039,14 +5332,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.info">tdigestInfo</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.info/">TDIGEST.INFO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestInfo(List<String> args) {
     return send(Command.TDIGEST_INFO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.max">tdigestMax</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.max/">TDIGEST.MAX</a>.
    * @return fluent self
    */
   @Fluent
@@ -5056,14 +5350,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.max">tdigestMax</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.max/">TDIGEST.MAX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestMax(List<String> args) {
     return send(Command.TDIGEST_MAX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.merge">tdigestMerge</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.merge/">TDIGEST.MERGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -5073,14 +5368,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.merge">tdigestMerge</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.merge/">TDIGEST.MERGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestMerge(List<String> args) {
     return send(Command.TDIGEST_MERGE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.min">tdigestMin</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.min/">TDIGEST.MIN</a>.
    * @return fluent self
    */
   @Fluent
@@ -5090,14 +5386,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.min">tdigestMin</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.min/">TDIGEST.MIN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestMin(List<String> args) {
     return send(Command.TDIGEST_MIN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.quantile">tdigestQuantile</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.quantile/">TDIGEST.QUANTILE</a>.
    * @return fluent self
    */
   @Fluent
@@ -5107,14 +5404,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.quantile">tdigestQuantile</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.quantile/">TDIGEST.QUANTILE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestQuantile(List<String> args) {
     return send(Command.TDIGEST_QUANTILE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.rank">tdigestRank</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.rank/">TDIGEST.RANK</a>.
    * @return fluent self
    */
   @Fluent
@@ -5124,14 +5422,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.rank">tdigestRank</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.rank/">TDIGEST.RANK</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestRank(List<String> args) {
     return send(Command.TDIGEST_RANK, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.reset">tdigestReset</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.reset/">TDIGEST.RESET</a>.
    * @return fluent self
    */
   @Fluent
@@ -5141,14 +5440,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.reset">tdigestReset</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.reset/">TDIGEST.RESET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestReset(List<String> args) {
     return send(Command.TDIGEST_RESET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.revrank">tdigestRevrank</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.revrank/">TDIGEST.REVRANK</a>.
    * @return fluent self
    */
   @Fluent
@@ -5158,14 +5458,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.revrank">tdigestRevrank</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.revrank/">TDIGEST.REVRANK</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestRevrank(List<String> args) {
     return send(Command.TDIGEST_REVRANK, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.trimmed_mean">tdigestTrimmedMean</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.trimmed_mean/">TDIGEST.TRIMMED_MEAN</a>.
    * @return fluent self
    */
   @Fluent
@@ -5175,14 +5476,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/tdigest.trimmed_mean">tdigestTrimmedMean</a>.
+   * Redis command <a href="https://redis.io/commands/tdigest.trimmed_mean/">TDIGEST.TRIMMED_MEAN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tdigestTrimmedMean(List<String> args) {
     return send(Command.TDIGEST_TRIMMED_MEAN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/time">time</a>.
+   * Redis command <a href="https://redis.io/commands/time/">TIME</a>.
    * @return fluent self
    */
   @Fluent
@@ -5192,14 +5494,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/time">time</a>.
+   * Redis command <a href="https://redis.io/commands/time/">TIME</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> time() {
     return send(Command.TIME);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.CLUSTERSET">timeseriesClusterset</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.clusterset/">TIMESERIES.CLUSTERSET</a>.
    * @return fluent self
    */
   @Fluent
@@ -5209,14 +5512,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.CLUSTERSET">timeseriesClusterset</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.clusterset/">TIMESERIES.CLUSTERSET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> timeseriesClusterset(List<String> args) {
     return send(Command.TIMESERIES_CLUSTERSET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.CLUSTERSETFROMSHARD">timeseriesClustersetfromshard</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.clustersetfromshard/">TIMESERIES.CLUSTERSETFROMSHARD</a>.
    * @return fluent self
    */
   @Fluent
@@ -5226,14 +5530,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.CLUSTERSETFROMSHARD">timeseriesClustersetfromshard</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.clustersetfromshard/">TIMESERIES.CLUSTERSETFROMSHARD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> timeseriesClustersetfromshard(List<String> args) {
     return send(Command.TIMESERIES_CLUSTERSETFROMSHARD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.HELLO">timeseriesHello</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.hello/">TIMESERIES.HELLO</a>.
    * @return fluent self
    */
   @Fluent
@@ -5243,14 +5548,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.HELLO">timeseriesHello</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.hello/">TIMESERIES.HELLO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> timeseriesHello(List<String> args) {
     return send(Command.TIMESERIES_HELLO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.INFOCLUSTER">timeseriesInfocluster</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.infocluster/">TIMESERIES.INFOCLUSTER</a>.
    * @return fluent self
    */
   @Fluent
@@ -5260,14 +5566,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.INFOCLUSTER">timeseriesInfocluster</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.infocluster/">TIMESERIES.INFOCLUSTER</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> timeseriesInfocluster(List<String> args) {
     return send(Command.TIMESERIES_INFOCLUSTER, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.INNERCOMMUNICATION">timeseriesInnercommunication</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.innercommunication/">TIMESERIES.INNERCOMMUNICATION</a>.
    * @return fluent self
    */
   @Fluent
@@ -5277,14 +5584,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.INNERCOMMUNICATION">timeseriesInnercommunication</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.innercommunication/">TIMESERIES.INNERCOMMUNICATION</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> timeseriesInnercommunication(List<String> args) {
     return send(Command.TIMESERIES_INNERCOMMUNICATION, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.NETWORKTEST">timeseriesNetworktest</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.networktest/">TIMESERIES.NETWORKTEST</a>.
    * @return fluent self
    */
   @Fluent
@@ -5294,14 +5602,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.NETWORKTEST">timeseriesNetworktest</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.networktest/">TIMESERIES.NETWORKTEST</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> timeseriesNetworktest(List<String> args) {
     return send(Command.TIMESERIES_NETWORKTEST, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.REFRESHCLUSTER">timeseriesRefreshcluster</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.refreshcluster/">TIMESERIES.REFRESHCLUSTER</a>.
    * @return fluent self
    */
   @Fluent
@@ -5311,14 +5620,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/timeseries.REFRESHCLUSTER">timeseriesRefreshcluster</a>.
+   * Redis command <a href="https://redis.io/commands/timeseries.refreshcluster/">TIMESERIES.REFRESHCLUSTER</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> timeseriesRefreshcluster(List<String> args) {
     return send(Command.TIMESERIES_REFRESHCLUSTER, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/topk.add">topkAdd</a>.
+   * Redis command <a href="https://redis.io/commands/topk.add/">TOPK.ADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -5328,14 +5638,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/topk.add">topkAdd</a>.
+   * Redis command <a href="https://redis.io/commands/topk.add/">TOPK.ADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> topkAdd(List<String> args) {
     return send(Command.TOPK_ADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/topk.count">topkCount</a>.
+   * Redis command <a href="https://redis.io/commands/topk.count/">TOPK.COUNT</a>.
    * @return fluent self
    */
   @Fluent
@@ -5345,14 +5656,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/topk.count">topkCount</a>.
+   * Redis command <a href="https://redis.io/commands/topk.count/">TOPK.COUNT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> topkCount(List<String> args) {
     return send(Command.TOPK_COUNT, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/topk.incrby">topkIncrby</a>.
+   * Redis command <a href="https://redis.io/commands/topk.incrby/">TOPK.INCRBY</a>.
    * @return fluent self
    */
   @Fluent
@@ -5362,14 +5674,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/topk.incrby">topkIncrby</a>.
+   * Redis command <a href="https://redis.io/commands/topk.incrby/">TOPK.INCRBY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> topkIncrby(List<String> args) {
     return send(Command.TOPK_INCRBY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/topk.info">topkInfo</a>.
+   * Redis command <a href="https://redis.io/commands/topk.info/">TOPK.INFO</a>.
    * @return fluent self
    */
   @Fluent
@@ -5379,14 +5692,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/topk.info">topkInfo</a>.
+   * Redis command <a href="https://redis.io/commands/topk.info/">TOPK.INFO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> topkInfo(List<String> args) {
     return send(Command.TOPK_INFO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/topk.list">topkList</a>.
+   * Redis command <a href="https://redis.io/commands/topk.list/">TOPK.LIST</a>.
    * @return fluent self
    */
   @Fluent
@@ -5396,14 +5710,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/topk.list">topkList</a>.
+   * Redis command <a href="https://redis.io/commands/topk.list/">TOPK.LIST</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> topkList(List<String> args) {
     return send(Command.TOPK_LIST, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/topk.query">topkQuery</a>.
+   * Redis command <a href="https://redis.io/commands/topk.query/">TOPK.QUERY</a>.
    * @return fluent self
    */
   @Fluent
@@ -5413,14 +5728,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/topk.query">topkQuery</a>.
+   * Redis command <a href="https://redis.io/commands/topk.query/">TOPK.QUERY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> topkQuery(List<String> args) {
     return send(Command.TOPK_QUERY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/topk.reserve">topkReserve</a>.
+   * Redis command <a href="https://redis.io/commands/topk.reserve/">TOPK.RESERVE</a>.
    * @return fluent self
    */
   @Fluent
@@ -5430,14 +5746,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/topk.reserve">topkReserve</a>.
+   * Redis command <a href="https://redis.io/commands/topk.reserve/">TOPK.RESERVE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> topkReserve(List<String> args) {
     return send(Command.TOPK_RESERVE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/touch">touch</a>.
+   * Redis command <a href="https://redis.io/commands/touch/">TOUCH</a>.
    * @return fluent self
    */
   @Fluent
@@ -5447,14 +5764,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/touch">touch</a>.
+   * Redis command <a href="https://redis.io/commands/touch/">TOUCH</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> touch(List<String> args) {
     return send(Command.TOUCH, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.add">tsAdd</a>.
+   * Redis command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -5464,14 +5782,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.add">tsAdd</a>.
+   * Redis command <a href="https://redis.io/commands/ts.add/">TS.ADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsAdd(List<String> args) {
     return send(Command.TS_ADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.alter">tsAlter</a>.
+   * Redis command <a href="https://redis.io/commands/ts.alter/">TS.ALTER</a>.
    * @return fluent self
    */
   @Fluent
@@ -5481,14 +5800,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.alter">tsAlter</a>.
+   * Redis command <a href="https://redis.io/commands/ts.alter/">TS.ALTER</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsAlter(List<String> args) {
     return send(Command.TS_ALTER, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.create">tsCreate</a>.
+   * Redis command <a href="https://redis.io/commands/ts.create/">TS.CREATE</a>.
    * @return fluent self
    */
   @Fluent
@@ -5498,14 +5818,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.create">tsCreate</a>.
+   * Redis command <a href="https://redis.io/commands/ts.create/">TS.CREATE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsCreate(List<String> args) {
     return send(Command.TS_CREATE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.createrule">tsCreaterule</a>.
+   * Redis command <a href="https://redis.io/commands/ts.createrule/">TS.CREATERULE</a>.
    * @return fluent self
    */
   @Fluent
@@ -5515,14 +5836,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.createrule">tsCreaterule</a>.
+   * Redis command <a href="https://redis.io/commands/ts.createrule/">TS.CREATERULE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsCreaterule(List<String> args) {
     return send(Command.TS_CREATERULE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.decrby">tsDecrby</a>.
+   * Redis command <a href="https://redis.io/commands/ts.decrby/">TS.DECRBY</a>.
    * @return fluent self
    */
   @Fluent
@@ -5532,14 +5854,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.decrby">tsDecrby</a>.
+   * Redis command <a href="https://redis.io/commands/ts.decrby/">TS.DECRBY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsDecrby(List<String> args) {
     return send(Command.TS_DECRBY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.del">tsDel</a>.
+   * Redis command <a href="https://redis.io/commands/ts.del/">TS.DEL</a>.
    * @return fluent self
    */
   @Fluent
@@ -5549,14 +5872,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.del">tsDel</a>.
+   * Redis command <a href="https://redis.io/commands/ts.del/">TS.DEL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsDel(List<String> args) {
     return send(Command.TS_DEL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.deleterule">tsDeleterule</a>.
+   * Redis command <a href="https://redis.io/commands/ts.deleterule/">TS.DELETERULE</a>.
    * @return fluent self
    */
   @Fluent
@@ -5566,14 +5890,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.deleterule">tsDeleterule</a>.
+   * Redis command <a href="https://redis.io/commands/ts.deleterule/">TS.DELETERULE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsDeleterule(List<String> args) {
     return send(Command.TS_DELETERULE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.get">tsGet</a>.
+   * Redis command <a href="https://redis.io/commands/ts.get/">TS.GET</a>.
    * @return fluent self
    */
   @Fluent
@@ -5583,14 +5908,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.get">tsGet</a>.
+   * Redis command <a href="https://redis.io/commands/ts.get/">TS.GET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsGet(List<String> args) {
     return send(Command.TS_GET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.incrby">tsIncrby</a>.
+   * Redis command <a href="https://redis.io/commands/ts.incrby/">TS.INCRBY</a>.
    * @return fluent self
    */
   @Fluent
@@ -5600,14 +5926,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.incrby">tsIncrby</a>.
+   * Redis command <a href="https://redis.io/commands/ts.incrby/">TS.INCRBY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsIncrby(List<String> args) {
     return send(Command.TS_INCRBY, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.info">tsInfo</a>.
+   * Redis command <a href="https://redis.io/commands/ts.info/">TS.INFO</a>.
    * @return fluent self
    */
   @Fluent
@@ -5617,14 +5944,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.info">tsInfo</a>.
+   * Redis command <a href="https://redis.io/commands/ts.info/">TS.INFO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsInfo(List<String> args) {
     return send(Command.TS_INFO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.madd">tsMadd</a>.
+   * Redis command <a href="https://redis.io/commands/ts.madd/">TS.MADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -5634,14 +5962,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.madd">tsMadd</a>.
+   * Redis command <a href="https://redis.io/commands/ts.madd/">TS.MADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsMadd(List<String> args) {
     return send(Command.TS_MADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.mget">tsMget</a>.
+   * Redis command <a href="https://redis.io/commands/ts.mget/">TS.MGET</a>.
    * @return fluent self
    */
   @Fluent
@@ -5651,14 +5980,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.mget">tsMget</a>.
+   * Redis command <a href="https://redis.io/commands/ts.mget/">TS.MGET</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsMget(List<String> args) {
     return send(Command.TS_MGET, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.mrange">tsMrange</a>.
+   * Redis command <a href="https://redis.io/commands/ts.mrange/">TS.MRANGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -5668,14 +5998,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.mrange">tsMrange</a>.
+   * Redis command <a href="https://redis.io/commands/ts.mrange/">TS.MRANGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsMrange(List<String> args) {
     return send(Command.TS_MRANGE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.mrevrange">tsMrevrange</a>.
+   * Redis command <a href="https://redis.io/commands/ts.mrevrange/">TS.MREVRANGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -5685,14 +6016,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.mrevrange">tsMrevrange</a>.
+   * Redis command <a href="https://redis.io/commands/ts.mrevrange/">TS.MREVRANGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsMrevrange(List<String> args) {
     return send(Command.TS_MREVRANGE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.queryindex">tsQueryindex</a>.
+   * Redis command <a href="https://redis.io/commands/ts.queryindex/">TS.QUERYINDEX</a>.
    * @return fluent self
    */
   @Fluent
@@ -5702,14 +6034,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.queryindex">tsQueryindex</a>.
+   * Redis command <a href="https://redis.io/commands/ts.queryindex/">TS.QUERYINDEX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsQueryindex(List<String> args) {
     return send(Command.TS_QUERYINDEX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.range">tsRange</a>.
+   * Redis command <a href="https://redis.io/commands/ts.range/">TS.RANGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -5719,14 +6052,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.range">tsRange</a>.
+   * Redis command <a href="https://redis.io/commands/ts.range/">TS.RANGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsRange(List<String> args) {
     return send(Command.TS_RANGE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ts.revrange">tsRevrange</a>.
+   * Redis command <a href="https://redis.io/commands/ts.revrange/">TS.REVRANGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -5736,14 +6070,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ts.revrange">tsRevrange</a>.
+   * Redis command <a href="https://redis.io/commands/ts.revrange/">TS.REVRANGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> tsRevrange(List<String> args) {
     return send(Command.TS_REVRANGE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/ttl">ttl</a>.
+   * Redis command <a href="https://redis.io/commands/ttl/">TTL</a>.
    * @return fluent self
    */
   @Fluent
@@ -5753,14 +6088,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/ttl">ttl</a>.
+   * Redis command <a href="https://redis.io/commands/ttl/">TTL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> ttl(String arg0) {
     return send(Command.TTL, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/type">type</a>.
+   * Redis command <a href="https://redis.io/commands/type/">TYPE</a>.
    * @return fluent self
    */
   @Fluent
@@ -5770,14 +6106,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/type">type</a>.
+   * Redis command <a href="https://redis.io/commands/type/">TYPE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> type(String arg0) {
     return send(Command.TYPE, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/unlink">unlink</a>.
+   * Redis command <a href="https://redis.io/commands/unlink/">UNLINK</a>.
    * @return fluent self
    */
   @Fluent
@@ -5787,14 +6124,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/unlink">unlink</a>.
+   * Redis command <a href="https://redis.io/commands/unlink/">UNLINK</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> unlink(List<String> args) {
     return send(Command.UNLINK, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/unsubscribe">unsubscribe</a>.
+   * Redis command <a href="https://redis.io/commands/unsubscribe/">UNSUBSCRIBE</a>.
    * @return fluent self
    */
   @Fluent
@@ -5804,14 +6142,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/unsubscribe">unsubscribe</a>.
+   * Redis command <a href="https://redis.io/commands/unsubscribe/">UNSUBSCRIBE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> unsubscribe(List<String> args) {
     return send(Command.UNSUBSCRIBE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/unwatch">unwatch</a>.
+   * Redis command <a href="https://redis.io/commands/unwatch/">UNWATCH</a>.
    * @return fluent self
    */
   @Fluent
@@ -5821,14 +6160,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/unwatch">unwatch</a>.
+   * Redis command <a href="https://redis.io/commands/unwatch/">UNWATCH</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> unwatch() {
     return send(Command.UNWATCH);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/wait">wait</a>.
+   * Redis command <a href="https://redis.io/commands/wait/">WAIT</a>.
    * @return fluent self
    */
   @Fluent
@@ -5838,14 +6178,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/wait">wait</a>.
+   * Redis command <a href="https://redis.io/commands/wait/">WAIT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> wait(String arg0, String arg1) {
     return send(Command.WAIT, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/watch">watch</a>.
+   * Redis command <a href="https://redis.io/commands/watch/">WATCH</a>.
    * @return fluent self
    */
   @Fluent
@@ -5855,14 +6196,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/watch">watch</a>.
+   * Redis command <a href="https://redis.io/commands/watch/">WATCH</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> watch(List<String> args) {
     return send(Command.WATCH, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xack">xack</a>.
+   * Redis command <a href="https://redis.io/commands/xack/">XACK</a>.
    * @return fluent self
    */
   @Fluent
@@ -5872,14 +6214,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xack">xack</a>.
+   * Redis command <a href="https://redis.io/commands/xack/">XACK</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xack(List<String> args) {
     return send(Command.XACK, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xadd">xadd</a>.
+   * Redis command <a href="https://redis.io/commands/xadd/">XADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -5889,14 +6232,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xadd">xadd</a>.
+   * Redis command <a href="https://redis.io/commands/xadd/">XADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xadd(List<String> args) {
     return send(Command.XADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xautoclaim">xautoclaim</a>.
+   * Redis command <a href="https://redis.io/commands/xautoclaim/">XAUTOCLAIM</a>.
    * @return fluent self
    */
   @Fluent
@@ -5906,14 +6250,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xautoclaim">xautoclaim</a>.
+   * Redis command <a href="https://redis.io/commands/xautoclaim/">XAUTOCLAIM</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xautoclaim(List<String> args) {
     return send(Command.XAUTOCLAIM, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xclaim">xclaim</a>.
+   * Redis command <a href="https://redis.io/commands/xclaim/">XCLAIM</a>.
    * @return fluent self
    */
   @Fluent
@@ -5923,14 +6268,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xclaim">xclaim</a>.
+   * Redis command <a href="https://redis.io/commands/xclaim/">XCLAIM</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xclaim(List<String> args) {
     return send(Command.XCLAIM, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xdel">xdel</a>.
+   * Redis command <a href="https://redis.io/commands/xdel/">XDEL</a>.
    * @return fluent self
    */
   @Fluent
@@ -5940,14 +6286,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xdel">xdel</a>.
+   * Redis command <a href="https://redis.io/commands/xdel/">XDEL</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xdel(List<String> args) {
     return send(Command.XDEL, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xgroup">xgroup</a>.
+   * Redis command <a href="https://redis.io/commands/xgroup/">XGROUP</a>.
    * @return fluent self
    */
   @Fluent
@@ -5957,14 +6304,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xgroup">xgroup</a>.
+   * Redis command <a href="https://redis.io/commands/xgroup/">XGROUP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xgroup(List<String> args) {
     return send(Command.XGROUP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xinfo">xinfo</a>.
+   * Redis command <a href="https://redis.io/commands/xinfo/">XINFO</a>.
    * @return fluent self
    */
   @Fluent
@@ -5974,14 +6322,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xinfo">xinfo</a>.
+   * Redis command <a href="https://redis.io/commands/xinfo/">XINFO</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xinfo(List<String> args) {
     return send(Command.XINFO, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xlen">xlen</a>.
+   * Redis command <a href="https://redis.io/commands/xlen/">XLEN</a>.
    * @return fluent self
    */
   @Fluent
@@ -5991,14 +6340,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xlen">xlen</a>.
+   * Redis command <a href="https://redis.io/commands/xlen/">XLEN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xlen(String arg0) {
     return send(Command.XLEN, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xpending">xpending</a>.
+   * Redis command <a href="https://redis.io/commands/xpending/">XPENDING</a>.
    * @return fluent self
    */
   @Fluent
@@ -6008,14 +6358,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xpending">xpending</a>.
+   * Redis command <a href="https://redis.io/commands/xpending/">XPENDING</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xpending(List<String> args) {
     return send(Command.XPENDING, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xrange">xrange</a>.
+   * Redis command <a href="https://redis.io/commands/xrange/">XRANGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -6025,14 +6376,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xrange">xrange</a>.
+   * Redis command <a href="https://redis.io/commands/xrange/">XRANGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xrange(List<String> args) {
     return send(Command.XRANGE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xread">xread</a>.
+   * Redis command <a href="https://redis.io/commands/xread/">XREAD</a>.
    * @return fluent self
    */
   @Fluent
@@ -6042,14 +6394,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xread">xread</a>.
+   * Redis command <a href="https://redis.io/commands/xread/">XREAD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xread(List<String> args) {
     return send(Command.XREAD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xreadgroup">xreadgroup</a>.
+   * Redis command <a href="https://redis.io/commands/xreadgroup/">XREADGROUP</a>.
    * @return fluent self
    */
   @Fluent
@@ -6059,14 +6412,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xreadgroup">xreadgroup</a>.
+   * Redis command <a href="https://redis.io/commands/xreadgroup/">XREADGROUP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xreadgroup(List<String> args) {
     return send(Command.XREADGROUP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xrevrange">xrevrange</a>.
+   * Redis command <a href="https://redis.io/commands/xrevrange/">XREVRANGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -6076,14 +6430,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xrevrange">xrevrange</a>.
+   * Redis command <a href="https://redis.io/commands/xrevrange/">XREVRANGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xrevrange(List<String> args) {
     return send(Command.XREVRANGE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xsetid">xsetid</a>.
+   * Redis command <a href="https://redis.io/commands/xsetid/">XSETID</a>.
    * @return fluent self
    */
   @Fluent
@@ -6093,14 +6448,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xsetid">xsetid</a>.
+   * Redis command <a href="https://redis.io/commands/xsetid/">XSETID</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xsetid(List<String> args) {
     return send(Command.XSETID, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/xtrim">xtrim</a>.
+   * Redis command <a href="https://redis.io/commands/xtrim/">XTRIM</a>.
    * @return fluent self
    */
   @Fluent
@@ -6110,14 +6466,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/xtrim">xtrim</a>.
+   * Redis command <a href="https://redis.io/commands/xtrim/">XTRIM</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> xtrim(List<String> args) {
     return send(Command.XTRIM, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zadd">zadd</a>.
+   * Redis command <a href="https://redis.io/commands/zadd/">ZADD</a>.
    * @return fluent self
    */
   @Fluent
@@ -6127,14 +6484,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zadd">zadd</a>.
+   * Redis command <a href="https://redis.io/commands/zadd/">ZADD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zadd(List<String> args) {
     return send(Command.ZADD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zcard">zcard</a>.
+   * Redis command <a href="https://redis.io/commands/zcard/">ZCARD</a>.
    * @return fluent self
    */
   @Fluent
@@ -6144,14 +6502,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zcard">zcard</a>.
+   * Redis command <a href="https://redis.io/commands/zcard/">ZCARD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zcard(String arg0) {
     return send(Command.ZCARD, arg0);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zcount">zcount</a>.
+   * Redis command <a href="https://redis.io/commands/zcount/">ZCOUNT</a>.
    * @return fluent self
    */
   @Fluent
@@ -6161,14 +6520,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zcount">zcount</a>.
+   * Redis command <a href="https://redis.io/commands/zcount/">ZCOUNT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zcount(String arg0, String arg1, String arg2) {
     return send(Command.ZCOUNT, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zdiff">zdiff</a>.
+   * Redis command <a href="https://redis.io/commands/zdiff/">ZDIFF</a>.
    * @return fluent self
    */
   @Fluent
@@ -6178,14 +6538,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zdiff">zdiff</a>.
+   * Redis command <a href="https://redis.io/commands/zdiff/">ZDIFF</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zdiff(List<String> args) {
     return send(Command.ZDIFF, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zdiffstore">zdiffstore</a>.
+   * Redis command <a href="https://redis.io/commands/zdiffstore/">ZDIFFSTORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -6195,14 +6556,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zdiffstore">zdiffstore</a>.
+   * Redis command <a href="https://redis.io/commands/zdiffstore/">ZDIFFSTORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zdiffstore(List<String> args) {
     return send(Command.ZDIFFSTORE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zincrby">zincrby</a>.
+   * Redis command <a href="https://redis.io/commands/zincrby/">ZINCRBY</a>.
    * @return fluent self
    */
   @Fluent
@@ -6212,14 +6574,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zincrby">zincrby</a>.
+   * Redis command <a href="https://redis.io/commands/zincrby/">ZINCRBY</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zincrby(String arg0, String arg1, String arg2) {
     return send(Command.ZINCRBY, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zinter">zinter</a>.
+   * Redis command <a href="https://redis.io/commands/zinter/">ZINTER</a>.
    * @return fluent self
    */
   @Fluent
@@ -6229,14 +6592,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zinter">zinter</a>.
+   * Redis command <a href="https://redis.io/commands/zinter/">ZINTER</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zinter(List<String> args) {
     return send(Command.ZINTER, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zintercard">zintercard</a>.
+   * Redis command <a href="https://redis.io/commands/zintercard/">ZINTERCARD</a>.
    * @return fluent self
    */
   @Fluent
@@ -6246,14 +6610,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zintercard">zintercard</a>.
+   * Redis command <a href="https://redis.io/commands/zintercard/">ZINTERCARD</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zintercard(List<String> args) {
     return send(Command.ZINTERCARD, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zinterstore">zinterstore</a>.
+   * Redis command <a href="https://redis.io/commands/zinterstore/">ZINTERSTORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -6263,14 +6628,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zinterstore">zinterstore</a>.
+   * Redis command <a href="https://redis.io/commands/zinterstore/">ZINTERSTORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zinterstore(List<String> args) {
     return send(Command.ZINTERSTORE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zlexcount">zlexcount</a>.
+   * Redis command <a href="https://redis.io/commands/zlexcount/">ZLEXCOUNT</a>.
    * @return fluent self
    */
   @Fluent
@@ -6280,14 +6646,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zlexcount">zlexcount</a>.
+   * Redis command <a href="https://redis.io/commands/zlexcount/">ZLEXCOUNT</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zlexcount(String arg0, String arg1, String arg2) {
     return send(Command.ZLEXCOUNT, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zmpop">zmpop</a>.
+   * Redis command <a href="https://redis.io/commands/zmpop/">ZMPOP</a>.
    * @return fluent self
    */
   @Fluent
@@ -6297,14 +6664,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zmpop">zmpop</a>.
+   * Redis command <a href="https://redis.io/commands/zmpop/">ZMPOP</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zmpop(List<String> args) {
     return send(Command.ZMPOP, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zmscore">zmscore</a>.
+   * Redis command <a href="https://redis.io/commands/zmscore/">ZMSCORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -6314,14 +6682,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zmscore">zmscore</a>.
+   * Redis command <a href="https://redis.io/commands/zmscore/">ZMSCORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zmscore(List<String> args) {
     return send(Command.ZMSCORE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zpopmax">zpopmax</a>.
+   * Redis command <a href="https://redis.io/commands/zpopmax/">ZPOPMAX</a>.
    * @return fluent self
    */
   @Fluent
@@ -6331,14 +6700,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zpopmax">zpopmax</a>.
+   * Redis command <a href="https://redis.io/commands/zpopmax/">ZPOPMAX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zpopmax(List<String> args) {
     return send(Command.ZPOPMAX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zpopmin">zpopmin</a>.
+   * Redis command <a href="https://redis.io/commands/zpopmin/">ZPOPMIN</a>.
    * @return fluent self
    */
   @Fluent
@@ -6348,14 +6718,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zpopmin">zpopmin</a>.
+   * Redis command <a href="https://redis.io/commands/zpopmin/">ZPOPMIN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zpopmin(List<String> args) {
     return send(Command.ZPOPMIN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zrandmember">zrandmember</a>.
+   * Redis command <a href="https://redis.io/commands/zrandmember/">ZRANDMEMBER</a>.
    * @return fluent self
    */
   @Fluent
@@ -6365,14 +6736,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zrandmember">zrandmember</a>.
+   * Redis command <a href="https://redis.io/commands/zrandmember/">ZRANDMEMBER</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zrandmember(List<String> args) {
     return send(Command.ZRANDMEMBER, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zrange">zrange</a>.
+   * Redis command <a href="https://redis.io/commands/zrange/">ZRANGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -6382,14 +6754,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zrange">zrange</a>.
+   * Redis command <a href="https://redis.io/commands/zrange/">ZRANGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zrange(List<String> args) {
     return send(Command.ZRANGE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zrangebylex">zrangebylex</a>.
+   * Redis command <a href="https://redis.io/commands/zrangebylex/">ZRANGEBYLEX</a>.
    * @return fluent self
    */
   @Fluent
@@ -6399,14 +6772,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zrangebylex">zrangebylex</a>.
+   * Redis command <a href="https://redis.io/commands/zrangebylex/">ZRANGEBYLEX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zrangebylex(List<String> args) {
     return send(Command.ZRANGEBYLEX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zrangebyscore">zrangebyscore</a>.
+   * Redis command <a href="https://redis.io/commands/zrangebyscore/">ZRANGEBYSCORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -6416,14 +6790,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zrangebyscore">zrangebyscore</a>.
+   * Redis command <a href="https://redis.io/commands/zrangebyscore/">ZRANGEBYSCORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zrangebyscore(List<String> args) {
     return send(Command.ZRANGEBYSCORE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zrangestore">zrangestore</a>.
+   * Redis command <a href="https://redis.io/commands/zrangestore/">ZRANGESTORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -6433,14 +6808,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zrangestore">zrangestore</a>.
+   * Redis command <a href="https://redis.io/commands/zrangestore/">ZRANGESTORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zrangestore(List<String> args) {
     return send(Command.ZRANGESTORE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zrank">zrank</a>.
+   * Redis command <a href="https://redis.io/commands/zrank/">ZRANK</a>.
    * @return fluent self
    */
   @Fluent
@@ -6450,14 +6826,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zrank">zrank</a>.
+   * Redis command <a href="https://redis.io/commands/zrank/">ZRANK</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zrank(String arg0, String arg1) {
     return send(Command.ZRANK, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zrem">zrem</a>.
+   * Redis command <a href="https://redis.io/commands/zrem/">ZREM</a>.
    * @return fluent self
    */
   @Fluent
@@ -6467,14 +6844,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zrem">zrem</a>.
+   * Redis command <a href="https://redis.io/commands/zrem/">ZREM</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zrem(List<String> args) {
     return send(Command.ZREM, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zremrangebylex">zremrangebylex</a>.
+   * Redis command <a href="https://redis.io/commands/zremrangebylex/">ZREMRANGEBYLEX</a>.
    * @return fluent self
    */
   @Fluent
@@ -6484,14 +6862,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zremrangebylex">zremrangebylex</a>.
+   * Redis command <a href="https://redis.io/commands/zremrangebylex/">ZREMRANGEBYLEX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zremrangebylex(String arg0, String arg1, String arg2) {
     return send(Command.ZREMRANGEBYLEX, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zremrangebyrank">zremrangebyrank</a>.
+   * Redis command <a href="https://redis.io/commands/zremrangebyrank/">ZREMRANGEBYRANK</a>.
    * @return fluent self
    */
   @Fluent
@@ -6501,14 +6880,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zremrangebyrank">zremrangebyrank</a>.
+   * Redis command <a href="https://redis.io/commands/zremrangebyrank/">ZREMRANGEBYRANK</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zremrangebyrank(String arg0, String arg1, String arg2) {
     return send(Command.ZREMRANGEBYRANK, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zremrangebyscore">zremrangebyscore</a>.
+   * Redis command <a href="https://redis.io/commands/zremrangebyscore/">ZREMRANGEBYSCORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -6518,14 +6898,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zremrangebyscore">zremrangebyscore</a>.
+   * Redis command <a href="https://redis.io/commands/zremrangebyscore/">ZREMRANGEBYSCORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zremrangebyscore(String arg0, String arg1, String arg2) {
     return send(Command.ZREMRANGEBYSCORE, arg0, arg1, arg2);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zrevrange">zrevrange</a>.
+   * Redis command <a href="https://redis.io/commands/zrevrange/">ZREVRANGE</a>.
    * @return fluent self
    */
   @Fluent
@@ -6535,14 +6916,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zrevrange">zrevrange</a>.
+   * Redis command <a href="https://redis.io/commands/zrevrange/">ZREVRANGE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zrevrange(List<String> args) {
     return send(Command.ZREVRANGE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zrevrangebylex">zrevrangebylex</a>.
+   * Redis command <a href="https://redis.io/commands/zrevrangebylex/">ZREVRANGEBYLEX</a>.
    * @return fluent self
    */
   @Fluent
@@ -6552,14 +6934,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zrevrangebylex">zrevrangebylex</a>.
+   * Redis command <a href="https://redis.io/commands/zrevrangebylex/">ZREVRANGEBYLEX</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zrevrangebylex(List<String> args) {
     return send(Command.ZREVRANGEBYLEX, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zrevrangebyscore">zrevrangebyscore</a>.
+   * Redis command <a href="https://redis.io/commands/zrevrangebyscore/">ZREVRANGEBYSCORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -6569,14 +6952,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zrevrangebyscore">zrevrangebyscore</a>.
+   * Redis command <a href="https://redis.io/commands/zrevrangebyscore/">ZREVRANGEBYSCORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zrevrangebyscore(List<String> args) {
     return send(Command.ZREVRANGEBYSCORE, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zrevrank">zrevrank</a>.
+   * Redis command <a href="https://redis.io/commands/zrevrank/">ZREVRANK</a>.
    * @return fluent self
    */
   @Fluent
@@ -6586,14 +6970,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zrevrank">zrevrank</a>.
+   * Redis command <a href="https://redis.io/commands/zrevrank/">ZREVRANK</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zrevrank(String arg0, String arg1) {
     return send(Command.ZREVRANK, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zscan">zscan</a>.
+   * Redis command <a href="https://redis.io/commands/zscan/">ZSCAN</a>.
    * @return fluent self
    */
   @Fluent
@@ -6603,14 +6988,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zscan">zscan</a>.
+   * Redis command <a href="https://redis.io/commands/zscan/">ZSCAN</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zscan(List<String> args) {
     return send(Command.ZSCAN, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zscore">zscore</a>.
+   * Redis command <a href="https://redis.io/commands/zscore/">ZSCORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -6620,14 +7006,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zscore">zscore</a>.
+   * Redis command <a href="https://redis.io/commands/zscore/">ZSCORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zscore(String arg0, String arg1) {
     return send(Command.ZSCORE, arg0, arg1);
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zunion">zunion</a>.
+   * Redis command <a href="https://redis.io/commands/zunion/">ZUNION</a>.
    * @return fluent self
    */
   @Fluent
@@ -6637,14 +7024,15 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zunion">zunion</a>.
+   * Redis command <a href="https://redis.io/commands/zunion/">ZUNION</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zunion(List<String> args) {
     return send(Command.ZUNION, args.toArray(new String[0]));
   }
+
   /**
-   * Redis command <a href="https://redis.io/commands/zunionstore">zunionstore</a>.
+   * Redis command <a href="https://redis.io/commands/zunionstore/">ZUNIONSTORE</a>.
    * @return fluent self
    */
   @Fluent
@@ -6654,7 +7042,7 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/zunionstore">zunionstore</a>.
+   * Redis command <a href="https://redis.io/commands/zunionstore/">ZUNIONSTORE</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> zunionstore(List<String> args) {

--- a/src/main/java/io/vertx/redis/client/RedisAPI.java
+++ b/src/main/java/io/vertx/redis/client/RedisAPI.java
@@ -30,7 +30,7 @@ import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
 
 /**
  * <b>Auto generated</b> Redis API client wrapper.
- * @version redis_version:7.0.0
+ * @version redis_version:7.0.12
  */
 @VertxGen
 public interface RedisAPI {
@@ -811,6 +811,23 @@ public interface RedisAPI {
    */
   default Future<@Nullable Response> bfAdd(List<String> args) {
     return send(Command.BF_ADD, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/bf.card">bfCard</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI bfCard(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.BF_CARD, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/bf.card">bfCard</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> bfCard(List<String> args) {
+    return send(Command.BF_CARD, args.toArray(new String[0]));
   }
   /**
    * Redis command <a href="https://redis.io/commands/bf.debug">bfDebug</a>.
@@ -4925,6 +4942,244 @@ public interface RedisAPI {
    */
   default Future<@Nullable Response> sync() {
     return send(Command.SYNC);
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.add">tdigestAdd</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestAdd(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_ADD, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.add">tdigestAdd</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestAdd(List<String> args) {
+    return send(Command.TDIGEST_ADD, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.byrank">tdigestByrank</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestByrank(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_BYRANK, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.byrank">tdigestByrank</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestByrank(List<String> args) {
+    return send(Command.TDIGEST_BYRANK, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.byrevrank">tdigestByrevrank</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestByrevrank(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_BYREVRANK, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.byrevrank">tdigestByrevrank</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestByrevrank(List<String> args) {
+    return send(Command.TDIGEST_BYREVRANK, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.cdf">tdigestCdf</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestCdf(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_CDF, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.cdf">tdigestCdf</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestCdf(List<String> args) {
+    return send(Command.TDIGEST_CDF, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.create">tdigestCreate</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestCreate(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_CREATE, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.create">tdigestCreate</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestCreate(List<String> args) {
+    return send(Command.TDIGEST_CREATE, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.info">tdigestInfo</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestInfo(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_INFO, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.info">tdigestInfo</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestInfo(List<String> args) {
+    return send(Command.TDIGEST_INFO, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.max">tdigestMax</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestMax(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_MAX, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.max">tdigestMax</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestMax(List<String> args) {
+    return send(Command.TDIGEST_MAX, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.merge">tdigestMerge</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestMerge(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_MERGE, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.merge">tdigestMerge</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestMerge(List<String> args) {
+    return send(Command.TDIGEST_MERGE, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.min">tdigestMin</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestMin(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_MIN, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.min">tdigestMin</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestMin(List<String> args) {
+    return send(Command.TDIGEST_MIN, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.quantile">tdigestQuantile</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestQuantile(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_QUANTILE, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.quantile">tdigestQuantile</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestQuantile(List<String> args) {
+    return send(Command.TDIGEST_QUANTILE, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.rank">tdigestRank</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestRank(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_RANK, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.rank">tdigestRank</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestRank(List<String> args) {
+    return send(Command.TDIGEST_RANK, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.reset">tdigestReset</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestReset(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_RESET, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.reset">tdigestReset</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestReset(List<String> args) {
+    return send(Command.TDIGEST_RESET, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.revrank">tdigestRevrank</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestRevrank(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_REVRANK, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.revrank">tdigestRevrank</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestRevrank(List<String> args) {
+    return send(Command.TDIGEST_REVRANK, args.toArray(new String[0]));
+  }
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.trimmed_mean">tdigestTrimmedMean</a>.
+   * @return fluent self
+   */
+  @Fluent
+  default RedisAPI tdigestTrimmedMean(List<String> args, Handler<AsyncResult<@Nullable Response>> handler) {
+    send(Command.TDIGEST_TRIMMED_MEAN, args.toArray(new String[0])).onComplete(handler);
+    return this;
+  }
+
+  /**
+   * Redis command <a href="https://redis.io/commands/tdigest.trimmed_mean">tdigestTrimmedMean</a>.
+   * @return Future response.
+   */
+  default Future<@Nullable Response> tdigestTrimmedMean(List<String> args) {
+    return send(Command.TDIGEST_TRIMMED_MEAN, args.toArray(new String[0]));
   }
   /**
    * Redis command <a href="https://redis.io/commands/time">time</a>.

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -234,6 +234,7 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
     if (index >= endpoints.size()) {
       // stop condition
       onGotSlots.handle(Future.failedFuture(new RedisConnectException("Cannot connect to any of the provided endpoints")));
+      scheduleCachedSlotsExpiration();
       return;
     }
 
@@ -254,7 +255,7 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
           } else {
             Slots slots = result.result();
             onGotSlots.handle(Future.succeededFuture(slots));
-            vertx.setTimer(connectOptions.getHashSlotCacheTTL(), ignored -> this.slots.set(null));
+            scheduleCachedSlotsExpiration();
           }
         });
       });
@@ -279,5 +280,9 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
 
       onGetSlots.handle(Future.succeededFuture(new Slots(endpoint, reply)));
     });
+  }
+
+  private void scheduleCachedSlotsExpiration() {
+    vertx.setTimer(connectOptions.getHashSlotCacheTTL(), ignored -> this.slots.set(null));
   }
 }

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -155,7 +155,7 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
     final int totalUniqueEndpoints = slots.endpoints().length;
     if (poolOptions.getMaxSize() < totalUniqueEndpoints) {
       // this isn't a valid setup, the connection pool will not accommodate all the required connections
-      onConnected.handle(Future.failedFuture("RedisOptions maxPoolSize < Cluster size(" + totalUniqueEndpoints + "): The pool is not able to hold all required connections!"));
+      onConnected.handle(Future.failedFuture(new RedisConnectException("RedisOptions maxPoolSize < Cluster size(" + totalUniqueEndpoints + "): The pool is not able to hold all required connections!")));
       return;
     }
 
@@ -204,7 +204,7 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
         for (Throwable failure : failures) {
           message.append("\n- ").append(failure);
         }
-        onConnected.handle(Future.failedFuture(message.toString()));
+        onConnected.handle(Future.failedFuture(new RedisConnectException(message.toString())));
       } else {
         onConnected.handle(Future.succeededFuture(new RedisClusterConnection(vertx, connectOptions, slots,
           () -> this.slots.set(null), connections)));
@@ -233,7 +233,7 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
   private void getSlots(List<String> endpoints, int index, Handler<AsyncResult<Slots>> onGotSlots) {
     if (index >= endpoints.size()) {
       // stop condition
-      onGotSlots.handle(Future.failedFuture("Cannot connect to any of the provided endpoints"));
+      onGotSlots.handle(Future.failedFuture(new RedisConnectException("Cannot connect to any of the provided endpoints")));
       return;
     }
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -120,8 +120,10 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
 
     addMasterOnlyCommand(SUBSCRIBE);
     addMasterOnlyCommand(PSUBSCRIBE);
+    addMasterOnlyCommand(SSUBSCRIBE);
     addReducer(UNSUBSCRIBE, list -> SimpleStringType.OK);
     addReducer(PUNSUBSCRIBE, list -> SimpleStringType.OK);
+    addReducer(SUNSUBSCRIBE, list -> SimpleStringType.OK);
   }
 
   private final RedisClusterConnectOptions connectOptions;

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
@@ -19,17 +19,16 @@ public class RedisClusterConnection implements RedisConnection {
 
   private static final Logger LOG = LoggerFactory.getLogger(RedisClusterConnection.class);
 
-  // we need some randomness, it doesn't need
-  // to be secure or unpredictable
+  // we need some randomness, it doesn't need to be cryptographically secure
   private static final Random RANDOM = new Random();
 
   // number of attempts/redirects when we get connection errors
   // or when we get MOVED/ASK responses
   private static final int RETRIES = 16;
 
-  // reduce from list fo responses to a single response
+  // reduce from list of responses to a single response
   private static final Map<Command, Function<List<Response>, Response>> REDUCERS = new HashMap<>();
-  // List of commands they should run every time only against master nodes
+  // List of commands that should always run only against master nodes
   private static final List<Command> MASTER_ONLY_COMMANDS = new ArrayList<>();
 
   public static void addReducer(Command command, Function<List<Response>, Response> fn) {

--- a/src/main/java/io/vertx/redis/client/impl/RedisConnectException.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisConnectException.java
@@ -1,0 +1,19 @@
+package io.vertx.redis.client.impl;
+
+import java.net.ConnectException;
+
+/**
+ * Used to signal connection failure in certain Redis clients that don't propagate underlying
+ * exceptions directly, but use a custom logic. Intentionally a subclass of {@code ConnectException},
+ * so that users of Redis clients can handle connection failures uniformly.
+ */
+class RedisConnectException extends ConnectException {
+  RedisConnectException(String msg) {
+    super(msg);
+  }
+
+  @Override
+  public Throwable fillInStackTrace() {
+    return this;
+  }
+}

--- a/src/main/java/io/vertx/redis/client/impl/RedisReplicationClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisReplicationClient.java
@@ -116,7 +116,7 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
   private void connect(List<String> endpoints, int index, Handler<AsyncResult<RedisConnection>> onConnect) {
     if (index >= endpoints.size()) {
       // stop condition
-      onConnect.handle(Future.failedFuture("Cannot connect to any of the provided endpoints"));
+      onConnect.handle(Future.failedFuture(new RedisConnectException("Cannot connect to any of the provided endpoints")));
       return;
     }
 
@@ -145,7 +145,7 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
           final int totalUniqueEndpoints = nodes.size();
           if (poolOptions.getMaxSize() < totalUniqueEndpoints) {
             // this isn't a valid setup, the connection pool will not accommodate all the required connections
-            onConnect.handle(Future.failedFuture("RedisOptions maxPoolSize < Cluster size(" + totalUniqueEndpoints + "): The pool is not able to hold all required connections!"));
+            onConnect.handle(Future.failedFuture(new RedisConnectException("RedisOptions maxPoolSize < Cluster size(" + totalUniqueEndpoints + "): The pool is not able to hold all required connections!")));
             return;
           }
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisReplicationConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisReplicationConnection.java
@@ -12,8 +12,7 @@ public class RedisReplicationConnection implements RedisConnection {
 
   private static final Logger LOG = LoggerFactory.getLogger(RedisReplicationConnection.class);
 
-  // we need some randomness, it doesn't need
-  // to be secure or unpredictable
+  // we need some randomness, it doesn't need to be cryptographically secure
   private static final Random RANDOM = new Random();
 
   // List of commands they should run every time only against master nodes

--- a/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
@@ -70,8 +70,8 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
   synchronized void setValid() {
     //System.out.println("setValid()#" + this.hashCode());
     closed = false;
-    // tainted will be reset, as a select during the handshake could have
-    // changed the state
+    // the `tainted` flag must be reset, as a `SELECT` or `AUTH` during the handshake
+    // could have tainted the connection
     tainted = false;
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/Slots.java
+++ b/src/main/java/io/vertx/redis/client/impl/Slots.java
@@ -22,8 +22,7 @@ import java.util.*;
 
 class Slots {
 
-  // we need some randomness, it doesn't need
-  // to be secure or unpredictable
+  // we need some randomness, it doesn't need to be cryptographically secure
   private static final Random RANDOM = new Random();
 
   static class Slot {

--- a/src/test/java/io/vertx/redis/client/CommandGenerator.java
+++ b/src/test/java/io/vertx/redis/client/CommandGenerator.java
@@ -113,8 +113,10 @@ public class CommandGenerator extends AbstractVerticle {
 
           for (Response flag : cmd.get(2)) {
             if ("pubsub".equals(flag.toString())) {
-              // we exclude PUBSUB / PUBLISH from the flag
-              if ("pubsub".equalsIgnoreCase(commandName) || "publish".equalsIgnoreCase(commandName)) {
+              // we exclude PUBSUB / PUBLISH / SPUBLISH from the flag
+              if ("pubsub".equalsIgnoreCase(commandName)
+                  || "publish".equalsIgnoreCase(commandName)
+                  || "spublish".equalsIgnoreCase(commandName)) {
                 continue;
               }
               pubSub = true;

--- a/tools/commands.js
+++ b/tools/commands.js
@@ -4,7 +4,7 @@ var redis = require('redis').createClient(6379);
 var Handlebars = require('handlebars');
 require('handlebars-helpers')();
 
-const excludedPubSub = ['PUBSUB', 'PUBLISH'];
+const excludedPubSub = ['PUBSUB', 'PUBLISH', 'SPUBLISH'];
 
 redis.info((err, info) => {
   if (err) {
@@ -40,6 +40,8 @@ redis.info((err, info) => {
       let args = "";
       let argLen = 0;
 
+      let identifier = cmd[0].replace('.', '_').replace('-', '_').replace(':', '').toUpperCase();
+
       if (cmd[1] > 0) {
         for (let i = 0; i < cmd[1] - 1; i++) {
           if (i !== 0) {
@@ -63,7 +65,7 @@ redis.info((err, info) => {
       }
 
       commands.push({
-        enum: cmd[0].replace('-', '_').replace(':', '').toUpperCase(),
+        enum: identifier,
         name: cmd[0],
         safename: cmd[0].replace('-', ' ').replace(':', '').toUpperCase(),
         arity: cmd[1],
@@ -79,7 +81,7 @@ redis.info((err, info) => {
         write: cmd[2].indexOf('write') !== -1,
         readOnly: cmd[2].indexOf('readonly') !== -1,
         movable: cmd[2].indexOf('movablekeys') !== -1,
-        pubsub: cmd[2].indexOf('pubsub') !== -1 && !excludedPubSub.includes(cmd[0].replace('-', '_').replace(':', '').toUpperCase())
+        pubsub: cmd[2].indexOf('pubsub') !== -1 && !excludedPubSub.includes(identifier)
       });
     });
 

--- a/tools/package.json
+++ b/tools/package.json
@@ -8,7 +8,7 @@
     "redis": "^2.8.0"
   },
   "scripts": {
-    "--prestart": "docker run --rm --net=host redis/redis-stack-server:7.0.6-RC8",
+    "--prestart": "docker run --rm --net=host redis/redis-stack-server:7.0.6-RC9",
     "start": "node commands.js"
   }
 }

--- a/tools/redis-api.hbs
+++ b/tools/redis-api.hbs
@@ -46,10 +46,10 @@ public interface RedisAPI {
   }
 
   void close();
-
 {{#each .}}
+
   /**
-   * Redis command <a href="https://redis.io/commands/{{ name }}">{{ camelcase safename }}</a>.
+   * Redis command <a href="https://redis.io/commands/{{ lowercase safename }}/">{{ uppercase name }}</a>.
    * @return fluent self
    */
   @Fluent
@@ -59,7 +59,7 @@ public interface RedisAPI {
   }
 
   /**
-   * Redis command <a href="https://redis.io/commands/{{ name }}">{{ camelcase safename }}</a>.
+   * Redis command <a href="https://redis.io/commands/{{ lowercase safename }}/">{{ uppercase name }}</a>.
    * @return Future response.
    */
   default Future<@Nullable Response> {{ camelcase safename }}({{{ types }}}) {


### PR DESCRIPTION
Several commits, best reviewed in isolation:

- show all errors when connecting to Redis cluster fails
- use a subclass of ConnectException on connection failure in cluster/replication client
- fix caching of hash slot assignment in cluster client
- improve some code comments slightly
- treat sharded pub/sub commands as pub/sub commands
- improve how documentation links are generated in RedisAPI

Backport of #419 to 4.x.