### PR TITLE
fix Redis connection sharing

### DIFF
--- a/src/test/java/io/vertx/redis/client/test/RedisTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisTest.java
@@ -215,7 +215,7 @@ public class RedisTest {
 
         Future.all(futures)
           .onFailure(f -> {
-            should.assertEquals("Redis waiting Queue is full", f.getMessage());
+            should.assertEquals("Redis waiting queue is full", f.getMessage());
             test.complete();
           })
           .onSuccess(r -> {

--- a/src/test/java/io/vertx/redis/client/test/SharedRedisConnectionTest.java
+++ b/src/test/java/io/vertx/redis/client/test/SharedRedisConnectionTest.java
@@ -1,0 +1,126 @@
+package io.vertx.redis.client.test;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.RedisClientType;
+import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.Response;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.GenericContainer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RunWith(VertxUnitRunner.class)
+public class SharedRedisConnectionTest {
+
+  @ClassRule
+  public static final GenericContainer<?> redis = new GenericContainer<>("redis:7")
+    .withExposedPorts(6379);
+
+  private static final int VERTICLES_COUNT = 10;
+  private static final int ITERATIONS_COUNT = 1000;
+
+  private static final String REDIS_NUMBER_VALUE_KEY = "user:post:pinned:1372";
+  private static final String REDIS_SET_VALUE_KEY = "user:like:post:975";
+
+  Vertx vertx;
+  RedisAPI conn;
+
+  @Before
+  public void setup(TestContext test) {
+    Async async = test.async();
+    vertx = Vertx.vertx();
+    RedisOptions options = new RedisOptions()
+      .setConnectionString("redis://" + redis.getHost() + ":" + redis.getFirstMappedPort())
+      .setMaxWaitingHandlers(VERTICLES_COUNT * ITERATIONS_COUNT * 2); // 2 requests per iteration
+    Redis.createClient(vertx, options)
+      .connect()
+      .map(RedisAPI::api)
+      .flatMap(api -> {
+        return api.set(Arrays.asList(REDIS_NUMBER_VALUE_KEY, "42"))
+          .map(api);
+      }).flatMap(api -> {
+        return api.sadd(Arrays.asList(REDIS_SET_VALUE_KEY, "100", "101", "102"))
+          .map(api);
+      })
+      .onComplete(result -> {
+        if (result.succeeded()) {
+          conn = result.result();
+        } else {
+          test.fail(result.cause());
+        }
+        async.complete();
+      });
+  }
+
+  @After
+  public void teardown(TestContext test) {
+    conn.close();
+    vertx.close().onComplete(test.asyncAssertSuccess());
+  }
+
+  @Test
+  public void test(TestContext test) {
+    vertx.deployVerticle(() -> new MyVerticle(conn, test), new DeploymentOptions().setInstances(VERTICLES_COUNT));
+  }
+
+  public static class MyVerticle extends AbstractVerticle {
+    private final RedisAPI conn;
+    private final TestContext test;
+
+    public MyVerticle(RedisAPI conn, TestContext test) {
+      this.conn = conn;
+      this.test = test;
+    }
+
+    @Override
+    public void start() {
+      Async async = test.async(ITERATIONS_COUNT);
+      for (int i = 0; i < ITERATIONS_COUNT; i++) {
+        test()
+          .onSuccess(ignored -> async.countDown())
+          .onFailure(test::fail);
+      }
+    }
+
+    private Future<?> test() {
+      Future<Response> fetchNumberFuture = conn.get(REDIS_NUMBER_VALUE_KEY)
+        .onSuccess(response -> {
+          try {
+            response.toInteger();
+          } catch (Exception e) {
+            test.fail(e);
+          }
+        });
+
+      Future<Response> fetchSetFuture = conn.smembers(REDIS_SET_VALUE_KEY)
+        .onSuccess(response -> {
+          try {
+            for (Response part : response) {
+              part.toInteger();
+            }
+          } catch (Exception e) {
+            test.fail(e);
+          }
+        });
+
+      return Future.all(fetchNumberFuture, fetchSetFuture);
+    }
+  }
+}

--- a/src/test/java/io/vertx/test/redis/RedisClientTLSTest.java
+++ b/src/test/java/io/vertx/test/redis/RedisClientTLSTest.java
@@ -116,18 +116,13 @@ public class RedisClientTLSTest {
         .setConnectionString("rediss://0.0.0.0:" + port + "?test=upgrade"));
 
     client.connect()
-      .onFailure(err -> {
-        System.out.println("REDIS CLIENT (CONNECT) ERR: " + err);
-      })
-      .onSuccess(conn -> {
+      .onComplete(should.asyncAssertSuccess(conn -> {
         conn.send(Request.cmd(Command.PING))
-          .onFailure(should::fail)
-          .onSuccess(res -> {
-            System.out.println("REDIS CLIENT SUCCESS");
+          .onComplete(should.asyncAssertSuccess(ignored -> {
             conn.close();
             test.complete();
-          });
-      });
+          }));
+      }));
   }
 
   @Test(timeout = 30_000L)
@@ -145,12 +140,13 @@ public class RedisClientTLSTest {
         .setConnectionString("rediss://localhost:" + server.actualPort()));
 
     client.connect()
-      .onFailure(should::fail)
-      .onSuccess(conn -> {
+      .onComplete(should.asyncAssertSuccess(conn -> {
         conn.send(Request.cmd(Command.PING))
-          .onFailure(should::fail)
-          .onSuccess(res -> test.complete());
-      });
+          .onComplete(should.asyncAssertSuccess(ignored -> {
+            conn.close();
+            test.complete();
+          }));
+      }));
   }
 
   @Test(timeout = 30_000L)
@@ -169,7 +165,8 @@ public class RedisClientTLSTest {
         .setConnectionString("redis://localhost:" + server.actualPort()));
 
     client.connect()
-      .onFailure(t -> test.complete())
-      .onSuccess(res -> should.fail());
+      .onComplete(should.asyncAssertFailure(ignored -> {
+        test.complete();
+      }));
   }
 }


### PR DESCRIPTION
When a single `RedisConnection` is shared among multiple contexts (e.g. verticles), pipelining doesn't work correctly, because there is no coordination for concurrent access. This commit fixes that by making sure that all requests are performed from the same context on which the `NetSocket` was created. If the current context is different from the `NetSocket` context, the request is emitted on the correct context, which means no concurrent access, all requests are serialized.

Fixes #394