### PR TITLE
Add Redis cluster utilities

### DIFF
--- a/src/main/java/io/vertx/redis/client/RedisCluster.java
+++ b/src/main/java/io/vertx/redis/client/RedisCluster.java
@@ -1,0 +1,74 @@
+package io.vertx.redis.client;
+
+import io.vertx.core.Future;
+import io.vertx.redis.client.impl.RedisClusterImpl;
+
+import java.util.List;
+
+/**
+ * Utilities for Redis cluster. Calling {@code create()} with an instance of {@link Redis}
+ * or {@link RedisConnection} that are not Redis cluster client/connection leads to
+ * an exception.
+ *
+ * @see #onAllNodes(Request)
+ * @see #onAllMasterNodes(Request)
+ * @see #groupByNodes(List)
+ */
+public interface RedisCluster {
+  static RedisCluster create(Redis client) {
+    return new RedisClusterImpl(client);
+  }
+
+  static RedisCluster create(RedisConnection connection) {
+    return new RedisClusterImpl(connection);
+  }
+
+  /**
+   * Runs the {@code request} against all nodes in the cluster.
+   * Returns a future that completes with a list of responses, one from each
+   * node, or failure when one of the operations fails. Note that in case
+   * of a failure, there are no guarantees that the request was or wasn't
+   * executed successfully on other Redis cluster nodes. No result order
+   * is guaranteed either.
+   *
+   * @param request the request, must not be {@code null}
+   * @return the future result, never {@code null}
+   */
+  Future<List<Response>> onAllNodes(Request request);
+
+  /**
+   * Runs the {@code request} against all <em>master</em> nodes in the cluster.
+   * Returns a future that completes with a list of responses, one from each
+   * master node, or failure when one of the operations fails. Note that in case
+   * of a failure, there are no guarantees that the request was or wasn't
+   * executed successfully on other Redis cluster master nodes. No result order
+   * is guaranteed either.
+   *
+   * @param request the request, must not be {@code null}
+   * @return the future result, never {@code null}
+   */
+  Future<List<Response>> onAllMasterNodes(Request request);
+
+  /**
+   * Groups the {@code requests} such that all requests in each inner list in the result
+   * are guaranteed to be sent to the same Redis <em>master</em> node.
+   * <p>
+   * If the cluster client was not created with {@link RedisReplicas#NEVER} and
+   * the commands are executed individually (not using {@link RedisConnection#batch(List) batch()}),
+   * it is possible that the commands will be spread across different replicas
+   * of the same master node.
+   * <p>
+   * If any of the {@code requests} don't have keys and hence are targeted at a random
+   * node, all such requests shall be grouped into an extra single list for which
+   * the above guarantee does not apply. If any of the {@code requests} includes multiple
+   * keys that belong to different master nodes, the resulting future will fail.
+   * <p>
+   * Note that this method is only reliable in case the Redis cluster is in a stable
+   * state. In case of resharding, failover or in general any change of cluster topology,
+   * there are no guarantees on the validity of the result.
+   *
+   * @param requests the requests, must not be {@code null}
+   * @return the requests grouped by the cluster node assignment
+   */
+  Future<List<List<Request>>> groupByNodes(List<Request> requests);
+}

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
@@ -36,7 +36,7 @@ public class RedisClusterConnection implements RedisConnection {
 
   // number of attempts/redirects when we get connection errors
   // or when we get MOVED/ASK responses
-  private static final int RETRIES = 16;
+  static final int RETRIES = 16;
 
   // reduce from list of responses to a single response
   private static final Map<Command, Function<List<Response>, Response>> REDUCERS = new HashMap<>();
@@ -51,10 +51,10 @@ public class RedisClusterConnection implements RedisConnection {
     MASTER_ONLY_COMMANDS.add(command);
   }
 
-  private final VertxInternal vertx;
+  final VertxInternal vertx;
   private final RedisConnectionManager connectionManager;
   private final RedisClusterConnectOptions connectOptions;
-  private final SharedSlots sharedSlots;
+  final SharedSlots sharedSlots;
   private final Map<String, PooledRedisConnection> connections;
 
   RedisClusterConnection(Vertx vertx, RedisConnectionManager connectionManager, RedisClusterConnectOptions connectOptions,
@@ -266,7 +266,7 @@ public class RedisClusterConnection implements RedisConnection {
     return map;
   }
 
-  private void send(String endpoint, int retries, Request command, Handler<AsyncResult<Response>> handler) {
+  void send(String endpoint, int retries, Request command, Handler<AsyncResult<Response>> handler) {
     PooledRedisConnection connection = connections.get(endpoint);
     if (connection == null) {
       connectionManager.getConnection(endpoint, RedisReplicas.NEVER != connectOptions.getUseReplicas() ? Request.cmd(Command.READONLY) : null)
@@ -610,7 +610,7 @@ public class RedisClusterConnection implements RedisConnection {
     return endpoints[0];
   }
 
-  private String buildCrossslotFailureMsg(RequestImpl req) {
+  String buildCrossslotFailureMsg(RequestImpl req) {
     return "Keys of command or batch: \"" + req.toString() + "\" targets not all in the same hash slot (CROSSSLOT) and client side resharding is not supported";
   }
 }

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterImpl.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterImpl.java
@@ -1,0 +1,152 @@
+package io.vertx.redis.client.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisCluster;
+import io.vertx.redis.client.RedisConnection;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+public class RedisClusterImpl implements RedisCluster {
+  private static final Logger LOG = LoggerFactory.getLogger(RedisClusterImpl.class);
+
+  private final Redis client;
+  private final RedisConnection connection;
+
+  public RedisClusterImpl(Redis client) {
+    if (!(client instanceof RedisClusterClient)) {
+      throw new IllegalArgumentException("Given Redis client is not a Redis cluster client: " + client);
+    }
+
+    this.client = client;
+    this.connection = null;
+  }
+
+  public RedisClusterImpl(RedisConnection connection) {
+    if (!(connection instanceof RedisClusterConnection)) {
+      throw new IllegalArgumentException("Given Redis connection is not a Redis cluster connection: " + connection);
+    }
+
+    this.client = null;
+    this.connection = connection;
+  }
+
+  @Override
+  public Future<List<Response>> onAllNodes(Request request) {
+    return onAllNodes(request, false);
+  }
+
+  @Override
+  public Future<List<Response>> onAllMasterNodes(Request request) {
+    return onAllNodes(request, true);
+  }
+
+  private Future<List<Response>> onAllNodes(Request request, boolean mastersOnly) {
+    if (connection != null) {
+      return onAllNodes(request, mastersOnly, (RedisClusterConnection) connection);
+    } else /* client != null */ {
+      return client.connect()
+        .compose(conn -> onAllNodes(request, mastersOnly, (RedisClusterConnection) conn)
+          .andThen(ignored -> {
+            conn.close().onFailure(LOG::warn);
+          }));
+    }
+  }
+
+  private Future<List<Response>> onAllNodes(Request request, boolean mastersOnly, RedisClusterConnection conn) {
+    return conn.sharedSlots.get()
+      .compose(slots -> {
+        String[] endpoints = mastersOnly ? slots.masterEndpoints() : slots.endpoints();
+        HashSet<String> endpointsSet = new HashSet<>(endpoints.length);
+        Collections.addAll(endpointsSet, endpoints);
+        String[] uniqueEndpoints = endpointsSet.toArray(new String[0]);
+
+        Promise<List<Response>> promise = conn.vertx.promise();
+        onAllNodes(uniqueEndpoints, 0, request, new ArrayList<>(uniqueEndpoints.length), conn, promise);
+        return promise.future();
+      });
+  }
+
+  private void onAllNodes(String[] endpoints, int index, Request request, List<Response> result, RedisClusterConnection conn, Promise<List<Response>> promise) {
+    if (index >= endpoints.length) {
+      promise.complete(result);
+      return;
+    }
+
+    conn.send(endpoints[index], RedisClusterConnection.RETRIES, request, ar -> {
+      if (ar.succeeded()) {
+        result.add(ar.result());
+        onAllNodes(endpoints, index + 1, request, result, conn, promise);
+      } else {
+        promise.fail(ar.cause());
+      }
+    });
+  }
+
+  @Override
+  public Future<List<List<Request>>> groupByNodes(List<Request> requests) {
+    if (connection != null) {
+      return groupByNodes(requests, (RedisClusterConnection) connection);
+    } else /* client != null */ {
+      return client.connect()
+        .compose(conn -> groupByNodes(requests, (RedisClusterConnection) conn)
+          .andThen(ignored -> {
+            conn.close().onFailure(LOG::warn);
+          }));
+    }
+  }
+
+  private Future<List<List<Request>>> groupByNodes(List<Request> requests, RedisClusterConnection conn) {
+    return conn.sharedSlots.get()
+      .compose(slots -> {
+        Map<String, List<Request>> grouping = new HashMap<>();
+        List<Request> ambiguous = null;
+
+        for (Request request : requests) {
+          RequestImpl req = (RequestImpl) request;
+          CommandImpl cmd = (CommandImpl) req.command();
+          List<byte[]> keys = req.keys();
+
+          if (cmd.needsGetKeys() || keys.isEmpty()) {
+            if (ambiguous == null) {
+              ambiguous = new ArrayList<>();
+            }
+            ambiguous.add(request);
+          } else if (keys.size() == 1) {
+            int slot = ZModem.generate(keys.get(0));
+            String endpoint = slots.endpointsForKey(slot)[0];
+            grouping.computeIfAbsent(endpoint, ignored -> new ArrayList<>()).add(request);
+          } else {
+            String endpoint = null;
+            for (byte[] key : keys) {
+              int slot = ZModem.generate(key);
+              String endpointForSlot = slots.endpointsForKey(slot)[0];
+              if (endpoint == null) {
+                endpoint = endpointForSlot;
+              } else if (!endpointForSlot.equals(endpoint)) {
+                return Future.failedFuture(conn.buildCrossslotFailureMsg(req));
+              }
+            }
+
+            grouping.computeIfAbsent(endpoint, ignored -> new ArrayList<>()).add(request);
+          }
+        }
+
+        List<List<Request>> result = new ArrayList<>(grouping.values());
+        if (ambiguous != null) {
+          result.add(ambiguous);
+        }
+        return Future.succeededFuture(result);
+      });
+  }
+}

--- a/src/main/java/io/vertx/redis/client/impl/Slots.java
+++ b/src/main/java/io/vertx/redis/client/impl/Slots.java
@@ -132,6 +132,10 @@ class Slots {
     return endpoints;
   }
 
+  String[] masterEndpoints() {
+    return masterEndpoints;
+  }
+
   long timestamp() {
     return ts;
   }

--- a/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClusterTest.java
@@ -4,11 +4,11 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.redis.client.Command;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisClientType;
 import io.vertx.redis.client.RedisConnection;
@@ -16,7 +16,7 @@ import io.vertx.redis.client.RedisOptions;
 import io.vertx.redis.client.RedisReplicas;
 import io.vertx.redis.client.Request;
 import io.vertx.redis.client.Response;
-import io.vertx.redis.client.impl.ZModem;
+import io.vertx.redis.client.ResponseType;
 import io.vertx.redis.containers.RedisCluster;
 import org.junit.After;
 import org.junit.Before;
@@ -27,10 +27,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1138,50 +1138,30 @@ public class RedisClusterTest {
 
     Redis.createClient(rule.vertx(), options)
       .connect()
-      .onComplete(should.asyncAssertSuccess(cluster -> {
-        cluster
-          .send(cmd(CLUSTER).arg("SLOTS"))
-          .compose(reply -> {
-            if (reply == null || reply.size() == 0) {
-              // no slots available we can't really proceed
-              return Future.failedFuture("CLUSTER SLOTS No slots available in the cluster.");
-            }
+      .onComplete(should.asyncAssertSuccess(conn -> {
+        io.vertx.redis.client.RedisCluster cluster = io.vertx.redis.client.RedisCluster.create(conn);
 
-            Map<Integer, JsonObject> slotRangeMap = new HashMap<>();
-            for (int i = 0; i < reply.size(); i++) {
-              Response s = reply.get(i);
-              JsonObject slotRange = new JsonObject()
-                .put("start", s.get(0).toInteger())
-                .put("end", s.get(1).toInteger());
-              slotRangeMap.put(i, slotRange);
-            }
+        List<Request> commands = new ArrayList<>();
+        for (int i = 0; i < 100000; i++) {
+          String key = "key-" + i;
+          String value = "value-" + i;
+          commands.add(cmd(SET).arg(key).arg(value));
+        }
 
-            Map<Integer, List<Request>> mapCommands = new HashMap<>();
-            for (int i = 0; i < 100000; i++) {
-              String key = "key-" + i;
-              String value = "value-" + i;
-              int group;
-              int slot = ZModem.generate(key);
-              for (Map.Entry<Integer, JsonObject> entry : slotRangeMap.entrySet()) {
-                if (slot >= entry.getValue().getInteger("start") && slot <= entry.getValue().getInteger("end")) {
-                  mapCommands.computeIfAbsent(entry.getKey(), k -> new ArrayList<>()).add(cmd(SET).arg(key).arg(value));
-                  break;
-                }
-              }
-            }
-
+        cluster.groupByNodes(commands)
+          .onComplete(should.asyncAssertSuccess(groupedCommands -> {
             List<Future<List<Response>>> futures = new ArrayList<>();
-            for (Map.Entry<Integer, List<Request>> entry : mapCommands.entrySet()) {
-              futures.add(cluster.batch(entry.getValue()));
+            for (List<Request> commandGroup : groupedCommands) {
+              futures.add(conn.batch(commandGroup));
             }
-
-            return Future.all(futures)
+            Future.all(futures)
               .onComplete(should.asyncAssertSuccess(responses -> {
-                should.assertEquals(mapCommands.values().stream().map(List::size).reduce(0, Integer::sum), responses.result().list().stream().map(item -> ((List<Request>) item).size()).reduce(0, Integer::sum));
+                should.assertEquals(groupedCommands.stream().map(List::size).reduce(0, Integer::sum),
+                  responses.result().list().stream().map(item -> ((List<Request>) item).size()).reduce(0, Integer::sum));
                 test.complete();
               }));
-          }).onFailure(should::fail);
-      })).onFailure(should::fail);
+          }));
+      }));
   }
 
   @Test(timeout = 30_000)
@@ -1190,37 +1170,46 @@ public class RedisClusterTest {
 
     Redis.createClient(rule.vertx(), options)
       .connect()
-      .onComplete(should.asyncAssertSuccess(cluster -> {
-        cluster
-          .send(cmd(CLUSTER).arg("SLOTS"))
-          .compose(reply -> {
-            if (reply == null || reply.size() == 0) {
-              // no slots available we can't really proceed
-              return Future.failedFuture("CLUSTER SLOTS No slots available in the cluster.");
-            }
+      .onComplete(should.asyncAssertSuccess(conn -> {
+        io.vertx.redis.client.RedisCluster cluster = io.vertx.redis.client.RedisCluster.create(conn);
 
-            //take random slot
-            Response s = reply.get(0);
-            JsonObject slotRange = new JsonObject()
-              .put("start", s.get(0).toInteger())
-              .put("end", s.get(1).toInteger());
+        List<Request> commands = new ArrayList<>();
+        for (int i = 0; i < 100000; i++) {
+          String key = "key-" + i;
+          String value = "value-" + i;
+          commands.add(cmd(SET).arg(key).arg(value));
+        }
 
-            List<Request> rawCommands = new ArrayList<>();
-            for (int i = 0; i < 100000; i++) {
-              String key = "key-" + i;
-              String value = "value-" + i;
-              int endpoint;
-              int slot = ZModem.generate(key);
-              if (slot >= slotRange.getInteger("start") && slot <= slotRange.getInteger("end")) {
-                rawCommands.add(Request.cmd(SET).arg(key).arg(value));
-              }
-            }
-            return cluster.batch(rawCommands).onComplete(should.asyncAssertSuccess(responses -> {
-              should.assertEquals(rawCommands.size(), responses.size());
-              test.complete();
-            }));
-          }).onFailure(should::fail);
-      })).onFailure(should::fail);
+        cluster.groupByNodes(commands)
+          .onComplete(should.asyncAssertSuccess(groupedCommands -> {
+            List<Request> commandGroup = groupedCommands.get(0);
+
+            conn.batch(commandGroup)
+              .onComplete(should.asyncAssertSuccess(responses -> {
+                should.assertEquals(commandGroup.size(), responses.size());
+                test.complete();
+              }));
+          }));
+      }));
+  }
+
+  @Test(timeout = 30_000)
+  public void groupByNodesCrossSlotFailure(TestContext test) {
+    Async async = test.async();
+
+    Redis.createClient(rule.vertx(), options)
+      .connect()
+      .onComplete(test.asyncAssertSuccess(conn -> {
+        io.vertx.redis.client.RedisCluster cluster = io.vertx.redis.client.RedisCluster.create(conn);
+
+        List<Request> commands = Collections.singletonList(cmd(DEL).arg("key1").arg("key2").arg("key3"));
+
+        cluster.groupByNodes(commands)
+          .onComplete(test.asyncAssertFailure(err -> {
+            test.assertTrue(err.getMessage().contains("CROSSSLOT"));
+            async.complete();
+          }));
+      }));
   }
 
   @Test(timeout = 30_000)
@@ -1311,6 +1300,42 @@ public class RedisClusterTest {
             should.assertEquals("foobar", result.toString());
             test.complete();
           }));
+      }));
+  }
+
+  @Test
+  public void testRedisClusterOnAllNodes(TestContext test) {
+    Async async = test.async();
+
+    client.connect()
+      .compose(conn -> {
+        io.vertx.redis.client.RedisCluster cluster = io.vertx.redis.client.RedisCluster.create(conn);
+        return cluster.onAllMasterNodes(cmd(FLUSHDB))
+          .compose(result -> {
+            for (Response response : result) {
+              test.assertEquals(ResponseType.SIMPLE, response.type());
+            }
+
+            return conn.send(cmd(SET).arg("key1").arg("value1"));
+          }).compose(ignored -> {
+            return conn.send(cmd(SET).arg("key2").arg("value2"));
+          }).compose(ignored -> {
+            return conn.send(cmd(SET).arg("key3").arg("value3"));
+          }).compose(ignored -> {
+            return cluster.onAllMasterNodes(cmd(KEYS).arg("*"));
+          }).compose(responses -> {
+            Set<String> keys = new HashSet<>();
+            for (Response response : responses) {
+              for (Response item : response) {
+                keys.add(item.toString());
+              }
+            }
+            test.assertEquals(new HashSet<>(Arrays.asList("key1", "key2", "key3")), keys);
+            return Future.succeededFuture();
+          });
+      })
+      .onComplete(test.asyncAssertSuccess(ignored -> {
+        async.complete();
       }));
   }
 }


### PR DESCRIPTION
The `RedisCluster` interface exposes several useful operations that only make sense in the context of a cluster:

- run a command against all nodes in the cluster
- run a command against all _master_ nodes in the cluster
- group commands such that each group is guaranteed to be executed on the same node

Fixes #450
Closes #418