### PR TITLE
Fix initialization of RedisOptions and Redis[*]ConnectOptions

### DIFF
--- a/src/main/generated/io/vertx/redis/client/RedisConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisConnectOptionsConverter.java
@@ -40,16 +40,6 @@ public class RedisConnectOptionsConverter {
             obj.setPassword((String)member.getValue());
           }
           break;
-        case "endpoints":
-          if (member.getValue() instanceof JsonArray) {
-            java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
-            ((Iterable<Object>)member.getValue()).forEach( item -> {
-              if (item instanceof String)
-                list.add((String)item);
-            });
-            obj.setEndpoints(list);
-          }
-          break;
         case "endpoint":
           break;
         case "connectionStrings":
@@ -63,6 +53,16 @@ public class RedisConnectOptionsConverter {
         case "connectionString":
           if (member.getValue() instanceof String) {
             obj.setConnectionString((String)member.getValue());
+          }
+          break;
+        case "endpoints":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                list.add((String)item);
+            });
+            obj.setEndpoints(list);
           }
           break;
         case "maxWaitingHandlers":
@@ -87,13 +87,13 @@ public class RedisConnectOptionsConverter {
     if (obj.getPassword() != null) {
       json.put("password", obj.getPassword());
     }
+    if (obj.getEndpoint() != null) {
+      json.put("endpoint", obj.getEndpoint());
+    }
     if (obj.getEndpoints() != null) {
       JsonArray array = new JsonArray();
       obj.getEndpoints().forEach(item -> array.add(item));
       json.put("endpoints", array);
-    }
-    if (obj.getEndpoint() != null) {
-      json.put("endpoint", obj.getEndpoint());
     }
     json.put("maxWaitingHandlers", obj.getMaxWaitingHandlers());
   }

--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -30,6 +30,11 @@ public class RedisOptionsConverter {
             obj.setNetClientOptions(new io.vertx.core.net.NetClientOptions((io.vertx.core.json.JsonObject)member.getValue()));
           }
           break;
+        case "endpoint":
+          if (member.getValue() instanceof String) {
+            obj.setEndpoint((String)member.getValue());
+          }
+          break;
         case "endpoints":
           if (member.getValue() instanceof JsonArray) {
             java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
@@ -38,11 +43,6 @@ public class RedisOptionsConverter {
                 list.add((String)item);
             });
             obj.setEndpoints(list);
-          }
-          break;
-        case "endpoint":
-          if (member.getValue() instanceof String) {
-            obj.setEndpoint((String)member.getValue());
           }
           break;
         case "connectionStrings":
