### PR TITLE
[4.x] Fix initialization of RedisOptions and Redis[*]ConnectOptions

### DIFF
--- a/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
@@ -107,6 +107,11 @@ public class RedisClusterConnectOptions extends RedisConnectOptions {
   }
 
   @Override
+  public RedisClusterConnectOptions setPreferredProtocolVersion(ProtocolVersion preferredProtocolVersion) {
+    return (RedisClusterConnectOptions) super.setPreferredProtocolVersion(preferredProtocolVersion);
+  }
+
+  @Override
   public RedisClusterConnectOptions setPassword(String password) {
     return (RedisClusterConnectOptions) super.setPassword(password);
   }
@@ -114,6 +119,11 @@ public class RedisClusterConnectOptions extends RedisConnectOptions {
   @Override
   public RedisClusterConnectOptions setEndpoints(List<String> endpoints) {
     return (RedisClusterConnectOptions) super.setEndpoints(endpoints);
+  }
+
+  @Override
+  public RedisClusterConnectOptions addConnectionString(String connectionString) {
+    return (RedisClusterConnectOptions) super.addConnectionString(connectionString);
   }
 
   @Override

--- a/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
@@ -28,25 +28,27 @@ public class RedisClusterConnectOptions extends RedisConnectOptions {
   private RedisReplicas useReplicas;
   private long hashSlotCacheTTL;
 
+  public RedisClusterConnectOptions() {
+    super();
+    useReplicas = RedisReplicas.NEVER;
+    hashSlotCacheTTL = 1000;
+  }
+
   public RedisClusterConnectOptions(RedisOptions options) {
     super(options);
     setUseReplicas(options.getUseReplicas());
     setHashSlotCacheTTL(options.getHashSlotCacheTTL());
   }
 
-  public RedisClusterConnectOptions() {
-    useReplicas = RedisReplicas.NEVER;
-    hashSlotCacheTTL = 1000;
-  }
-
   public RedisClusterConnectOptions(RedisClusterConnectOptions other) {
-    this.useReplicas = other.useReplicas;
-    this.hashSlotCacheTTL = other.hashSlotCacheTTL;
+    super(other);
+    setUseReplicas(other.getUseReplicas());
+    setHashSlotCacheTTL(other.getHashSlotCacheTTL());
   }
 
   public RedisClusterConnectOptions(JsonObject json) {
-    this();
-    RedisConnectOptionsConverter.fromJson(json, this);
+    super(json);
+    RedisClusterConnectOptionsConverter.fromJson(json, this);
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
@@ -33,38 +33,34 @@ public abstract class RedisConnectOptions {
   private ProtocolVersion preferredProtocolVersion;
   private int maxWaitingHandlers;
 
-  private void init() {
+  public RedisConnectOptions() {
     maxNestedArrays = 32;
     protocolNegotiation = true;
     maxWaitingHandlers = 2048;
   }
 
   public RedisConnectOptions(RedisOptions options) {
+    this();
+    setPassword(options.getPassword());
     setEndpoints(new ArrayList<>(options.getEndpoints()));
+    setMaxNestedArrays(options.getMaxNestedArrays());
     setProtocolNegotiation(options.isProtocolNegotiation());
     setPreferredProtocolVersion(options.getPreferredProtocolVersion());
-    setMaxNestedArrays(options.getMaxNestedArrays());
-    setPassword(options.getPassword());
     setMaxWaitingHandlers(options.getMaxWaitingHandlers());
-    setMaxNestedArrays(options.getMaxNestedArrays());
-  }
-
-  public RedisConnectOptions() {
-    init();
   }
 
   public RedisConnectOptions(RedisConnectOptions other) {
-    init();
-    this.maxNestedArrays = other.maxNestedArrays;
-    this.protocolNegotiation = other.protocolNegotiation;
-    this.preferredProtocolVersion = other.preferredProtocolVersion;
-    this.password = other.password;
-    this.endpoints = new ArrayList<>(other.endpoints);
-    this.maxWaitingHandlers = other.maxWaitingHandlers;
+    this();
+    setPassword(other.getPassword());
+    setEndpoints(new ArrayList<>(other.getEndpoints()));
+    setMaxNestedArrays(other.getMaxNestedArrays());
+    setProtocolNegotiation(other.isProtocolNegotiation());
+    setPreferredProtocolVersion(other.getPreferredProtocolVersion());
+    setMaxWaitingHandlers(other.getMaxWaitingHandlers());
   }
 
   public RedisConnectOptions(JsonObject json) {
-    init();
+    this();
     RedisConnectOptionsConverter.fromJson(json, this);
   }
 

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -59,17 +59,18 @@ public class RedisOptions {
    * Creates a default configuration object using redis server defaults
    */
   public RedisOptions() {
+    type = RedisClientType.STANDALONE;
     netClientOptions =
       new NetClientOptions()
         .setTcpKeepAlive(true)
         .setTcpNoDelay(true);
-
     poolOptions = new PoolOptions();
-    type = RedisClientType.STANDALONE;
-    useReplicas = RedisReplicas.NEVER;
-    maxNestedArrays = 32;
-    protocolNegotiation = true;
     maxWaitingHandlers = 2048;
+    maxNestedArrays = 32;
+    masterName = "mymaster";
+    role = RedisRole.MASTER;
+    useReplicas = RedisReplicas.NEVER;
+    protocolNegotiation = true;
     hashSlotCacheTTL = 1000;
   }
 
@@ -79,10 +80,12 @@ public class RedisOptions {
    * @param other the object to clone.
    */
   public RedisOptions(RedisOptions other) {
+    this();
     this.type = other.type;
     this.netClientOptions = other.netClientOptions;
-    this.poolOptions = new PoolOptions(other.poolOptions);
     this.endpoints = other.endpoints;
+    this.poolOptions = new PoolOptions(other.poolOptions);
+    this.maxWaitingHandlers = other.maxWaitingHandlers;
     this.maxNestedArrays = other.maxNestedArrays;
     this.masterName = other.masterName;
     this.role = other.role;
@@ -91,6 +94,7 @@ public class RedisOptions {
     this.protocolNegotiation = other.protocolNegotiation;
     this.preferredProtocolVersion = other.preferredProtocolVersion;
     this.hashSlotCacheTTL = other.hashSlotCacheTTL;
+    this.tracingPolicy = other.tracingPolicy;
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
@@ -28,25 +28,27 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
   private RedisRole role;
   private String masterName;
 
+  public RedisSentinelConnectOptions() {
+    super();
+    role = RedisRole.MASTER;
+    masterName = "mymaster";
+  }
+
   public RedisSentinelConnectOptions(RedisOptions options) {
     super(options);
     setRole(options.getRole());
     setMasterName(options.getMasterName());
   }
 
-  public RedisSentinelConnectOptions() {
-    role = RedisRole.MASTER;
-    masterName = "mymaster";
-  }
-
   public RedisSentinelConnectOptions(RedisSentinelConnectOptions other) {
-    this.role = other.role;
-    this.masterName = other.masterName;
+    super(other);
+    setRole(other.getRole());
+    setMasterName(other.getMasterName());
   }
 
   public RedisSentinelConnectOptions(JsonObject json) {
-    this();
-    RedisConnectOptionsConverter.fromJson(json, this);
+    super(json);
+    RedisSentinelConnectOptionsConverter.fromJson(json, this);
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
@@ -102,6 +102,11 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
   }
 
   @Override
+  public RedisSentinelConnectOptions setPreferredProtocolVersion(ProtocolVersion preferredProtocolVersion) {
+    return (RedisSentinelConnectOptions) super.setPreferredProtocolVersion(preferredProtocolVersion);
+  }
+
+  @Override
   public RedisSentinelConnectOptions setPassword(String password) {
     return (RedisSentinelConnectOptions) super.setPassword(password);
   }
@@ -109,6 +114,11 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
   @Override
   public RedisSentinelConnectOptions setEndpoints(List<String> endpoints) {
     return (RedisSentinelConnectOptions) super.setEndpoints(endpoints);
+  }
+
+  @Override
+  public RedisSentinelConnectOptions addConnectionString(String connectionString) {
+    return (RedisSentinelConnectOptions) super.addConnectionString(connectionString);
   }
 
   @Override

--- a/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
@@ -25,19 +25,21 @@ import java.util.List;
 @JsonGen(publicConverter = false)
 public class RedisStandaloneConnectOptions extends RedisConnectOptions {
 
+  public RedisStandaloneConnectOptions() {
+    super();
+  }
+
   public RedisStandaloneConnectOptions(RedisOptions options) {
     super(options);
   }
 
-  public RedisStandaloneConnectOptions() {
-  }
-
   public RedisStandaloneConnectOptions(RedisStandaloneConnectOptions other) {
+    super(other);
   }
 
   public RedisStandaloneConnectOptions(JsonObject json) {
-    this();
-    RedisConnectOptionsConverter.fromJson(json, this);
+    super(json);
+    RedisStandaloneConnectOptionsConverter.fromJson(json, this);
   }
 
   @Override

--- a/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
@@ -53,6 +53,11 @@ public class RedisStandaloneConnectOptions extends RedisConnectOptions {
   }
 
   @Override
+  public RedisStandaloneConnectOptions setPreferredProtocolVersion(ProtocolVersion preferredProtocolVersion) {
+    return (RedisStandaloneConnectOptions) super.setPreferredProtocolVersion(preferredProtocolVersion);
+  }
+
+  @Override
   public RedisStandaloneConnectOptions setPassword(String password) {
     return (RedisStandaloneConnectOptions) super.setPassword(password);
   }
@@ -60,6 +65,11 @@ public class RedisStandaloneConnectOptions extends RedisConnectOptions {
   @Override
   public RedisStandaloneConnectOptions setEndpoints(List<String> endpoints) {
     return (RedisStandaloneConnectOptions) super.setEndpoints(endpoints);
+  }
+
+  @Override
+  public RedisStandaloneConnectOptions addConnectionString(String connectionString) {
+    return (RedisStandaloneConnectOptions) super.addConnectionString(connectionString);
   }
 
   @Override

--- a/src/test/java/io/vertx/redis/client/test/RedisConnectOptionsTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisConnectOptionsTest.java
@@ -1,0 +1,105 @@
+package io.vertx.redis.client.test;
+
+import io.vertx.redis.client.RedisClusterConnectOptions;
+import io.vertx.redis.client.RedisReplicas;
+import io.vertx.redis.client.RedisRole;
+import io.vertx.redis.client.RedisSentinelConnectOptions;
+import io.vertx.redis.client.RedisStandaloneConnectOptions;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RedisConnectOptionsTest {
+  @Test
+  public void testRedisStandaloneConnectOptions() {
+    RedisStandaloneConnectOptions options = new RedisStandaloneConnectOptions();
+    assertTrue(options.isProtocolNegotiation()); // default value
+  }
+
+  @Test
+  public void testRedisStandaloneConnectOptionsCopy() {
+    RedisStandaloneConnectOptions previousOptions = new RedisStandaloneConnectOptions();
+    previousOptions.setPassword("password");
+
+    RedisStandaloneConnectOptions options = new RedisStandaloneConnectOptions(previousOptions);
+    assertTrue(options.isProtocolNegotiation()); // default value
+    assertEquals("password", options.getPassword());
+  }
+
+  @Test
+  public void testRedisStandaloneConnectOptionsFromJson() {
+    RedisStandaloneConnectOptions previousOptions = new RedisStandaloneConnectOptions();
+    previousOptions.setPassword("password");
+
+    RedisStandaloneConnectOptions options = new RedisStandaloneConnectOptions(previousOptions.toJson());
+    assertTrue(options.isProtocolNegotiation()); // default value
+    assertEquals("password", options.getPassword());
+  }
+
+  // ---
+
+  @Test
+  public void testRedisClusterConnectOptions() {
+    RedisClusterConnectOptions options = new RedisClusterConnectOptions();
+    assertTrue(options.isProtocolNegotiation()); // default value
+    assertEquals(RedisReplicas.NEVER, options.getUseReplicas()); // default value
+  }
+
+  @Test
+  public void testRedisClusterConnectOptionsCopy() {
+    RedisClusterConnectOptions original = new RedisClusterConnectOptions();
+    original.setPassword("password");
+    original.setUseReplicas(RedisReplicas.ALWAYS);
+
+    RedisClusterConnectOptions copy = new RedisClusterConnectOptions(original);
+    assertTrue(copy.isProtocolNegotiation()); // default value
+    assertEquals("password", copy.getPassword());
+    assertEquals(RedisReplicas.ALWAYS, copy.getUseReplicas());
+  }
+
+  @Test
+  public void testRedisClusterConnectOptionsFromJson() {
+    RedisClusterConnectOptions original = new RedisClusterConnectOptions();
+    original.setPassword("password");
+    original.setUseReplicas(RedisReplicas.SHARE);
+
+    RedisClusterConnectOptions copy = new RedisClusterConnectOptions(original.toJson());
+    assertTrue(copy.isProtocolNegotiation()); // default value
+    assertEquals("password", copy.getPassword());
+    assertEquals(RedisReplicas.SHARE, copy.getUseReplicas());
+  }
+
+  // ---
+
+  @Test
+  public void testRedisSentinelConnectOptions() {
+    RedisSentinelConnectOptions options = new RedisSentinelConnectOptions();
+    assertTrue(options.isProtocolNegotiation()); // default value
+    assertEquals(RedisRole.MASTER, options.getRole()); // default value
+  }
+
+  @Test
+  public void testRedisSentinelConnectOptionsCopy() {
+    RedisSentinelConnectOptions previousOptions = new RedisSentinelConnectOptions();
+    previousOptions.setPassword("password");
+    previousOptions.setRole(RedisRole.SENTINEL);
+
+    RedisSentinelConnectOptions options = new RedisSentinelConnectOptions(previousOptions);
+    assertTrue(options.isProtocolNegotiation()); // default value
+    assertEquals("password", options.getPassword());
+    assertEquals(RedisRole.SENTINEL, options.getRole());
+  }
+
+  @Test
+  public void testRedisSentinelConnectOptionsFromJson() {
+    RedisSentinelConnectOptions previousOptions = new RedisSentinelConnectOptions();
+    previousOptions.setPassword("password");
+    previousOptions.setRole(RedisRole.REPLICA);
+
+    RedisSentinelConnectOptions options = new RedisSentinelConnectOptions(previousOptions.toJson());
+    assertTrue(options.isProtocolNegotiation()); // default value
+    assertEquals("password", options.getPassword());
+    assertEquals(RedisRole.REPLICA, options.getRole());
+  }
+}

--- a/src/test/java/io/vertx/redis/client/test/RedisOptionsTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisOptionsTest.java
@@ -1,9 +1,14 @@
 package io.vertx.redis.client.test;
 
+import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.redis.client.RedisClientType;
 import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.RedisRole;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -11,8 +16,63 @@ public class RedisOptionsTest {
 
   @Test
   public void testRedisOptions() {
-    assertEquals(6, new RedisOptions().getMaxPoolSize());
-    assertEquals("redis://localhost:6379", new RedisOptions().getEndpoint());
-    assertEquals(Collections.singletonList("redis://localhost:6379"), new RedisOptions().getEndpoints());
+    RedisOptions options = new RedisOptions();
+
+    assertEquals(RedisClientType.STANDALONE, options.getType()); // default value
+    assertEquals(6, options.getMaxPoolSize()); // default value
+    assertEquals("redis://localhost:6379", options.getEndpoint()); // default value
+    assertEquals(Collections.singletonList("redis://localhost:6379"), options.getEndpoints()); // default value
   }
+
+  @Test
+  public void testOptionsCopy() {
+    List<String> endpoints = new ArrayList<>(3);
+    endpoints.add("redis://localhost:123");
+    endpoints.add("redis://localhost:124");
+    endpoints.add("redis://localhost:125");
+
+    // Set values for which there is no default to ensure they are copied correctly
+    RedisOptions original = new RedisOptions()
+      .setEndpoints(endpoints)
+      .setMasterName("someOtherMaster")
+      .setRole(RedisRole.SENTINEL)
+      .setPassword("myPassword")
+      .setTracingPolicy(TracingPolicy.ALWAYS);
+
+    RedisOptions copy = new RedisOptions(original);
+
+    assertEquals(RedisClientType.STANDALONE, copy.getType()); // default value
+    assertEquals(6, copy.getMaxPoolSize()); // default value
+    assertEquals(endpoints, copy.getEndpoints());
+    assertEquals("someOtherMaster", copy.getMasterName());
+    assertEquals(RedisRole.SENTINEL, copy.getRole());
+    assertEquals("myPassword", copy.getPassword());
+    assertEquals(TracingPolicy.ALWAYS, copy.getTracingPolicy());
+  }
+
+  @Test
+  public void testFromJsonInstance() {
+    List<String> endpoints = new ArrayList<>(3);
+    endpoints.add("redis://localhost:123");
+    endpoints.add("redis://localhost:124");
+    endpoints.add("redis://localhost:125");
+
+    RedisOptions original = new RedisOptions()
+      .setEndpoints(endpoints)
+      .setMasterName("someOtherMaster")
+      .setRole(RedisRole.SENTINEL)
+      .setPassword("myPassword")
+      .setTracingPolicy(TracingPolicy.ALWAYS);
+
+    RedisOptions copy = new RedisOptions(original.toJson());
+
+    assertEquals(RedisClientType.STANDALONE, copy.getType()); // default value
+    assertEquals(6, copy.getMaxPoolSize()); // default value
+    assertEquals(endpoints, copy.getEndpoints());
+    assertEquals("someOtherMaster", copy.getMasterName());
+    assertEquals(RedisRole.SENTINEL, copy.getRole());
+    assertEquals("myPassword", copy.getPassword());
+    assertEquals(TracingPolicy.ALWAYS, copy.getTracingPolicy());
+  }
+
 }


### PR DESCRIPTION
This commit makes sure that:

- all mandatory fields of `RedisOptions` are initialized (initializing them only in `Redis[*]ConnectOptions` is not enough due to the usage of copy constructors);
- all constructors of subclasses of `RedisConnectOptions` properly delegate to the corresponding superclass constructors;
- the `JsonObject`-accepting constructors of subclasses of `RedisConnectOptions` call the correct conversion function, after delegating to the corresponding superclass constructor, which calls its own conversion function.

Backport of #428 to 4.x