### PR TITLE
[4.x] fix Redis connection sharing

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
@@ -177,15 +177,21 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
 
   @Override
   public Future<Response> send(final Request request) {
-    //System.out.println("send()#" + this.hashCode());
-    final Promise<Response> promise;
+    Promise<Response> promise = vertx.promise();
+    context.execute(() -> doSend(request, promise));
+    return promise.future();
+  }
 
+  private void doSend(final Request request, Promise<Response> promise) {
+    //System.out.println("send()#" + this.hashCode());
     if (closed) {
-      throw new IllegalStateException("Connection is closed");
+      promise.fail("Connection is closed");
+      return;
     }
 
     if (!((RequestImpl) request).valid()) {
-      return Future.failedFuture("Redis command is not valid, check https://redis.io/commands");
+      promise.fail("Redis command is not valid, check https://redis.io/commands: " + request);
+      return;
     }
 
     final CommandImpl cmd = (CommandImpl) request.command();
@@ -201,17 +207,11 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
       // we might have switch thread/context
       synchronized (waiting) {
         if (waiting.isFull()) {
-          return Future.failedFuture("Redis waiting Queue is full");
+          promise.fail("Redis waiting queue is full");
+          return;
         }
-        // create a new promise bound to the caller not
-        // the instance of this object (a.k.a. "context")
-        promise = vertx.promise();
         waiting.offer(promise);
       }
-    } else {
-      // create a new promise bound to the caller not
-      // the instance of this object (a.k.a. "context")
-      promise = vertx.promise();
     }
     // write to the socket
     try {
@@ -236,26 +236,26 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
       context.execute(err, this::fail);
       promise.fail(err);
     }
-
-    return promise.future();
   }
 
   @Override
   public Future<List<Response>> batch(List<Request> commands) {
-    //System.out.println("batch()#" + this.hashCode());
+    Promise<List<Response>> promise = vertx.promise();
+    context.execute(() -> doBatch(commands, promise));
+    return promise.future();
+  }
 
+  private void doBatch(List<Request> commands, Promise<List<Response>> promise) {
+    //System.out.println("batch()#" + this.hashCode());
     if (closed) {
-      throw new IllegalStateException("Connection is closed");
+      promise.fail("Connection is closed");
+      return;
     }
 
     if (commands.isEmpty()) {
       LOG.debug("Empty batch");
-      return Future.succeededFuture(Collections.emptyList());
+      promise.complete(Collections.emptyList());
     } else {
-      // create a new promise bound to the caller not
-      // the instance of this object (a.k.a. "context")
-      final Promise<List<Response>> promise = vertx.promise();
-
       // will re-encode the handler into a list of promises
       final List<Promise<Response>> callbacks = new ArrayList<>(commands.size());
       final Response[] replies = new Response[commands.size()];
@@ -271,12 +271,14 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
         final CommandImpl cmd = (CommandImpl) req.command();
 
         if (!req.valid()) {
-          return Future.failedFuture("Redis command is not valid, check https://redis.io/commands");
+          promise.fail("Redis command is not valid, check https://redis.io/commands: " + req);
+          return;
         }
 
         if (cmd.isPubSub()) {
           // mixing pubSub cannot be used on a one-shot operation
-          return Future.failedFuture("PubSub command in batch not allowed");
+          promise.fail("PubSub command in batch not allowed");
+          return;
         }
         // encode to the single buffer
         req.encode(messages);
@@ -326,7 +328,8 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
         // we might have switch thread/context
         // this means the check needs to be performed again
         if (waiting.freeSlots() < callbacks.size()) {
-          return Future.failedFuture("Redis waiting Queue is full");
+          promise.fail("Redis waiting queue is full");
+          return;
         }
         // offer all handlers to the waiting queue
         for (Promise<Response> callback : callbacks) {
@@ -344,8 +347,6 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
         context.execute(err, this::fail);
         promise.fail(err);
       }
-
-      return promise.future();
     }
   }
 

