### PR TITLE
@GenIgnore non-canonical getters/setters of Redis[Connect]Options.endpoints

### DIFF
--- a/src/main/generated/io/vertx/redis/client/RedisConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisConnectOptionsConverter.java
@@ -40,21 +40,6 @@ public class RedisConnectOptionsConverter {
             obj.setPassword((String)member.getValue());
           }
           break;
-        case "endpoint":
-          break;
-        case "connectionStrings":
-          if (member.getValue() instanceof JsonArray) {
-            ((Iterable<Object>)member.getValue()).forEach( item -> {
-              if (item instanceof String)
-                obj.addConnectionString((String)item);
-            });
-          }
-          break;
-        case "connectionString":
-          if (member.getValue() instanceof String) {
-            obj.setConnectionString((String)member.getValue());
-          }
-          break;
         case "endpoints":
           if (member.getValue() instanceof JsonArray) {
             java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
@@ -86,9 +71,6 @@ public class RedisConnectOptionsConverter {
     }
     if (obj.getPassword() != null) {
       json.put("password", obj.getPassword());
-    }
-    if (obj.getEndpoint() != null) {
-      json.put("endpoint", obj.getEndpoint());
     }
     if (obj.getEndpoints() != null) {
       JsonArray array = new JsonArray();

--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -30,11 +30,6 @@ public class RedisOptionsConverter {
             obj.setNetClientOptions(new io.vertx.core.net.NetClientOptions((io.vertx.core.json.JsonObject)member.getValue()));
           }
           break;
-        case "endpoint":
-          if (member.getValue() instanceof String) {
-            obj.setEndpoint((String)member.getValue());
-          }
-          break;
         case "endpoints":
           if (member.getValue() instanceof JsonArray) {
             java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
@@ -43,19 +38,6 @@ public class RedisOptionsConverter {
                 list.add((String)item);
             });
             obj.setEndpoints(list);
-          }
-          break;
-        case "connectionStrings":
-          if (member.getValue() instanceof JsonArray) {
-            ((Iterable<Object>)member.getValue()).forEach( item -> {
-              if (item instanceof String)
-                obj.addConnectionString((String)item);
-            });
-          }
-          break;
-        case "connectionString":
-          if (member.getValue() instanceof String) {
-            obj.setConnectionString((String)member.getValue());
           }
           break;
         case "maxWaitingHandlers":
@@ -147,9 +129,6 @@ public class RedisOptionsConverter {
     }
     if (obj.getNetClientOptions() != null) {
       json.put("netClientOptions", obj.getNetClientOptions().toJson());
-    }
-    if (obj.getEndpoint() != null) {
-      json.put("endpoint", obj.getEndpoint());
     }
     if (obj.getEndpoints() != null) {
       JsonArray array = new JsonArray();

--- a/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
@@ -16,6 +16,7 @@
 package io.vertx.redis.client;
 
 import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
 
@@ -158,6 +159,7 @@ public abstract class RedisConnectOptions {
    *
    * @return the Redis connection string URI
    */
+  @GenIgnore
   public String getEndpoint() {
     if (endpoints == null || endpoints.isEmpty()) {
       return RedisOptions.DEFAULT_ENDPOINT;
@@ -175,6 +177,7 @@ public abstract class RedisConnectOptions {
    *
    * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on iana.org</a>
    */
+  @GenIgnore
   public RedisConnectOptions addConnectionString(String connectionString) {
     if (endpoints == null) {
       endpoints = new ArrayList<>();
@@ -191,6 +194,7 @@ public abstract class RedisConnectOptions {
    * @return fluent self.
    * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on iana.org</a>
    */
+  @GenIgnore
   public RedisConnectOptions setConnectionString(String connectionString) {
     if (endpoints == null) {
       endpoints = new ArrayList<>();

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -153,6 +153,7 @@ public class RedisOptions {
    *
    * @return the Redis connection string URI
    */
+  @GenIgnore
   public String getEndpoint() {
     if (endpoints == null || endpoints.isEmpty()) {
       return DEFAULT_ENDPOINT;
@@ -170,6 +171,7 @@ public class RedisOptions {
    * @deprecated see {@link #setConnectionString(String connectionString)} for a better naming
    */
   @Deprecated
+  @GenIgnore
   public RedisOptions addEndpoint(String connectionString) {
     if (endpoints == null) {
       endpoints = new ArrayList<>();
@@ -187,6 +189,7 @@ public class RedisOptions {
    * @deprecated see {@link #setConnectionString(String connectionString)} for a better naming
    */
   @Deprecated
+  @GenIgnore
   public RedisOptions setEndpoint(String connectionString) {
     if (endpoints == null) {
       endpoints = new ArrayList<>();
@@ -206,6 +209,7 @@ public class RedisOptions {
    * @return fluent self.
    * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on iana.org</a>
    */
+  @GenIgnore
   public RedisOptions addConnectionString(String connectionString) {
     if (endpoints == null) {
       endpoints = new ArrayList<>();
@@ -222,6 +226,7 @@ public class RedisOptions {
    * @return fluent self.
    * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on iana.org</a>
    */
+  @GenIgnore
   public RedisOptions setConnectionString(String connectionString) {
     if (endpoints == null) {
       endpoints = new ArrayList<>();


### PR DESCRIPTION
The `RedisOptions` class has a field `endpoints` of type `List<String>` for which multiple accessors and mutators exist:

- `getEndpoints()`: the canonical getter
- `setEndpoints()`: the canonical setter
- `getEndpoint()`: returns the first element of the list
- `setEndpoint()`: turns the list into a single-element list
- `addEndpoint()`: adds one element to the list
- `setConnectionString()`: same as `setEndpoint()`
- `addConnectionString()`: same as `addEndpoint()`

The `RedisConnectOptions` class, which is `public` but is only used internally, has the same problem.

All these methods are treated as individual properties by the code generator that produces the JSON serialization/deserialization classes, even though they are all backed by a single field. Since the code generator considers properties in declaration order (in upcoming Vert.x 5; it is lexicographic order in Vert.x 4), we had to reorder the methods so that serialization and deserialization does not lose information.

That is arguably a provisional solution, as it is very much not obvious that declaration order matters. This commit provides a permanent solution: all the non-canonical methods are marked as `@GenIgnore`. Only the `getEndpoints()` and `setEndpoints()` methods are used for serialization/deserialization.

This is a breaking change, so it shall not be backported to Vert.x 4 and shall be documented as such.