### PR TITLE
[4.x] Improve connection pooling

### DIFF
--- a/src/main/java/io/vertx/redis/client/PoolOptions.java
+++ b/src/main/java/io/vertx/redis/client/PoolOptions.java
@@ -75,11 +75,11 @@ public class PoolOptions {
 
   /**
    * Get how often the connection pool will be cleaned. Cleaning the connection pool
-   * means scanning for unused invalid connections and if any are found, they are forcibly
+   * means scanning for unused and invalid connections and if any are found, they are forcibly
    * closed and evicted from the pool.
    * <p>
-   * A connection is marked invalid if it enters a exception or fatal state or if it exists
-   * longer than the {@linkplain #getRecycleTimeout() recycle timeout}.
+   * A connection is marked invalid if it enters a exception or fatal state. It is marked unused
+   * if it is unused for longer than the {@linkplain #getRecycleTimeout() recycle timeout}.
    * <p>
    * The return value is in milliseconds. By default, the cleaning interval is 30 seconds.
    * The value of -1 means connection pool cleaning is disabled.
@@ -92,11 +92,11 @@ public class PoolOptions {
 
   /**
    * Set how often the connection pool will be cleaned. Cleaning the connection pool
-   * means scanning for unused invalid connections and if any are found, they are forcibly
+   * means scanning for unused and invalid connections and if any are found, they are forcibly
    * closed and evicted from the pool.
    * <p>
-   * A connection is marked invalid if it enters a exception or fatal state or if it exists
-   * longer than the {@linkplain #setRecycleTimeout(int)} recycle timeout}.
+   * A connection is marked invalid if it enters a exception or fatal state. It is marked unused
+   * if it is unused for longer than the {@linkplain #setRecycleTimeout(int) recycle timeout}.
    * <p>
    * The value is in milliseconds. By default, the cleaning interval is 30 seconds.
    * The value of -1 means connection pool cleaning is disabled.
@@ -161,7 +161,7 @@ public class PoolOptions {
   }
 
   /**
-   * Get how long a connection can exist before it is recycled during connection pool
+   * Get how long a connection can stay unused before it is recycled during connection pool
    * {@linkplain #getCleanerInterval() cleaning}.
    * <p>
    * The value is in milliseconds. By default, the recycle timeout is 3 minutes.
@@ -174,7 +174,7 @@ public class PoolOptions {
   }
 
   /**
-   * Set how long a connection can exist before it is recycled during connection pool
+   * Set how long a connection can stay unused before it is recycled during connection pool
    * {@linkplain #setCleanerInterval(int) cleaning}.
    * <p>
    * The value is in milliseconds. By default, the recycle timeout is 3 minutes.

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -451,11 +451,11 @@ public class RedisOptions {
 
   /**
    * Get how often the connection pool will be cleaned. Cleaning the connection pool
-   * means scanning for unused invalid connections and if any are found, they are forcibly
+   * means scanning for unused and invalid connections and if any are found, they are forcibly
    * closed and evicted from the pool.
    * <p>
-   * A connection is marked invalid if it enters a exception or fatal state or if it exists
-   * longer than the {@linkplain #getPoolRecycleTimeout() recycle timeout}.
+   * A connection is marked invalid if it enters a exception or fatal state. It is marked unused
+   * if it is unused for longer than the {@linkplain #getPoolRecycleTimeout() recycle timeout}.
    * <p>
    * The return value is in milliseconds. By default, the cleaning interval is 30 seconds.
    * The value of -1 means connection pool cleaning is disabled.
@@ -468,11 +468,11 @@ public class RedisOptions {
 
   /**
    * Set how often the connection pool will be cleaned. Cleaning the connection pool
-   * means scanning for unused invalid connections and if any are found, they are forcibly
+   * means scanning for unused and invalid connections and if any are found, they are forcibly
    * closed and evicted from the pool.
    * <p>
-   * A connection is marked invalid if it enters a exception or fatal state or if it exists
-   * longer than the {@linkplain #setPoolRecycleTimeout(int) recycle timeout}.
+   * A connection is marked invalid if it enters a exception or fatal state. It is marked unused
+   * if it is unused for longer than the {@linkplain #setPoolRecycleTimeout(int) recycle timeout}.
    * <p>
    * The value is in milliseconds. By default, the cleaning interval is 30 seconds.
    * The value of -1 means connection pool cleaning is disabled.
@@ -537,7 +537,7 @@ public class RedisOptions {
   }
 
   /**
-   * Get how long a connection can exist before it is recycled during connection pool
+   * Get how long a connection can stay unused before it is recycled during connection pool
    * {@linkplain #getPoolCleanerInterval() cleaning}.
    * <p>
    * The value is in milliseconds. By default, the recycle timeout is 3 minutes.
@@ -550,7 +550,7 @@ public class RedisOptions {
   }
 
   /**
-   * Set how long a connection can exist before it is recycled during connection pool
+   * Set how long a connection can stay unused before it is recycled during connection pool
    * {@linkplain #setPoolCleanerInterval(int) cleaning}.
    * <p>
    * The value is in milliseconds. By default, the recycle timeout is 3 minutes.

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -138,8 +138,6 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
     // validate options
     if (poolOptions.getMaxWaiting() < poolOptions.getMaxSize()) {
       throw new IllegalStateException("Invalid options: maxWaiting < maxSize");
-      // we can't validate the max pool size yet as we need to know the slots first
-      // the remaining validation will happen at the connect time
     }
   }
 
@@ -153,14 +151,6 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
   }
 
   private void connect(Slots slots, Handler<AsyncResult<RedisConnection>> onConnected) {
-    // validate if the pool config is valid
-    final int totalUniqueEndpoints = slots.endpoints().length;
-    if (poolOptions.getMaxSize() < totalUniqueEndpoints) {
-      // this isn't a valid setup, the connection pool will not accommodate all the required connections
-      onConnected.handle(Future.failedFuture(new RedisConnectException("RedisOptions maxPoolSize < Cluster size(" + totalUniqueEndpoints + "): The pool is not able to hold all required connections!")));
-      return;
-    }
-
     // create a cluster connection
     final Set<Throwable> failures = ConcurrentHashMap.newKeySet();
     final AtomicInteger counter = new AtomicInteger();

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
@@ -515,7 +515,8 @@ public class RedisClusterConnection implements RedisConnection {
 
     // if we haven't got config for this slot, try any connection
     if (endpoints == null || endpoints.length == 0) {
-      return connectOptions.getEndpoint();
+      RedisURI uri = new RedisURI(connectOptions.getEndpoint());
+      return uri.protocol() + "://" + uri.userinfo() + uri.socketAddress();
     }
     return selectMasterOrReplicaEndpoint(readOnly, endpoints, forceMasterEndpoint);
   }

--- a/src/main/java/io/vertx/redis/client/impl/RedisReplicationClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisReplicationClient.java
@@ -99,8 +99,6 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
     // validate options
     if (poolOptions.getMaxWaiting() < poolOptions.getMaxSize()) {
       throw new IllegalStateException("Invalid options: maxWaiting < maxSize");
-      // we can't validate the max pool size yet as we need to know the slots first
-      // the remaining validation will happen at the connect time
     }
   }
 
@@ -152,14 +150,6 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
           final List<Node> replicas = getReplicas.result();
           final AtomicInteger counter = new AtomicInteger();
           final List<PooledRedisConnection> replicaConnections = new ArrayList<>();
-
-          // validate if the pool config is valid
-          final int totalUniqueEndpoints = replicas.size();
-          if (poolOptions.getMaxSize() < totalUniqueEndpoints) {
-            // this isn't a valid setup, the connection pool will not accommodate all the required connections
-            onConnect.handle(Future.failedFuture(new RedisConnectException("RedisOptions maxPoolSize < Cluster size(" + totalUniqueEndpoints + "): The pool is not able to hold all required connections!")));
-            return;
-          }
 
           for (Node replica : replicas) {
             if (!replica.online) {

--- a/src/main/java/io/vertx/redis/client/impl/RedisSentinelClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisSentinelClient.java
@@ -55,9 +55,6 @@ public class RedisSentinelClient extends BaseRedisClient implements Redis {
     super(vertx, tcpOptions, poolOptions, connectOptions, tracingPolicy);
     this.connectOptions = connectOptions;
     // validate options
-    if (poolOptions.getMaxSize() < 2) {
-      throw new IllegalStateException("Invalid options: maxSize must be at least 2");
-    }
     if (poolOptions.getMaxWaiting() < poolOptions.getMaxSize()) {
       throw new IllegalStateException("Invalid options: maxWaiting < maxSize");
     }

--- a/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
@@ -31,6 +31,7 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
 
   private static final ErrorType CONNECTION_CLOSED = ErrorType.create("CONNECTION_CLOSED");
 
+  private final PoolOptions poolOptions;
   private final PoolConnector.Listener listener;
   // to be used for callbacks
   private final VertxInternal vertx;
@@ -38,7 +39,6 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
   private final ContextInternal context;
   private final EventBus eventBus;
   private final NetSocket netSocket;
-  private final long expiresAt;
   // waiting: commands that have been sent but not answered
   // the queue is only accessed from the event loop
   private final ArrayQueue waiting;
@@ -53,19 +53,25 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
   private Runnable onEvict;
   private boolean closed = false;
   private boolean tainted = false;
+  private long expiresAt;
 
   public RedisStandaloneConnection(VertxInternal vertx, ContextInternal context, PoolConnector.Listener connectionListener, NetSocket netSocket, PoolOptions options, int maxWaitingHandlers, RedisURI uri, ClientMetrics metrics, TracingPolicy tracingPolicy) {
     //System.out.println("<ctor>#" + this.hashCode());
     this.vertx = vertx;
     this.context = context;
+    this.poolOptions = options;
     this.listener = connectionListener;
     this.eventBus = vertx.eventBus();
     this.netSocket = netSocket;
     this.waiting = new ArrayQueue(maxWaitingHandlers);
-    this.expiresAt = options.getRecycleTimeout() == -1 ? -1 : System.currentTimeMillis() + options.getRecycleTimeout();
+    this.expiresAt = computeExpiration();
     this.uri = uri;
     this.metrics = metrics;
     this.tracingPolicy = tracingPolicy;
+  }
+
+  private long computeExpiration() {
+    return poolOptions.getRecycleTimeout() == -1 ? -1 : System.currentTimeMillis() + poolOptions.getRecycleTimeout();
   }
 
   synchronized void setValid() {
@@ -84,7 +90,7 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
   }
 
   @Override
-  public boolean isValid() {
+  public synchronized boolean isValid() {
     //System.out.println("isValid()#" + this.hashCode());
     return !closed && (expiresAt <= 0 || System.currentTimeMillis() < expiresAt);
   }
@@ -475,6 +481,7 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
       forceClose();
       return false;
     }
+    expiresAt = computeExpiration();
     return true;
   }
 

--- a/src/test/java/io/vertx/redis/client/impl/ConnectionRecyclingTest.java
+++ b/src/test/java/io/vertx/redis/client/impl/ConnectionRecyclingTest.java
@@ -1,0 +1,134 @@
+package io.vertx.redis.client.impl;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.net.impl.pool.ConnectionManager;
+import io.vertx.core.net.impl.pool.ConnectionPool;
+import io.vertx.core.net.impl.pool.Lease;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisConnection;
+import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.impl.RedisConnectionManager.ConnectionKey;
+import io.vertx.redis.client.impl.RedisConnectionManager.RedisEndpoint;
+import io.vertx.redis.containers.RedisStandalone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+
+@RunWith(VertxUnitRunner.class)
+public class ConnectionRecyclingTest {
+
+  @ClassRule
+  public static final RedisStandalone redis = new RedisStandalone();
+
+  Vertx vertx;
+  Redis client;
+
+  @Before
+  public void setup() {
+    vertx = Vertx.vertx();
+    RedisOptions options = new RedisOptions()
+      .setConnectionString(redis.getRedisUri())
+      .setMaxPoolSize(2)
+      .setPoolCleanerInterval(100)
+      .setPoolRecycleTimeout(1000);
+    client = Redis.createClient(vertx, options);
+  }
+
+  @After
+  public void teardown(TestContext test) {
+    client.close();
+    vertx.close().onComplete(test.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testUsageShorterThanRecycleTimeout(TestContext test) {
+    Async async = test.async();
+
+    assertConnectionPool(test, 0);
+
+    client.connect()
+      .flatMap(conn -> {
+        assertConnectionPool(test, 1);
+        return conn.close();
+      }).onComplete(test.asyncAssertSuccess(ignored -> {
+        assertConnectionPool(test, 1);
+
+        vertx.setTimer(2000, ignored2 -> {
+          assertConnectionPool(test, 0);
+          async.complete();
+        });
+      }));
+  }
+
+  @Test
+  public void testUsageLongerThanRecycleTimeout(TestContext test) {
+    Async async = test.async();
+
+    assertConnectionPool(test, 0);
+
+    client.connect().onComplete(test.asyncAssertSuccess(conn -> {
+      assertConnectionPool(test, 1);
+      useConnectionForLongTime(conn, System.currentTimeMillis() + 2000);
+    }));
+
+    vertx.setTimer(2500, ignored -> {
+      assertConnectionPool(test, 1);
+
+      vertx.setTimer(1000, ignored2 -> {
+        assertConnectionPool(test, 0);
+        async.complete();
+      });
+    });
+  }
+
+  private void useConnectionForLongTime(RedisConnection conn, long endTime) {
+    if (endTime < System.currentTimeMillis()) {
+      conn.close();
+      return;
+    }
+
+    conn.send(Request.cmd(Command.INFO))
+      .onSuccess(ignored -> {
+        vertx.setTimer(100, ignored2 -> {
+          useConnectionForLongTime(conn, endTime);
+        });
+      });
+  }
+
+  private void assertConnectionPool(TestContext test, int expectedSize) {
+    IntBox size = new IntBox(0);
+
+    try {
+      RedisConnectionManager connManager = ((RedisClient) client).connectionManager;
+      Field field = RedisConnectionManager.class.getDeclaredField("pooledConnectionManager");
+      field.setAccessible(true);
+      ConnectionManager<ConnectionKey, Lease<RedisConnectionInternal>> endpointManager =
+        (ConnectionManager<ConnectionKey, Lease<RedisConnectionInternal>>) field.get(connManager);
+      endpointManager.forEach(endpoint -> {
+        ConnectionPool<RedisConnectionInternal> pool = ((RedisEndpoint) endpoint).pool;
+        size.value += pool.size();
+      });
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+
+    test.assertEquals(expectedSize, size.value);
+  }
+
+  static class IntBox {
+    int value;
+
+    IntBox(int value) {
+      this.value = value;
+    }
+  }
+}


### PR DESCRIPTION
- fix connection recycling
- canonicalize fallback URL in the cluster client
- remove useless validations

Backport of #456 to 4.x

Fixes #415