### PR TITLE
Add more properties to CommandReporter

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/CommandReporter.java
+++ b/src/main/java/io/vertx/redis/client/impl/CommandReporter.java
@@ -14,7 +14,11 @@ import java.util.function.Function;
 class CommandReporter {
   enum Tags {
     // Generic
+    NETWORK_PEER_ADDRESS("network.peer.address", reporter-> reporter.networkPeerAddress),
+    NETWORK_PEER_PORT("network.peer.port", reporter -> reporter.networkPeerPort),
     PEER_ADDRESS("peer.address", reporter -> reporter.address),
+    SERVER_ADDRESS("server.address", reporter -> reporter.serverAddress),
+    SERVER_PORT("server.port", reporter -> reporter.serverPort),
     SPAN_KIND("span.kind", reporter -> "client"),
 
     // DB
@@ -59,6 +63,10 @@ class CommandReporter {
   private final String address;
   private final String user;
   private final String database;
+  private final String networkPeerAddress;
+  private final String networkPeerPort;
+  private final String serverAddress;
+  private final String serverPort;
 
   private Object trace;
   private Object metric;
@@ -72,6 +80,10 @@ class CommandReporter {
     this.tracingPolicy = conn.tracingPolicy();
     this.command = command;
     this.address = uri.socketAddress().toString();
+    this.networkPeerAddress = conn.remoteAddress().hostAddress();
+    this.networkPeerPort = String.valueOf(conn.remoteAddress().port());
+    this.serverAddress = uri.socketAddress().host();
+    this.serverPort = String.valueOf(uri.socketAddress().port());
     this.user = uri.user();
     // the connection doesn't track the current database, so we have to report "unknown" when tainted
     this.database = conn.isTainted() ? null : (uri.select() == null ? "0" : String.valueOf(uri.select()));

--- a/src/main/java/io/vertx/redis/client/impl/RedisConnectionInternal.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisConnectionInternal.java
@@ -16,6 +16,7 @@
 package io.vertx.redis.client.impl;
 
 import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.redis.client.RedisConnection;
@@ -54,4 +55,9 @@ public interface RedisConnectionInternal extends RedisConnection {
    * Returns the {@linkplain TracingPolicy tracing policy} configured for this connection.
    */
   TracingPolicy tracingPolicy();
+
+  /**
+   * Returns the {@linkplain SocketAddress remote address} of the Redis server to which this connection is connected.
+   */
+  SocketAddress remoteAddress();
 }

--- a/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
@@ -12,6 +12,7 @@ import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.pool.PoolConnector;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.tracing.TracingPolicy;
@@ -539,5 +540,10 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
   @Override
   public TracingPolicy tracingPolicy() {
     return tracingPolicy;
+  }
+
+  @Override
+  public SocketAddress remoteAddress() {
+    return netSocket.remoteAddress();
   }
 }

--- a/src/test/java/io/vertx/redis/client/test/RedisTracingTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisTracingTest.java
@@ -2,11 +2,9 @@ package io.vertx.redis.client.test;
 
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
 import io.vertx.core.spi.tracing.SpanKind;
 import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
-import io.vertx.core.tracing.TracingOptions;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -81,8 +79,13 @@ public class RedisTracingTest {
       @Override
       public Object sendRequest(Context context, SpanKind kind, TracingPolicy policy, Object request, String operation, BiConsumer headers, TagExtractor tagExtractor) {
         Map<String, String> tags = tagExtractor.extract(request);
+        String redisPort = String.valueOf(redis.getFirstMappedPort());
         test.assertEquals("client", tags.get("span.kind"));
         test.assertEquals("redis", tags.get("db.type"));
+        test.assertEquals("127.0.0.1", tags.get("network.peer.address"));
+        test.assertEquals(redisPort, tags.get("network.peer.port"));
+        test.assertEquals("localhost", tags.get("server.address"));
+        test.assertEquals(redisPort, tags.get("server.port"));
         test.assertEquals(clientRequest.command().toString(), tags.get("db.statement"));
         actions.add("sendRequest");
         return trace;


### PR DESCRIPTION
Add more properties to CommandReporter so we are able to add Server and Network attributes for OpenTelemetry tracing.

Closes https://github.com/vert-x3/vertx-redis-client/issues/441