### PR TITLE
Add Response.isArray() and isMap()

### DIFF
--- a/src/main/java/io/vertx/redis/client/Response.java
+++ b/src/main/java/io/vertx/redis/client/Response.java
@@ -287,6 +287,29 @@ public interface Response extends Iterable<Response> {
   }
 
   /**
+   * Returns whether this multi response is an array and hence {@link #get(int)} can be called.
+   * <p>
+   * Returns {@code true} also for {@link ResponseType#PUSH} and {@link ResponseType#ATTRIBUTE}.
+   *
+   * @return whether this multi response is an array
+   */
+  default boolean isArray() {
+    throw new UnsupportedOperationException("This type doesn't hold an Array/Map type");
+  }
+
+  /**
+   * Returns whether this multi response is a map and hence {@link #get(String)},
+   * {@link #containsKey(String)} and {@link #getKeys()} may be called.
+   * <p>
+   * Returns {@code true} also for {@link ResponseType#ATTRIBUTE}.
+   *
+   * @return whether this multi response is a map
+   */
+  default boolean isMap() {
+    throw new UnsupportedOperationException("This type doesn't hold an Array/Map type");
+  }
+
+  /**
    * Return an iterator so it can be iterated using the foreach construct.
    *
    * @return response iterator.
@@ -294,7 +317,7 @@ public interface Response extends Iterable<Response> {
   @Override
   @GenIgnore
   default Iterator<Response> iterator() {
-    throw new UnsupportedOperationException("This type doesn't hold a Array type");
+    throw new UnsupportedOperationException("This type doesn't hold an Array/Map type");
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/impl/types/AttributeType.java
+++ b/src/main/java/io/vertx/redis/client/impl/types/AttributeType.java
@@ -75,6 +75,11 @@ public final class AttributeType implements Multi {
   }
 
   @Override
+  public boolean containsKey(String key) {
+    return map.containsKey(key);
+  }
+
+  @Override
   public Set<String> getKeys() {
     return map.keySet();
   }
@@ -82,6 +87,16 @@ public final class AttributeType implements Multi {
   @Override
   public int size() {
     return replies.length;
+  }
+
+  @Override
+  public boolean isArray() {
+    return true;
+  }
+
+  @Override
+  public boolean isMap() {
+    return true;
   }
 
   @Override

--- a/src/main/java/io/vertx/redis/client/impl/types/MultiType.java
+++ b/src/main/java/io/vertx/redis/client/impl/types/MultiType.java
@@ -193,6 +193,16 @@ public final class MultiType implements Multi {
   }
 
   @Override
+  public boolean isArray() {
+    return multi != null;
+  }
+
+  @Override
+  public boolean isMap() {
+    return map != null;
+  }
+
+  @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder();
 

--- a/src/main/java/io/vertx/redis/client/impl/types/PushType.java
+++ b/src/main/java/io/vertx/redis/client/impl/types/PushType.java
@@ -59,6 +59,16 @@ public final class PushType implements Multi {
   }
 
   @Override
+  public boolean isArray() {
+    return true;
+  }
+
+  @Override
+  public boolean isMap() {
+    return false;
+  }
+
+  @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder();
 

--- a/src/test/java/io/vertx/redis/client/test/RedisProtocolVersionTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisProtocolVersionTest.java
@@ -15,6 +15,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
 
+import java.util.Arrays;
+import java.util.HashSet;
+
 @RunWith(VertxUnitRunner.class)
 public class RedisProtocolVersionTest {
   @ClassRule
@@ -43,13 +46,15 @@ public class RedisProtocolVersionTest {
         return client.send(Request.cmd(Command.HGETALL).arg("myhash"));
       })
       .onSuccess(response -> {
-        test.assertTrue(response.toString().startsWith("[")); // list
+        test.assertTrue(response.isArray());
 
         test.assertTrue(response.containsKey("field1"));
         test.assertEquals(1, response.get("field1").toInteger());
 
         test.assertTrue(response.containsKey("field2"));
         test.assertEquals(2, response.get("field2").toInteger());
+
+        test.assertEquals(new HashSet<>(Arrays.asList("field1", "field2")), response.getKeys());
 
         test.assertEquals("field1", response.get(0).toString());
 
@@ -77,13 +82,15 @@ public class RedisProtocolVersionTest {
         return client.send(Request.cmd(Command.HGETALL).arg("myhash"));
       })
       .onSuccess(response -> {
-        test.assertTrue(response.toString().startsWith("{")); // map
+        test.assertTrue(response.isMap());
 
         test.assertTrue(response.containsKey("field1"));
         test.assertEquals(3, response.get("field1").toInteger());
 
         test.assertTrue(response.containsKey("field2"));
         test.assertEquals(4, response.get("field2").toInteger());
+
+        test.assertEquals(new HashSet<>(Arrays.asList("field1", "field2")), response.getKeys());
 
         try {
           response.get(0);


### PR DESCRIPTION
This makes working with responses of type `ResponseType.MULTI`, `PUSH` and `ATTRIBUTE` a bit easier.

Fixes #342