--- a/src/test/java/io/vertx/redis/client/test/RedisTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisTest.java
@@ -216,7 +216,7 @@ public class RedisTest {
 
         CompositeFuture.all(futures)
           .onFailure(f -> {
-            should.assertEquals("Redis waiting Queue is full", f.getMessage());
+            should.assertEquals("Redis waiting queue is full", f.getMessage());
             test.complete();
           })
           .onSuccess(r -> {

--- a/src/test/java/io/vertx/redis/client/test/SharedRedisConnectionTest.java
+++ b/src/test/java/io/vertx/redis/client/test/SharedRedisConnectionTest.java
@@ -1,0 +1,126 @@
+package io.vertx.redis.client.test;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.RedisClientType;
+import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.Response;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.GenericContainer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RunWith(VertxUnitRunner.class)
+public class SharedRedisConnectionTest {
+
+  @ClassRule
+  public static final GenericContainer<?> redis = new GenericContainer<>("redis:7")
+    .withExposedPorts(6379);
+
+  private static final int VERTICLES_COUNT = 10;
+  private static final int ITERATIONS_COUNT = 1000;
+
+  private static final String REDIS_NUMBER_VALUE_KEY = "user:post:pinned:1372";
+  private static final String REDIS_SET_VALUE_KEY = "user:like:post:975";
+
+  Vertx vertx;
+  RedisAPI conn;
+
+  @Before
+  public void setup(TestContext test) {
+    Async async = test.async();
+    vertx = Vertx.vertx();
+    RedisOptions options = new RedisOptions()
+      .setConnectionString("redis://" + redis.getHost() + ":" + redis.getFirstMappedPort())
+      .setMaxWaitingHandlers(VERTICLES_COUNT * ITERATIONS_COUNT * 2); // 2 requests per iteration
+    Redis.createClient(vertx, options)
+      .connect()
+      .map(RedisAPI::api)
+      .flatMap(api -> {
+        return api.set(Arrays.asList(REDIS_NUMBER_VALUE_KEY, "42"))
+          .map(api);
+      }).flatMap(api -> {
+        return api.sadd(Arrays.asList(REDIS_SET_VALUE_KEY, "100", "101", "102"))
+          .map(api);
+      })
+      .onComplete(result -> {
+        if (result.succeeded()) {
+          conn = result.result();
+        } else {
+          test.fail(result.cause());
+        }
+        async.complete();
+      });
+  }
+
+  @After
+  public void teardown(TestContext test) {
+    conn.close();
+    vertx.close().onComplete(test.asyncAssertSuccess());
+  }
+
+  @Test
+  public void test(TestContext test) {
+    vertx.deployVerticle(() -> new MyVerticle(conn, test), new DeploymentOptions().setInstances(VERTICLES_COUNT));
+  }
+
+  public static class MyVerticle extends AbstractVerticle {
+    private final RedisAPI conn;
+    private final TestContext test;
+
+    public MyVerticle(RedisAPI conn, TestContext test) {
+      this.conn = conn;
+      this.test = test;
+    }
+
+    @Override
+    public void start() {
+      Async async = test.async(ITERATIONS_COUNT);
+      for (int i = 0; i < ITERATIONS_COUNT; i++) {
+        test()
+          .onSuccess(ignored -> async.countDown())
+          .onFailure(test::fail);
+      }
+    }
+
+    private Future<?> test() {
+      Future<Response> fetchNumberFuture = conn.get(REDIS_NUMBER_VALUE_KEY)
+        .onSuccess(response -> {
+          try {
+            response.toInteger();
+          } catch (Exception e) {
+            test.fail(e);
+          }
+        });
+
+      Future<Response> fetchSetFuture = conn.smembers(REDIS_SET_VALUE_KEY)
+        .onSuccess(response -> {
+          try {
+            for (Response part : response) {
+              part.toInteger();
+            }
+          } catch (Exception e) {
+            test.fail(e);
+          }
+        });
+
+      return Future.all(fetchNumberFuture, fetchSetFuture);
+    }
+  }
+}

--- a/src/test/java/io/vertx/test/redis/RedisClientTLSTest.java
+++ b/src/test/java/io/vertx/test/redis/RedisClientTLSTest.java
@@ -114,18 +114,13 @@ public class RedisClientTLSTest {
         .setConnectionString("rediss://0.0.0.0:" + port + "?test=upgrade"));
 
     client.connect()
-      .onFailure(err -> {
-        System.out.println("REDIS CLIENT (CONNECT) ERR: " + err);
-      })
-      .onSuccess(conn -> {
+      .onComplete(should.asyncAssertSuccess(conn -> {
         conn.send(Request.cmd(Command.PING))
-          .onFailure(should::fail)
-          .onSuccess(res -> {
-            System.out.println("REDIS CLIENT SUCCESS");
+          .onComplete(should.asyncAssertSuccess(ignored -> {
             conn.close();
             test.complete();
-          });
-      });
+          }));
+      }));
   }
 
   @Test(timeout = 30_000L)
@@ -143,12 +138,13 @@ public class RedisClientTLSTest {
         .setConnectionString("rediss://localhost:" + server.actualPort()));
 
     client.connect()
-      .onFailure(should::fail)
-      .onSuccess(conn -> {
+      .onComplete(should.asyncAssertSuccess(conn -> {
         conn.send(Request.cmd(Command.PING))
-          .onFailure(should::fail)
-          .onSuccess(res -> test.complete());
-      });
+          .onComplete(should.asyncAssertSuccess(ignored -> {
+            conn.close();
+            test.complete();
+          }));
+      }));
   }
 
   @Test(timeout = 30_000L)
@@ -167,7 +163,8 @@ public class RedisClientTLSTest {
         .setConnectionString("redis://localhost:" + server.actualPort()));
 
     client.connect()
-      .onFailure(t -> test.complete())
-      .onSuccess(res -> should.fail());
+      .onComplete(should.asyncAssertFailure(ignored -> {
+        test.complete();
+      }));
   }
 }


### PR DESCRIPTION
When a single `RedisConnection` is shared among multiple contexts (e.g. verticles), pipelining doesn't work correctly, because there is no coordination for concurrent access. This commit fixes that by making sure that all requests are performed from the same context on which the `NetSocket` was created. If the current context is different from the `NetSocket` context, the request is emitted on the correct context, which means no concurrent access, all requests are serialized.

Backport of #421 to 4.x