### PR TITLE
workaround a bug in the Grokzen Docker image

### DIFF
--- a/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
@@ -46,7 +46,9 @@ public class RedisClusterTest {
     // sentinel ports (5000-5002) 3x (match the cluster master nodes)
     .withFixedExposedPort(5000, 5000)
     .withFixedExposedPort(5001, 5001)
-    .withFixedExposedPort(5002, 5002);
+    .withFixedExposedPort(5002, 5002)
+    // workaround for new version of the Docker image that doesn't use the built `redis-sentinel` binary correctly
+    .withCommand("/bin/bash", "-c", "sed -i -e 's|redis-sentinel|/redis/src/redis-sentinel|g' /docker-entrypoint.sh && exec /docker-entrypoint.sh redis-cluster");
 
 
   @Rule

--- a/src/test/java/io/vertx/redis/client/test/RedisReplicationTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisReplicationTest.java
@@ -39,7 +39,9 @@ public class RedisReplicationTest {
     // sentinel ports (5000-5002) 3x (match the cluster master nodes)
     .withFixedExposedPort(5000, 5000)
     .withFixedExposedPort(5001, 5001)
-    .withFixedExposedPort(5002, 5002);
+    .withFixedExposedPort(5002, 5002)
+    // workaround for new version of the Docker image that doesn't use the built `redis-sentinel` binary correctly
+    .withCommand("/bin/bash", "-c", "sed -i -e 's|redis-sentinel|/redis/src/redis-sentinel|g' /docker-entrypoint.sh && exec /docker-entrypoint.sh redis-cluster");
 
   @Rule
   public final RunTestOnContext rule = new RunTestOnContext();

--- a/src/test/java/io/vertx/redis/client/test/RedisSentinelTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisSentinelTest.java
@@ -34,7 +34,9 @@ public class RedisSentinelTest {
     // sentinel ports (5000-5002) 3x (match the cluster master nodes)
     .withFixedExposedPort(5000, 5000)
     .withFixedExposedPort(5001, 5001)
-    .withFixedExposedPort(5002, 5002);
+    .withFixedExposedPort(5002, 5002)
+    // workaround for new version of the Docker image that doesn't use the built `redis-sentinel` binary correctly
+    .withCommand("/bin/bash", "-c", "sed -i -e 's|redis-sentinel|/redis/src/redis-sentinel|g' /docker-entrypoint.sh && exec /docker-entrypoint.sh redis-cluster");
 
   @Rule
   public final RunTestOnContext rule = new RunTestOnContext();

--- a/src/test/java/io/vertx/redis/client/test/RedisSentinelWithDBTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisSentinelWithDBTest.java
@@ -34,7 +34,9 @@ public class RedisSentinelWithDBTest {
     // sentinel ports (5000-5002) 3x (match the cluster master nodes)
     .withFixedExposedPort(5000, 5000)
     .withFixedExposedPort(5001, 5001)
-    .withFixedExposedPort(5002, 5002);
+    .withFixedExposedPort(5002, 5002)
+    // workaround for new version of the Docker image that doesn't use the built `redis-sentinel` binary correctly
+    .withCommand("/bin/bash", "-c", "sed -i -e 's|redis-sentinel|/redis/src/redis-sentinel|g' /docker-entrypoint.sh && exec /docker-entrypoint.sh redis-cluster");
 
   @Rule
   public final RunTestOnContext rule = new RunTestOnContext();

--- a/src/test/java/io/vertx/test/redis/RedisPubSubTest.java
+++ b/src/test/java/io/vertx/test/redis/RedisPubSubTest.java
@@ -33,7 +33,9 @@ public class RedisPubSubTest {
     // sentinel ports (5000-5002) 3x (match the cluster master nodes)
     .withFixedExposedPort(5000, 5000)
     .withFixedExposedPort(5001, 5001)
-    .withFixedExposedPort(5002, 5002);
+    .withFixedExposedPort(5002, 5002)
+    // workaround for new version of the Docker image that doesn't use the built `redis-sentinel` binary correctly
+    .withCommand("/bin/bash", "-c", "sed -i -e 's|redis-sentinel|/redis/src/redis-sentinel|g' /docker-entrypoint.sh && exec /docker-entrypoint.sh redis-cluster");
 
   @Rule
   public final RunTestOnContext rule = new RunTestOnContext(new VertxOptions().setEventLoopPoolSize(1));


### PR DESCRIPTION
When starting sentinel, the Grokzen image runs `redis-sentinel`, which is the default installation from the base image and not the built binary. This workaround rewrites the `docker-entrypoint.sh` script to use the built binary of `redis-sentinel`, which doesn't exhibit an issue.