@@ -148,13 +148,13 @@ public class RedisOptionsConverter {
     if (obj.getNetClientOptions() != null) {
       json.put("netClientOptions", obj.getNetClientOptions().toJson());
     }
+    if (obj.getEndpoint() != null) {
+      json.put("endpoint", obj.getEndpoint());
+    }
     if (obj.getEndpoints() != null) {
       JsonArray array = new JsonArray();
       obj.getEndpoints().forEach(item -> array.add(item));
       json.put("endpoints", array);
-    }
-    if (obj.getEndpoint() != null) {
-      json.put("endpoint", obj.getEndpoint());
     }
     json.put("maxWaitingHandlers", obj.getMaxWaitingHandlers());
     if (obj.getMasterName() != null) {

--- a/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
@@ -107,6 +107,11 @@ public class RedisClusterConnectOptions extends RedisConnectOptions {
   }
 
   @Override
+  public RedisClusterConnectOptions setPreferredProtocolVersion(ProtocolVersion preferredProtocolVersion) {
+    return (RedisClusterConnectOptions) super.setPreferredProtocolVersion(preferredProtocolVersion);
+  }
+
+  @Override
   public RedisClusterConnectOptions setPassword(String password) {
     return (RedisClusterConnectOptions) super.setPassword(password);
   }
@@ -114,6 +119,11 @@ public class RedisClusterConnectOptions extends RedisConnectOptions {
   @Override
   public RedisClusterConnectOptions setEndpoints(List<String> endpoints) {
     return (RedisClusterConnectOptions) super.setEndpoints(endpoints);
+  }
+
+  @Override
+  public RedisClusterConnectOptions addConnectionString(String connectionString) {
+    return (RedisClusterConnectOptions) super.addConnectionString(connectionString);
   }
 
   @Override

--- a/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
@@ -28,25 +28,27 @@ public class RedisClusterConnectOptions extends RedisConnectOptions {
   private RedisReplicas useReplicas;
   private long hashSlotCacheTTL;
 
+  public RedisClusterConnectOptions() {
+    super();
+    useReplicas = RedisReplicas.NEVER;
+    hashSlotCacheTTL = 1000;
+  }
+
   public RedisClusterConnectOptions(RedisOptions options) {
     super(options);
     setUseReplicas(options.getUseReplicas());
     setHashSlotCacheTTL(options.getHashSlotCacheTTL());
   }
 
-  public RedisClusterConnectOptions() {
-    useReplicas = RedisReplicas.NEVER;
-    hashSlotCacheTTL = 1000;
-  }
-
   public RedisClusterConnectOptions(RedisClusterConnectOptions other) {
-    this.useReplicas = other.useReplicas;
-    this.hashSlotCacheTTL = other.hashSlotCacheTTL;
+    super(other);
+    setUseReplicas(other.getUseReplicas());
+    setHashSlotCacheTTL(other.getHashSlotCacheTTL());
   }
 
   public RedisClusterConnectOptions(JsonObject json) {
-    this();
-    RedisConnectOptionsConverter.fromJson(json, this);
+    super(json);
+    RedisClusterConnectOptionsConverter.fromJson(json, this);
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
@@ -33,38 +33,34 @@ public abstract class RedisConnectOptions {
   private ProtocolVersion preferredProtocolVersion;
   private int maxWaitingHandlers;
 
-  private void init() {
+  public RedisConnectOptions() {
     maxNestedArrays = 32;
     protocolNegotiation = true;
     maxWaitingHandlers = 2048;
   }
 
   public RedisConnectOptions(RedisOptions options) {
+    this();
+    setPassword(options.getPassword());
     setEndpoints(new ArrayList<>(options.getEndpoints()));
+    setMaxNestedArrays(options.getMaxNestedArrays());
     setProtocolNegotiation(options.isProtocolNegotiation());
     setPreferredProtocolVersion(options.getPreferredProtocolVersion());
-    setMaxNestedArrays(options.getMaxNestedArrays());
-    setPassword(options.getPassword());
     setMaxWaitingHandlers(options.getMaxWaitingHandlers());
-    setMaxNestedArrays(options.getMaxNestedArrays());
-  }
-
-  public RedisConnectOptions() {
-    init();
   }
 
   public RedisConnectOptions(RedisConnectOptions other) {
-    init();
-    this.maxNestedArrays = other.maxNestedArrays;
-    this.protocolNegotiation = other.protocolNegotiation;
-    this.preferredProtocolVersion = other.preferredProtocolVersion;
-    this.password = other.password;
-    this.endpoints = new ArrayList<>(other.endpoints);
-    this.maxWaitingHandlers = other.maxWaitingHandlers;
+    this();
+    setPassword(other.getPassword());
+    setEndpoints(new ArrayList<>(other.getEndpoints()));
+    setMaxNestedArrays(other.getMaxNestedArrays());
+    setProtocolNegotiation(other.isProtocolNegotiation());
+    setPreferredProtocolVersion(other.getPreferredProtocolVersion());
+    setMaxWaitingHandlers(other.getMaxWaitingHandlers());
   }
 
   public RedisConnectOptions(JsonObject json) {
-    init();
+    this();
     RedisConnectOptionsConverter.fromJson(json, this);
   }
 
@@ -158,19 +154,6 @@ public abstract class RedisConnectOptions {
   }
 
   /**
-   * Gets the list of redis endpoints to use (mostly used while connecting to a cluster)
-   *
-   * @return list of socket addresses.
-   */
-  public List<String> getEndpoints() {
-    if (endpoints == null) {
-      endpoints = new ArrayList<>();
-      endpoints.add(RedisOptions.DEFAULT_ENDPOINT);
-    }
-    return endpoints;
-  }
-
-  /**
    * Gets the redis endpoint to use
    *
    * @return the Redis connection string URI
@@ -181,18 +164,6 @@ public abstract class RedisConnectOptions {
     }
 
     return endpoints.get(0);
-  }
-
-  /**
-   * Set the endpoints to use while connecting to the redis server. Only the cluster mode will consider more than
-   * 1 element. If more are provided, they are not considered by the client when in single server mode.
-   *
-   * @param endpoints list of socket addresses.
-   * @return fluent self.
-   */
-  public RedisConnectOptions setEndpoints(List<String> endpoints) {
-    this.endpoints = endpoints;
-    return this;
   }
 
   /**
@@ -228,6 +199,31 @@ public abstract class RedisConnectOptions {
     }
 
     this.endpoints.add(connectionString);
+    return this;
+  }
+
+  /**
+   * Gets the list of redis endpoints to use (mostly used while connecting to a cluster)
+   *
+   * @return list of socket addresses.
+   */
+  public List<String> getEndpoints() {
+    if (endpoints == null) {
+      endpoints = new ArrayList<>();
+      endpoints.add(RedisOptions.DEFAULT_ENDPOINT);
+    }
+    return endpoints;
+  }
+
+  /**
+   * Set the endpoints to use while connecting to the redis server. Only the cluster mode will consider more than
+   * 1 element. If more are provided, they are not considered by the client when in single server mode.
+   *
+   * @param endpoints list of socket addresses.
+   * @return fluent self.
+   */
+  public RedisConnectOptions setEndpoints(List<String> endpoints) {
+    this.endpoints = endpoints;
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -59,17 +59,18 @@ public class RedisOptions {
    * Creates a default configuration object using redis server defaults
    */
   public RedisOptions() {
+    type = RedisClientType.STANDALONE;
     netClientOptions =
       new NetClientOptions()
         .setTcpKeepAlive(true)
         .setTcpNoDelay(true);
-
     poolOptions = new PoolOptions();
-    type = RedisClientType.STANDALONE;
-    useReplicas = RedisReplicas.NEVER;
-    maxNestedArrays = 32;
-    protocolNegotiation = true;
     maxWaitingHandlers = 2048;
+    maxNestedArrays = 32;
+    masterName = "mymaster";
+    role = RedisRole.MASTER;
+    useReplicas = RedisReplicas.NEVER;
+    protocolNegotiation = true;
     hashSlotCacheTTL = 1000;
   }
 
@@ -79,10 +80,12 @@ public class RedisOptions {
    * @param other the object to clone.
    */
   public RedisOptions(RedisOptions other) {
+    this();
     this.type = other.type;
     this.netClientOptions = other.netClientOptions;
-    this.poolOptions = new PoolOptions(other.poolOptions);
     this.endpoints = other.endpoints;
+    this.poolOptions = new PoolOptions(other.poolOptions);
+    this.maxWaitingHandlers = other.maxWaitingHandlers;
     this.maxNestedArrays = other.maxNestedArrays;
     this.masterName = other.masterName;
     this.role = other.role;
@@ -91,7 +94,6 @@ public class RedisOptions {
     this.protocolNegotiation = other.protocolNegotiation;
     this.preferredProtocolVersion = other.preferredProtocolVersion;
     this.hashSlotCacheTTL = other.hashSlotCacheTTL;
-    this.maxWaitingHandlers = other.maxWaitingHandlers;
     this.tracingPolicy = other.tracingPolicy;
   }
 
@@ -147,19 +149,6 @@ public class RedisOptions {
   }
 
   /**
-   * Gets the list of redis endpoints to use (mostly used while connecting to a cluster)
-   *
-   * @return list of socket addresses.
-   */
-  public List<String> getEndpoints() {
-    if (endpoints == null) {
-      endpoints = new ArrayList<>();
-      endpoints.add(DEFAULT_ENDPOINT);
-    }
-    return endpoints;
-  }
-
-  /**
    * Gets the redis endpoint to use
    *
    * @return the Redis connection string URI
@@ -170,18 +159,6 @@ public class RedisOptions {
     }
 
     return endpoints.get(0);
-  }
-
-  /**
-   * Set the endpoints to use while connecting to the redis server. Only the cluster mode will consider more than
-   * 1 element. If more are provided, they are not considered by the client when in single server mode.
-   *
-   * @param endpoints list of socket addresses.
-   * @return fluent self.
-   */
-  public RedisOptions setEndpoints(List<String> endpoints) {
-    this.endpoints = endpoints;
-    return this;
   }
 
   /**
@@ -253,6 +230,31 @@ public class RedisOptions {
     }
 
     this.endpoints.add(connectionString);
+    return this;
+  }
+
+  /**
+   * Gets the list of redis endpoints to use (mostly used while connecting to a cluster)
+   *
+   * @return list of socket addresses.
+   */
+  public List<String> getEndpoints() {
+    if (endpoints == null) {
+      endpoints = new ArrayList<>();
+      endpoints.add(DEFAULT_ENDPOINT);
+    }
+    return endpoints;
+  }
+
+  /**
+   * Set the endpoints to use while connecting to the redis server. Only the cluster mode will consider more than
+   * 1 element. If more are provided, they are not considered by the client when in single server mode.
+   *
+   * @param endpoints list of socket addresses.
+   * @return fluent self.
+   */
+  public RedisOptions setEndpoints(List<String> endpoints) {
+    this.endpoints = endpoints;
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
@@ -28,25 +28,27 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
   private RedisRole role;
   private String masterName;
 
+  public RedisSentinelConnectOptions() {
+    super();
+    role = RedisRole.MASTER;
+    masterName = "mymaster";
+  }
+
   public RedisSentinelConnectOptions(RedisOptions options) {
     super(options);
     setRole(options.getRole());
     setMasterName(options.getMasterName());
   }
 
-  public RedisSentinelConnectOptions() {
-    role = RedisRole.MASTER;
-    masterName = "mymaster";
-  }
-
   public RedisSentinelConnectOptions(RedisSentinelConnectOptions other) {
-    this.role = other.role;
-    this.masterName = other.masterName;
+    super(other);
+    setRole(other.getRole());
+    setMasterName(other.getMasterName());
   }
 
   public RedisSentinelConnectOptions(JsonObject json) {
-    this();
-    RedisConnectOptionsConverter.fromJson(json, this);
+    super(json);
+    RedisSentinelConnectOptionsConverter.fromJson(json, this);
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
@@ -102,6 +102,11 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
   }
 
   @Override
+  public RedisSentinelConnectOptions setPreferredProtocolVersion(ProtocolVersion preferredProtocolVersion) {
+    return (RedisSentinelConnectOptions) super.setPreferredProtocolVersion(preferredProtocolVersion);
+  }
+
+  @Override
   public RedisSentinelConnectOptions setPassword(String password) {
     return (RedisSentinelConnectOptions) super.setPassword(password);
   }
@@ -109,6 +114,11 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
   @Override
   public RedisSentinelConnectOptions setEndpoints(List<String> endpoints) {
     return (RedisSentinelConnectOptions) super.setEndpoints(endpoints);
+  }
+
+  @Override
+  public RedisSentinelConnectOptions addConnectionString(String connectionString) {
+    return (RedisSentinelConnectOptions) super.addConnectionString(connectionString);
   }
 
   @Override

--- a/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
@@ -25,19 +25,21 @@ import java.util.List;
 @JsonGen(publicConverter = false)
 public class RedisStandaloneConnectOptions extends RedisConnectOptions {
 
+  public RedisStandaloneConnectOptions() {
+    super();
+  }
+
   public RedisStandaloneConnectOptions(RedisOptions options) {
     super(options);
   }
 
-  public RedisStandaloneConnectOptions() {
-  }
-
   public RedisStandaloneConnectOptions(RedisStandaloneConnectOptions other) {
+    super(other);
   }
 
   public RedisStandaloneConnectOptions(JsonObject json) {
-    this();
-    RedisConnectOptionsConverter.fromJson(json, this);
+    super(json);
+    RedisStandaloneConnectOptionsConverter.fromJson(json, this);
   }
 
   @Override

--- a/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
@@ -53,6 +53,11 @@ public class RedisStandaloneConnectOptions extends RedisConnectOptions {
   }
 
   @Override
+  public RedisStandaloneConnectOptions setPreferredProtocolVersion(ProtocolVersion preferredProtocolVersion) {
+    return (RedisStandaloneConnectOptions) super.setPreferredProtocolVersion(preferredProtocolVersion);
+  }
+
+  @Override
   public RedisStandaloneConnectOptions setPassword(String password) {
     return (RedisStandaloneConnectOptions) super.setPassword(password);
   }
@@ -60,6 +65,11 @@ public class RedisStandaloneConnectOptions extends RedisConnectOptions {
   @Override
   public RedisStandaloneConnectOptions setEndpoints(List<String> endpoints) {
     return (RedisStandaloneConnectOptions) super.setEndpoints(endpoints);
+  }
+
+  @Override
+  public RedisStandaloneConnectOptions addConnectionString(String connectionString) {
+    return (RedisStandaloneConnectOptions) super.addConnectionString(connectionString);
   }
 
   @Override

--- a/src/test/java/io/vertx/redis/client/test/RedisConnectOptionsTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisConnectOptionsTest.java
@@ -1,0 +1,105 @@
+package io.vertx.redis.client.test;
+
+import io.vertx.redis.client.RedisClusterConnectOptions;
+import io.vertx.redis.client.RedisReplicas;
+import io.vertx.redis.client.RedisRole;
+import io.vertx.redis.client.RedisSentinelConnectOptions;
+import io.vertx.redis.client.RedisStandaloneConnectOptions;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RedisConnectOptionsTest {
+  @Test
+  public void testRedisStandaloneConnectOptions() {
+    RedisStandaloneConnectOptions options = new RedisStandaloneConnectOptions();
+    assertTrue(options.isProtocolNegotiation()); // default value
+  }
+
+  @Test
+  public void testRedisStandaloneConnectOptionsCopy() {
+    RedisStandaloneConnectOptions previousOptions = new RedisStandaloneConnectOptions();
+    previousOptions.setPassword("password");
+
+    RedisStandaloneConnectOptions options = new RedisStandaloneConnectOptions(previousOptions);
+    assertTrue(options.isProtocolNegotiation()); // default value
+    assertEquals("password", options.getPassword());
+  }
+
+  @Test
+  public void testRedisStandaloneConnectOptionsFromJson() {
+    RedisStandaloneConnectOptions previousOptions = new RedisStandaloneConnectOptions();
+    previousOptions.setPassword("password");
+
+    RedisStandaloneConnectOptions options = new RedisStandaloneConnectOptions(previousOptions.toJson());
+    assertTrue(options.isProtocolNegotiation()); // default value
+    assertEquals("password", options.getPassword());
+  }
+
+  // ---
+
+  @Test
+  public void testRedisClusterConnectOptions() {
+    RedisClusterConnectOptions options = new RedisClusterConnectOptions();
+    assertTrue(options.isProtocolNegotiation()); // default value
+    assertEquals(RedisReplicas.NEVER, options.getUseReplicas()); // default value
+  }
+
+  @Test
+  public void testRedisClusterConnectOptionsCopy() {
+    RedisClusterConnectOptions original = new RedisClusterConnectOptions();
+    original.setPassword("password");
+    original.setUseReplicas(RedisReplicas.ALWAYS);
+
+    RedisClusterConnectOptions copy = new RedisClusterConnectOptions(original);
+    assertTrue(copy.isProtocolNegotiation()); // default value
+    assertEquals("password", copy.getPassword());
+    assertEquals(RedisReplicas.ALWAYS, copy.getUseReplicas());
+  }
+
+  @Test
+  public void testRedisClusterConnectOptionsFromJson() {
+    RedisClusterConnectOptions original = new RedisClusterConnectOptions();
+    original.setPassword("password");
+    original.setUseReplicas(RedisReplicas.SHARE);
+
+    RedisClusterConnectOptions copy = new RedisClusterConnectOptions(original.toJson());
+    assertTrue(copy.isProtocolNegotiation()); // default value
+    assertEquals("password", copy.getPassword());
+    assertEquals(RedisReplicas.SHARE, copy.getUseReplicas());
+  }
+
+  // ---
+
+  @Test
+  public void testRedisSentinelConnectOptions() {
+    RedisSentinelConnectOptions options = new RedisSentinelConnectOptions();
+    assertTrue(options.isProtocolNegotiation()); // default value
+    assertEquals(RedisRole.MASTER, options.getRole()); // default value
+  }
+
+  @Test
+  public void testRedisSentinelConnectOptionsCopy() {
+    RedisSentinelConnectOptions previousOptions = new RedisSentinelConnectOptions();
+    previousOptions.setPassword("password");
+    previousOptions.setRole(RedisRole.SENTINEL);
+
+    RedisSentinelConnectOptions options = new RedisSentinelConnectOptions(previousOptions);
+    assertTrue(options.isProtocolNegotiation()); // default value
+    assertEquals("password", options.getPassword());
+    assertEquals(RedisRole.SENTINEL, options.getRole());
+  }
+
+  @Test
+  public void testRedisSentinelConnectOptionsFromJson() {
+    RedisSentinelConnectOptions previousOptions = new RedisSentinelConnectOptions();
+    previousOptions.setPassword("password");
+    previousOptions.setRole(RedisRole.REPLICA);
+
+    RedisSentinelConnectOptions options = new RedisSentinelConnectOptions(previousOptions.toJson());
+    assertTrue(options.isProtocolNegotiation()); // default value
+    assertEquals("password", options.getPassword());
+    assertEquals(RedisRole.REPLICA, options.getRole());
+  }
+}

--- a/src/test/java/io/vertx/redis/client/test/RedisOptionsTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisOptionsTest.java
@@ -1,13 +1,14 @@
 package io.vertx.redis.client.test;
 
 import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.redis.client.RedisClientType;
 import io.vertx.redis.client.RedisOptions;
 import io.vertx.redis.client.RedisRole;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -15,9 +16,12 @@ public class RedisOptionsTest {
 
   @Test
   public void testRedisOptions() {
-    assertEquals(6, new RedisOptions().getMaxPoolSize());
-    assertEquals("redis://localhost:6379", new RedisOptions().getEndpoint());
-    assertEquals(Collections.singletonList("redis://localhost:6379"), new RedisOptions().getEndpoints());
+    RedisOptions options = new RedisOptions();
+
+    assertEquals(RedisClientType.STANDALONE, options.getType()); // default value
+    assertEquals(6, options.getMaxPoolSize()); // default value
+    assertEquals("redis://localhost:6379", options.getEndpoint()); // default value
+    assertEquals(Collections.singletonList("redis://localhost:6379"), options.getEndpoints()); // default value
   }
 
   @Test
@@ -37,6 +41,38 @@ public class RedisOptionsTest {
 
     RedisOptions copy = new RedisOptions(original);
 
-    assertEquals(original.toJson(), copy.toJson());
+    assertEquals(RedisClientType.STANDALONE, copy.getType()); // default value
+    assertEquals(6, copy.getMaxPoolSize()); // default value
+    assertEquals(endpoints, copy.getEndpoints());
+    assertEquals("someOtherMaster", copy.getMasterName());
+    assertEquals(RedisRole.SENTINEL, copy.getRole());
+    assertEquals("myPassword", copy.getPassword());
+    assertEquals(TracingPolicy.ALWAYS, copy.getTracingPolicy());
   }
+
+  @Test
+  public void testFromJsonInstance() {
+    List<String> endpoints = new ArrayList<>(3);
+    endpoints.add("redis://localhost:123");
+    endpoints.add("redis://localhost:124");
+    endpoints.add("redis://localhost:125");
+
+    RedisOptions original = new RedisOptions()
+      .setEndpoints(endpoints)
+      .setMasterName("someOtherMaster")
+      .setRole(RedisRole.SENTINEL)
+      .setPassword("myPassword")
+      .setTracingPolicy(TracingPolicy.ALWAYS);
+
+    RedisOptions copy = new RedisOptions(original.toJson());
+
+    assertEquals(RedisClientType.STANDALONE, copy.getType()); // default value
+    assertEquals(6, copy.getMaxPoolSize()); // default value
+    assertEquals(endpoints, copy.getEndpoints());
+    assertEquals("someOtherMaster", copy.getMasterName());
+    assertEquals(RedisRole.SENTINEL, copy.getRole());
+    assertEquals("myPassword", copy.getPassword());
+    assertEquals(TracingPolicy.ALWAYS, copy.getTracingPolicy());
+  }
+
 }


### PR DESCRIPTION
This commit makes sure that:

- all mandatory fields of `RedisOptions` are initialized (initializing them only in `Redis[*]ConnectOptions` is not enough due to the usage of copy constructors);
- all constructors of subclasses of `RedisConnectOptions` properly delegate to the corresponding superclass constructors;
- the `JsonObject`-accepting constructors of subclasses of `RedisConnectOptions` call the correct conversion function, after delegating to the corresponding superclass constructor, which calls its own conversion function;
- no information is lost during JSON serialization / deserialization, by reordering the getters / setters in the `Redis[Connect]Options` classes.