### PR TITLE
Remember failures when collecting initial information in cluster/replication/sentinel

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -226,16 +226,20 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
       if (this.slots.compareAndSet(null, future)) {
         LOG.debug("Obtaining hash slot assignment");
         // attempt to load the slots from the first good endpoint
-        getSlots(connectOptions.getEndpoints(), 0, promise);
+        getSlots(connectOptions.getEndpoints(), 0, ConcurrentHashMap.newKeySet(), promise);
         return future;
       }
     }
   }
 
-  private void getSlots(List<String> endpoints, int index, Handler<AsyncResult<Slots>> onGotSlots) {
+  private void getSlots(List<String> endpoints, int index, Set<Throwable> failures, Handler<AsyncResult<Slots>> onGotSlots) {
     if (index >= endpoints.size()) {
       // stop condition
-      onGotSlots.handle(Future.failedFuture(new RedisConnectException("Cannot connect to any of the provided endpoints")));
+      StringBuilder message = new StringBuilder("Cannot connect to any of the provided endpoints");
+      for (Throwable failure : failures) {
+        message.append("\n- ").append(failure);
+      }
+      onGotSlots.handle(Future.failedFuture(new RedisConnectException(message.toString())));
       scheduleCachedSlotsExpiration();
       return;
     }
@@ -243,7 +247,8 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
     connectionManager.getConnection(endpoints.get(index), RedisReplicas.NEVER != connectOptions.getUseReplicas() ? cmd(READONLY) : null)
       .onFailure(err -> {
         // try with the next endpoint
-        getSlots(endpoints, index + 1, onGotSlots);
+        failures.add(err);
+        getSlots(endpoints, index + 1, failures, onGotSlots);
       })
       .onSuccess(conn -> {
         getSlots(endpoints.get(index), conn).onComplete(result -> {
@@ -253,7 +258,8 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
 
           if (result.failed()) {
             // the slots command failed, try with next endpoint
-            getSlots(endpoints, index + 1, onGotSlots);
+            failures.add(result.cause());
+            getSlots(endpoints, index + 1, failures, onGotSlots);
           } else {
             Slots slots = result.result();
             onGotSlots.handle(Future.succeededFuture(slots));
@@ -269,10 +275,16 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
       .compose(reply -> {
         if (reply == null || reply.size() == 0) {
           // no slots available we can't really proceed
-          return Future.failedFuture("SLOTS No slots available in the cluster.");
+          return Future.failedFuture("CLUSTER SLOTS No slots available in the cluster.");
         }
 
-        return Future.succeededFuture(new Slots(endpoint, reply));
+        Slots result;
+        try {
+          result = new Slots(endpoint, reply);
+        } catch (Exception e) {
+          return Future.failedFuture("CLUSTER SLOTS response invalid: " + e);
+        }
+        return Future.succeededFuture(result);
       });
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisSentinelClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisSentinelClient.java
@@ -25,6 +25,8 @@ import io.vertx.redis.client.impl.types.ErrorType;
 
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static io.vertx.redis.client.Command.*;
 import static io.vertx.redis.client.Request.cmd;
@@ -158,7 +160,7 @@ public class RedisSentinelClient extends BaseRedisClient implements Redis {
   private static void resolveClient(final Resolver checkEndpointFn, final RedisSentinelConnectOptions options, final Handler<AsyncResult<RedisURI>> callback) {
     // Because finding the master is going to be an async list we will terminate
     // when we find one then use promises...
-    iterate(0, checkEndpointFn, options, iterate -> {
+    iterate(0, ConcurrentHashMap.newKeySet(), checkEndpointFn, options, iterate -> {
       if (iterate.failed()) {
         callback.handle(Future.failedFuture(iterate.cause()));
       } else {
@@ -175,12 +177,16 @@ public class RedisSentinelClient extends BaseRedisClient implements Redis {
     });
   }
 
-  private static void iterate(final int idx, final Resolver checkEndpointFn, final RedisSentinelConnectOptions argument, final Handler<AsyncResult<Pair<Integer, RedisURI>>> resultHandler) {
+  private static void iterate(final int idx, final Set<Throwable> failures, final Resolver checkEndpointFn, final RedisSentinelConnectOptions argument, final Handler<AsyncResult<Pair<Integer, RedisURI>>> resultHandler) {
     // stop condition
     final List<String> endpoints = argument.getEndpoints();
 
     if (idx >= endpoints.size()) {
-      resultHandler.handle(Future.failedFuture("No more endpoints in chain."));
+      StringBuilder message = new StringBuilder("Cannot connect to any of the provided endpoints");
+      for (Throwable failure : failures) {
+        message.append("\n- ").append(failure);
+      }
+      resultHandler.handle(Future.failedFuture(new RedisConnectException(message.toString())));
       return;
     }
 
@@ -190,7 +196,8 @@ public class RedisSentinelClient extends BaseRedisClient implements Redis {
         resultHandler.handle(Future.succeededFuture(new Pair<>(idx, res.result())));
       } else {
         // try again with next endpoint
-        iterate(idx + 1, checkEndpointFn, argument, resultHandler);
+        failures.add(res.cause());
+        iterate(idx + 1, failures, checkEndpointFn, argument, resultHandler);
       }
     });
   }


### PR DESCRIPTION
In the cluster, replication and sentinel modes, the first thing we do is iterate through known nodes and for each, connect and send a command to collect some information, until we obtain a successful response.

This commit makes sure we remember the failures and when no successful response is ever obtained, we can complete the connection `Future` with an error message that contains the actual failures and not just a placeholder string.