### PR TITLE
Add ability to provide `RedisConnectOptions` asynchronously

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -80,7 +80,7 @@ In the configuration contains a `password` and/or a `select` database, these 2 c
 {@link examples.RedisExamples#example2}
 ----
 
-== Connecting using TLS
+=== Connecting using TLS
 
 You can connect to a Redis server using TLS by configuring the client TCP options, make sure to set:
 
@@ -95,7 +95,7 @@ You can connect to a Redis server using TLS by configuring the client TCP option
 
 NOTE: More details on the TLS client config can be found https://vertx.io/docs/vertx-core/java/#_enabling_ssltls_on_the_client[here].
 
-== Connection String
+=== Connection String
 
 The client will recognize addresses that follow the expression:
 
@@ -110,6 +110,114 @@ unix://[:password@]/domain/docker.sock[?select=db-number]
 ----
 
 When specifying a password or a database, those commands are always executed on connection start.
+
+=== Providing `RedisConnectOptions` asynchronously
+
+The `Redis.createClient()` method takes a single `RedisOptions` object that contains all options.
+This is the most common way of connecting to Redis.
+
+However, there's also an option to provide `RedisOptions` synchronously and the `RedisConnectOptions` asynchronously.
+There are 4 methods with the same parameter list that allow this:
+
+- `Redis.createStandaloneClient()`
+- `Redis.createReplicationClient()`
+- `Redis.createSentinelClient()`
+- `Redis.createClusterClient()`
+
+These methods accept the `Vertx` object, the `RedisOptions` object, and a `Supplier<Future<RedisConnectOptions>>`.
+The `RedisOptions` object mainly provides `NetClientOptions` and `PoolOptions`, which are static.
+The `Supplier<Future<RedisConnectOptions>>` is used whenever a connection needs to be created and provides dynamic options.
+The type clearly shows that these dynamic options may be provided asynchronously.
+
+The prime example when you might want this is when using Amazon ElastiCache with IAM authentication.
+The IAM authentication accepts short-lived tokens (their lifetime is only 15 minutes), so they need to be regenerated frequently.
+
+Here's an implementation of the `Supplier<Future<RedisConnectOptions>>` that caches the `RedisConnectOptions` for 10 minutes:
+
+[source,$lang]
+----
+{@link examples.RedisConnectOptionsSupplier}
+----
+
+To create the token, here's a helper class that's heavily based on https://github.com/aws-samples/elasticache-iam-auth-demo-app/blob/main/src/main/java/com/amazon/elasticache/IAMAuthTokenRequest.java:
+
+[source,$lang]
+----
+package examples;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4FamilyHttpSigner;
+import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
+import software.amazon.awssdk.http.auth.spi.signer.SignRequest;
+
+import java.net.URI;
+import java.time.Duration;
+
+public class IamAuthToken {
+  private static final String PROTOCOL = "http://";
+
+  private final String userId;
+  private final String replicationGroupId;
+  private final String region;
+  private final AwsCredentialsProvider credentials;
+
+  public IamAuthToken(String userId, String replicationGroupId, String region, AwsCredentialsProvider credentials) {
+    this.userId = userId;
+    this.replicationGroupId = replicationGroupId;
+    this.region = region;
+    this.credentials = credentials;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  public String getToken() {
+    URI uri = URI.create(PROTOCOL + replicationGroupId + "/");
+    SdkHttpRequest request = SdkHttpRequest.builder()
+      .method(SdkHttpMethod.GET)
+      .uri(uri)
+      .appendRawQueryParameter("Action", "connect")
+      .appendRawQueryParameter("User", userId)
+      .build();
+
+    SdkHttpRequest signedRequest = sign(request, credentials.resolveCredentials());
+    return signedRequest.getUri().toString().replace(PROTOCOL, "");
+  }
+
+  private SdkHttpRequest sign(SdkHttpRequest request, AwsCredentials credentials) {
+    SignRequest<AwsCredentials> signRequest = SignRequest.builder(credentials)
+      .request(request)
+      .putProperty(AwsV4HttpSigner.REGION_NAME, region)
+      .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "elasticache")
+      .putProperty(AwsV4HttpSigner.EXPIRATION_DURATION, Duration.ofSeconds(900))
+      .putProperty(AwsV4HttpSigner.AUTH_LOCATION, AwsV4FamilyHttpSigner.AuthLocation.QUERY_STRING)
+      .build();
+    return AwsV4HttpSigner.create().sign(signRequest).request();
+  }
+}
+----
+
+This helper class might be instantiated like this:
+
+[source,$lang]
+----
+AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.builder()
+  .asyncCredentialUpdateEnabled(true)
+  .build();
+IamAuthToken token = new IamAuthToken("my-user", "my-redis", "us-east-1", credentialsProvider);
+----
+
+Then, the `Redis` client might be instantiated like this:
+
+[source,$lang]
+----
+Redis client = Redis.createStandaloneClient(vertx, redisOptions, new RedisConnectOptionsSupplier<>(vertx,
+  redisOptions, RedisStandaloneConnectOptions::new, token::getUserId, token::getToken));
+----
 
 == Running commands
 

--- a/src/main/generated/io/vertx/redis/client/RedisConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisConnectOptionsConverter.java
@@ -33,6 +33,11 @@ public class RedisConnectOptionsConverter {
             obj.setPreferredProtocolVersion(io.vertx.redis.client.ProtocolVersion.valueOf((String)member.getValue()));
           }
           break;
+        case "user":
+          if (member.getValue() instanceof String) {
+            obj.setUser((String)member.getValue());
+          }
+          break;
         case "password":
           if (member.getValue() instanceof String) {
             obj.setPassword((String)member.getValue());
@@ -66,6 +71,9 @@ public class RedisConnectOptionsConverter {
     json.put("protocolNegotiation", obj.isProtocolNegotiation());
     if (obj.getPreferredProtocolVersion() != null) {
       json.put("preferredProtocolVersion", obj.getPreferredProtocolVersion().name());
+    }
+    if (obj.getUser() != null) {
+      json.put("user", obj.getUser());
     }
     if (obj.getPassword() != null) {
       json.put("password", obj.getPassword());

--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -93,6 +93,11 @@ public class RedisOptionsConverter {
             obj.setPoolRecycleTimeout(((Number)member.getValue()).intValue());
           }
           break;
+        case "user":
+          if (member.getValue() instanceof String) {
+            obj.setUser((String)member.getValue());
+          }
+          break;
         case "password":
           if (member.getValue() instanceof String) {
             obj.setPassword((String)member.getValue());
@@ -169,6 +174,9 @@ public class RedisOptionsConverter {
     json.put("maxPoolSize", obj.getMaxPoolSize());
     json.put("maxPoolWaiting", obj.getMaxPoolWaiting());
     json.put("poolRecycleTimeout", obj.getPoolRecycleTimeout());
+    if (obj.getUser() != null) {
+      json.put("user", obj.getUser());
+    }
     if (obj.getPassword() != null) {
       json.put("password", obj.getPassword());
     }

--- a/src/main/java/examples/RedisConnectOptionsSupplier.java
+++ b/src/main/java/examples/RedisConnectOptionsSupplier.java
@@ -1,0 +1,56 @@
+package examples;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.redis.client.RedisConnectOptions;
+import io.vertx.redis.client.RedisOptions;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class RedisConnectOptionsSupplier<OPTS extends RedisConnectOptions> implements Supplier<Future<OPTS>> {
+  private final Vertx vertx;
+  private final RedisOptions options;
+  private final Function<RedisOptions, OPTS> creator;
+  private final Supplier<String> userName;
+  private final Supplier<String> password;
+  private final AtomicReference<Future<OPTS>> future;
+
+  public RedisConnectOptionsSupplier(Vertx vertx, RedisOptions options, Function<RedisOptions, OPTS> creator,
+    Supplier<String> userName, Supplier<String> password) {
+    this.vertx = vertx;
+    this.options = options;
+    this.creator = creator;
+    this.userName = userName;
+    this.password = password;
+    this.future = new AtomicReference<>();
+  }
+
+  @Override
+  public Future<OPTS> get() {
+    while (true) {
+      Future<OPTS> currentFuture = this.future.get();
+      if (currentFuture != null) {
+        return currentFuture;
+      }
+
+      Promise<OPTS> promise = Promise.promise();
+      Future<OPTS> future = promise.future();
+      if (this.future.compareAndSet(null, future)) {
+        OPTS result = creator.apply(options);
+        result.setUser(userName.get());
+        result.setPassword(password.get()); // TODO run on worker thread
+        promise.complete(result);
+
+        // clean up in 10 minutes, to force refresh
+        vertx.setTimer(10 * 60 * 1000, ignored -> {
+          this.future.set(null);
+        });
+
+        return future;
+      }
+    }
+  }
+}

--- a/src/main/java/examples/RedisExamples.java
+++ b/src/main/java/examples/RedisExamples.java
@@ -1,10 +1,24 @@
 package examples;
 
-import io.vertx.core.*;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.tracing.TracingPolicy;
-import io.vertx.redis.client.*;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.ProtocolVersion;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.RedisClientType;
+import io.vertx.redis.client.RedisConnection;
+import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.RedisRole;
+import io.vertx.redis.client.RedisTopology;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
+import io.vertx.redis.client.ResponseType;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/src/main/java/io/vertx/redis/client/ConstantSupplier.java
+++ b/src/main/java/io/vertx/redis/client/ConstantSupplier.java
@@ -1,0 +1,16 @@
+package io.vertx.redis.client;
+
+import java.util.function.Supplier;
+
+class ConstantSupplier<T> implements Supplier<T> {
+  private final T value;
+
+  ConstantSupplier(T value) {
+    this.value = value;
+  }
+
+  @Override
+  public T get() {
+    return value;
+  }
+}

--- a/src/main/java/io/vertx/redis/client/Redis.java
+++ b/src/main/java/io/vertx/redis/client/Redis.java
@@ -25,7 +25,6 @@ import io.vertx.redis.client.impl.RedisReplicationClient;
 import io.vertx.redis.client.impl.RedisSentinelClient;
 
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -35,7 +34,7 @@ import java.util.function.Supplier;
 public interface Redis {
 
   /**
-   * Create a new redis client using the default client options.
+   * Create a new Redis client using the default client options.
    *
    * @param vertx the vertx instance
    * @return the client
@@ -45,10 +44,10 @@ public interface Redis {
   }
 
   /**
-   * Create a new redis client using the default client options. Does not support rediss (redis over ssl scheme) for now.
+   * Create a new Redis client using the default client options. Does not support rediss (redis over ssl scheme) for now.
    *
    * @param connectionString a string URI following the scheme: redis://[username:password@][host][:port][/database]
-   * @param vertx            the vertx instance
+   * @param vertx the vertx instance
    * @return the client
    * @see <a href="https://www.iana.org/assignments/uri-schemes/prov/redis">Redis scheme on iana.org</a>
    */
@@ -57,29 +56,109 @@ public interface Redis {
   }
 
   /**
-   * Create a new redis client using the given client options.
+   * Create a new Redis client using the given client options.
    *
-   * @param vertx   the vertx instance
+   * @param vertx the Vert.x instance
    * @param options the user provided options
    * @return the client
    */
   static Redis createClient(Vertx vertx, RedisOptions options) {
     switch (options.getType()) {
       case STANDALONE:
-        return new RedisClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisStandaloneConnectOptions(options), options.getTracingPolicy());
+        return createStandaloneClient(vertx, options, new ConstantSupplier<>(Future.succeededFuture(new RedisStandaloneConnectOptions(options))));
       case SENTINEL:
-        return new RedisSentinelClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisSentinelConnectOptions(options), options.getTracingPolicy());
+        return createSentinelClient(vertx, options, new ConstantSupplier<>(Future.succeededFuture(new RedisSentinelConnectOptions(options))));
       case CLUSTER:
-        return new RedisClusterClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisClusterConnectOptions(options), options.getTracingPolicy());
+        return createClusterClient(vertx, options, new ConstantSupplier<>(Future.succeededFuture(new RedisClusterConnectOptions(options))));
       case REPLICATION:
-        return new RedisReplicationClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), new RedisReplicationConnectOptions(options), options.getTracingPolicy());
+        return createReplicationClient(vertx, options, new ConstantSupplier<>(Future.succeededFuture(new RedisReplicationConnectOptions(options))));
       default:
         throw new IllegalStateException("Unknown Redis Client type: " + options.getType());
     }
   }
 
   /**
-   * Connects to the redis server.
+   * Creates a new standalone Redis client. The {@code options} are used to obtain {@link RedisOptions#getType()},
+   * {@link RedisOptions#getNetClientOptions()}, {@link RedisOptions#getPoolOptions()}
+   * and {@link RedisOptions#getTracingPolicy()}. The {@code connectOptions} are queried for every
+   * connection attempt.
+   * <p>
+   * If {@code options.getType() != RedisClientType.STANDALONE}, an exception is thrown.
+   *
+   * @param vertx the Vert.x instance
+   * @param options the static options
+   * @param connectOptions supplier of the dynamic options
+   * @return the standalone client
+   */
+  static Redis createStandaloneClient(Vertx vertx, RedisOptions options, Supplier<Future<RedisStandaloneConnectOptions>> connectOptions) {
+    if (options.getType() != RedisClientType.STANDALONE) {
+      throw new IllegalArgumentException("RedisOptions.getType() != RedisClientType.STANDALONE");
+    }
+    return new RedisClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), connectOptions, options.getTracingPolicy());
+  }
+
+  /**
+   * Creates a new replication Redis client. The {@code options} are used to obtain {@link RedisOptions#getType()},
+   * {@link RedisOptions#getNetClientOptions()}, {@link RedisOptions#getPoolOptions()}
+   * and {@link RedisOptions#getTracingPolicy()}. The {@code connectOptions} are queried for every
+   * connection attempt.
+   * <p>
+   * If {@code options.getType() != RedisClientType.REPLICATION}, an exception is thrown.
+   *
+   * @param vertx the Vert.x instance
+   * @param options the static options
+   * @param connectOptions supplier of the dynamic options
+   * @return the replication client
+   */
+  static Redis createReplicationClient(Vertx vertx, RedisOptions options, Supplier<Future<RedisReplicationConnectOptions>> connectOptions) {
+    if (options.getType() != RedisClientType.REPLICATION) {
+      throw new IllegalArgumentException("RedisOptions.getType() != RedisClientType.REPLICATION");
+    }
+    return new RedisReplicationClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), connectOptions, options.getTracingPolicy());
+  }
+
+  /**
+   * Creates a new sentinel Redis client. The {@code options} are used to obtain {@link RedisOptions#getType()},
+   * {@link RedisOptions#getNetClientOptions()}, {@link RedisOptions#getPoolOptions()}
+   * and {@link RedisOptions#getTracingPolicy()}. The {@code connectOptions} are queried for every
+   * connection attempt.
+   * <p>
+   * If {@code options.getType() != RedisClientType.SENTINEL}, an exception is thrown.
+   *
+   * @param vertx the Vert.x instance
+   * @param options the static options
+   * @param connectOptions supplier of the dynamic options
+   * @return the sentinel client
+   */
+  static Redis createSentinelClient(Vertx vertx, RedisOptions options, Supplier<Future<RedisSentinelConnectOptions>> connectOptions) {
+    if (options.getType() != RedisClientType.SENTINEL) {
+      throw new IllegalArgumentException("RedisOptions.getType() != RedisClientType.SENTINEL");
+    }
+    return new RedisSentinelClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), connectOptions, options.getTracingPolicy());
+  }
+
+  /**
+   * Creates a new cluster Redis client. The {@code options} are used to obtain {@link RedisOptions#getType()},
+   * {@link RedisOptions#getNetClientOptions()}, {@link RedisOptions#getPoolOptions()}
+   * and {@link RedisOptions#getTracingPolicy()}. The {@code connectOptions} are queried for every
+   * connection attempt.
+   * <p>
+   * If {@code options.getType() != RedisClientType.CLUSTER}, an exception is thrown.
+   *
+   * @param vertx the Vert.x instance
+   * @param options the static options
+   * @param connectOptions supplier of the dynamic options
+   * @return the cluster client
+   */
+  static Redis createClusterClient(Vertx vertx, RedisOptions options, Supplier<Future<RedisClusterConnectOptions>> connectOptions) {
+    if (options.getType() != RedisClientType.CLUSTER) {
+      throw new IllegalArgumentException("RedisOptions.getType() != RedisClientType.CLUSTER");
+    }
+    return new RedisClusterClient(vertx, options.getNetClientOptions(), options.getPoolOptions(), connectOptions, options.getTracingPolicy());
+  }
+
+  /**
+   * Connects to the Redis server.
    *
    * @return a future with the result of the operation
    */
@@ -91,7 +170,7 @@ public interface Redis {
   Future<Void> close();
 
   /**
-   * Send the given command to the redis server or cluster.
+   * Send the given command to the Redis server or cluster.
    *
    * @param command the command to send
    * @return a future with the result of the operation

--- a/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
@@ -108,6 +108,11 @@ public class RedisClusterConnectOptions extends RedisConnectOptions {
   }
 
   @Override
+  public RedisClusterConnectOptions setUser(String user) {
+    return (RedisClusterConnectOptions) super.setUser(user);
+  }
+
+  @Override
   public RedisClusterConnectOptions setPassword(String password) {
     return (RedisClusterConnectOptions) super.setPassword(password);
   }

--- a/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
@@ -27,7 +27,8 @@ import java.util.List;
 @JsonGen(publicConverter = false)
 public abstract class RedisConnectOptions {
 
-  private volatile String password;
+  private String user;
+  private String password;
   private List<String> endpoints;
   private int maxNestedArrays;
   private boolean protocolNegotiation;
@@ -42,6 +43,7 @@ public abstract class RedisConnectOptions {
 
   public RedisConnectOptions(RedisOptions options) {
     this();
+    setUser(options.getUser());
     setPassword(options.getPassword());
     setEndpoints(new ArrayList<>(options.getEndpoints()));
     setMaxNestedArrays(options.getMaxNestedArrays());
@@ -52,6 +54,7 @@ public abstract class RedisConnectOptions {
 
   public RedisConnectOptions(RedisConnectOptions other) {
     this();
+    setUser(other.getUser());
     setPassword(other.getPassword());
     setEndpoints(new ArrayList<>(other.getEndpoints()));
     setMaxNestedArrays(other.getMaxNestedArrays());
@@ -134,8 +137,27 @@ public abstract class RedisConnectOptions {
   }
 
   /**
-   * Get the default password for cluster/sentinel connections, if not set it will try to
-   * extract it from the current default endpoint.
+   * Get the default username for Redis connections.
+   *
+   * @return username
+   */
+  public String getUser() {
+    return user;
+  }
+
+  /**
+   * Set the default username for Redis connections.
+   *
+   * @param user the default username
+   * @return fluent self
+   */
+  public RedisConnectOptions setUser(String user) {
+    this.user = user;
+    return this;
+  }
+
+  /**
+   * Get the default password for Redis connections.
    *
    * @return password
    */
@@ -144,7 +166,7 @@ public abstract class RedisConnectOptions {
   }
 
   /**
-   * Set the default password for cluster/sentinel connections.
+   * Set the default password for Redis connections.
    *
    * @param password the default password
    * @return fluent self

--- a/src/main/java/io/vertx/redis/client/RedisReplicationConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisReplicationConnectOptions.java
@@ -109,6 +109,11 @@ public class RedisReplicationConnectOptions extends RedisConnectOptions {
   }
 
   @Override
+  public RedisReplicationConnectOptions setUser(String user) {
+    return (RedisReplicationConnectOptions) super.setUser(user);
+  }
+
+  @Override
   public RedisReplicationConnectOptions setPassword(String password) {
     return (RedisReplicationConnectOptions) super.setPassword(password);
   }

--- a/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
@@ -170,6 +170,11 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
   }
 
   @Override
+  public RedisSentinelConnectOptions setUser(String user) {
+    return (RedisSentinelConnectOptions) super.setUser(user);
+  }
+
+  @Override
   public RedisSentinelConnectOptions setPassword(String password) {
     return (RedisSentinelConnectOptions) super.setPassword(password);
   }

--- a/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
@@ -58,6 +58,11 @@ public class RedisStandaloneConnectOptions extends RedisConnectOptions {
   }
 
   @Override
+  public RedisStandaloneConnectOptions setUser(String user) {
+    return (RedisStandaloneConnectOptions) super.setUser(user);
+  }
+
+  @Override
   public RedisStandaloneConnectOptions setPassword(String password) {
     return (RedisStandaloneConnectOptions) super.setPassword(password);
   }

--- a/src/main/java/io/vertx/redis/client/impl/BaseRedisClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/BaseRedisClient.java
@@ -16,17 +16,20 @@ import io.vertx.redis.client.Response;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
-public abstract class BaseRedisClient implements Redis {
+public abstract class BaseRedisClient<OPTS extends RedisConnectOptions> implements Redis {
 
   private static final Logger LOG = LoggerFactory.getLogger(BaseRedisClient.class);
 
   protected final VertxInternal vertx;
+  protected final Supplier<Future<OPTS>> connectOptions;
   protected final RedisConnectionManager connectionManager;
 
-  public BaseRedisClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisConnectOptions connectOptions, TracingPolicy tracingPolicy) {
+  public BaseRedisClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, Supplier<Future<OPTS>> connectOptions, TracingPolicy tracingPolicy) {
     this.vertx = (VertxInternal) vertx;
-    this.connectionManager = new RedisConnectionManager(this.vertx, tcpOptions, poolOptions, connectOptions, tracingPolicy);
+    this.connectOptions = connectOptions;
+    this.connectionManager = new RedisConnectionManager(this.vertx, tcpOptions, poolOptions, (Supplier) connectOptions, tracingPolicy);
     this.connectionManager.start();
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/BaseRedisClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/BaseRedisClient.java
@@ -8,7 +8,11 @@ import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.tracing.TracingPolicy;
-import io.vertx.redis.client.*;
+import io.vertx.redis.client.PoolOptions;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisConnectOptions;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/io/vertx/redis/client/impl/CommandImpl.java
+++ b/src/main/java/io/vertx/redis/client/impl/CommandImpl.java
@@ -19,7 +19,10 @@ import io.vertx.redis.client.Command;
 import io.vertx.redis.client.impl.keys.KeyConsumer;
 
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Implementation of the command metadata

--- a/src/main/java/io/vertx/redis/client/impl/RESPParser.java
+++ b/src/main/java/io/vertx/redis/client/impl/RESPParser.java
@@ -19,7 +19,15 @@ import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
-import io.vertx.redis.client.impl.types.*;
+import io.vertx.redis.client.impl.types.AttributeType;
+import io.vertx.redis.client.impl.types.BooleanType;
+import io.vertx.redis.client.impl.types.BulkType;
+import io.vertx.redis.client.impl.types.ErrorType;
+import io.vertx.redis.client.impl.types.Multi;
+import io.vertx.redis.client.impl.types.MultiType;
+import io.vertx.redis.client.impl.types.NumberType;
+import io.vertx.redis.client.impl.types.PushType;
+import io.vertx.redis.client.impl.types.SimpleStringType;
 
 public final class RESPParser implements Handler<Buffer> {
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisAPIImpl.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisAPIImpl.java
@@ -18,7 +18,12 @@ package io.vertx.redis.client.impl;
 import io.vertx.core.Future;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
-import io.vertx.redis.client.*;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.RedisConnection;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
 
 public class RedisAPIImpl implements RedisAPI {
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClient.java
@@ -15,10 +15,15 @@
  */
 package io.vertx.redis.client.impl;
 
-import io.vertx.core.*;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.tracing.TracingPolicy;
-import io.vertx.redis.client.*;
+import io.vertx.redis.client.PoolOptions;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisConnectOptions;
+import io.vertx.redis.client.RedisConnection;
 
 public class RedisClient extends BaseRedisClient implements Redis {
 
@@ -33,7 +38,7 @@ public class RedisClient extends BaseRedisClient implements Redis {
   public Future<RedisConnection> connect() {
     // so that the caller is called back on its original context
     Promise<RedisConnection> promise = vertx.promise();
-    connectionManager.getConnection(defaultAddress, null).onComplete((Promise) promise);
+    connectionManager.getConnection(defaultAddress, null).onComplete(promise);
     return promise.future();
   }
 }

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -15,7 +15,10 @@
  */
 package io.vertx.redis.client.impl;
 
-import io.vertx.core.*;
+import io.vertx.core.Completable;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.NetClientOptions;

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -42,8 +42,9 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
-public class RedisClusterClient extends BaseRedisClient implements Redis {
+public class RedisClusterClient extends BaseRedisClient<RedisClusterConnectOptions> implements Redis {
 
   private static final Logger LOG = LoggerFactory.getLogger(RedisClusterClient.class);
 
@@ -131,12 +132,10 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
     addReducer(Command.SUNSUBSCRIBE, list -> SimpleStringType.OK);
   }
 
-  final RedisClusterConnectOptions connectOptions;
-  final SharedSlots sharedSlots;
+  private final SharedSlots sharedSlots;
 
-  public RedisClusterClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, RedisClusterConnectOptions connectOptions, TracingPolicy tracingPolicy) {
+  public RedisClusterClient(Vertx vertx, NetClientOptions tcpOptions, PoolOptions poolOptions, Supplier<Future<RedisClusterConnectOptions>> connectOptions, TracingPolicy tracingPolicy) {
     super(vertx, tcpOptions, poolOptions, connectOptions, tracingPolicy);
-    this.connectOptions = connectOptions;
     this.sharedSlots = new SharedSlots(vertx, connectOptions, connectionManager);
     // validate options
     if (poolOptions.getMaxWaiting() < poolOptions.getMaxSize()) {
@@ -153,7 +152,13 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
     return promise.future();
   }
 
-  private void connect(Slots slots, Completable<RedisConnection> onConnected) {
+  private void connect(Slots slots, Completable<RedisConnection> promise) {
+    connectOptions.get()
+      .onSuccess(opts -> connect(slots, opts, promise))
+      .onFailure(promise::fail);
+  }
+
+  private void connect(Slots slots, RedisClusterConnectOptions connectOptions, Completable<RedisConnection> onConnected) {
     // create a cluster connection
     final Set<Throwable> failures = ConcurrentHashMap.newKeySet();
     final AtomicInteger counter = new AtomicInteger();
@@ -164,7 +169,7 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
         .onFailure(err -> {
           // failed try with the next endpoint
           failures.add(err);
-          connectionComplete(counter, slots, connections, failures, onConnected);
+          connectionComplete(counter, slots, connectOptions, connections, failures, onConnected);
         })
         .onSuccess(cconn -> {
           // there can be concurrent access to the connection map
@@ -173,13 +178,13 @@ public class RedisClusterClient extends BaseRedisClient implements Redis {
           synchronized (connections) {
             connections.put(endpoint, cconn);
           }
-          connectionComplete(counter, slots, connections, failures, onConnected);
+          connectionComplete(counter, slots, connectOptions, connections, failures, onConnected);
         });
     }
   }
 
-  private void connectionComplete(AtomicInteger counter, Slots slots, Map<String, PooledRedisConnection> connections,
-      Set<Throwable> failures, Completable<RedisConnection> onConnected) {
+  private void connectionComplete(AtomicInteger counter, Slots slots, RedisClusterConnectOptions connectOptions,
+      Map<String, PooledRedisConnection> connections, Set<Throwable> failures, Completable<RedisConnection> onConnected) {
     if (counter.incrementAndGet() == slots.endpoints().length) {
       // end condition
       if (!failures.isEmpty()) {

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterImpl.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterImpl.java
@@ -1,5 +1,6 @@
 package io.vertx.redis.client.impl;
 
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.logging.Logger;
@@ -77,9 +78,9 @@ public class RedisClusterImpl implements RedisCluster {
       });
   }
 
-  private void onAllNodes(String[] endpoints, int index, Request request, List<Response> result, RedisClusterConnection conn, Promise<List<Response>> promise) {
+  private void onAllNodes(String[] endpoints, int index, Request request, List<Response> result, RedisClusterConnection conn, Completable<List<Response>> promise) {
     if (index >= endpoints.length) {
-      promise.complete(result);
+      promise.succeed(result);
       return;
     }
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
@@ -243,7 +243,7 @@ public class RedisConnectionManager implements Function<RedisConnectionManager.C
         Request hello = Request.cmd(Command.HELLO).arg(version);
 
         String password = redisURI.password() != null ? redisURI.password() : options.getPassword();
-        String user = redisURI.user();
+        String user = redisURI.user() != null ? redisURI.user() : options.getUser();
 
         if (password != null) {
           // will perform auth at hello level
@@ -298,7 +298,8 @@ public class RedisConnectionManager implements Function<RedisConnectionManager.C
               if (((ErrorType) err).is("NOAUTH")) {
                 // old authentication required
                 String password = redisURI.password() != null ? redisURI.password() : options.getPassword();
-                return this.authenticate(ctx, connection, redisURI.user(), password);
+                String user = redisURI.user() != null ? redisURI.user() : options.getUser();
+                return this.authenticate(ctx, connection, user, password);
               }
             }
           }

--- a/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
@@ -237,7 +237,9 @@ public class RedisConnectionManager implements Function<RedisConnectionManager.C
         return ping(ctx, connection);
       } else {
         String version = RESPParser.VERSION;
-        if (options.getPreferredProtocolVersion() != null) {
+        if (redisURI.param("protocol") != null) {
+          version = redisURI.param("protocol");
+        } else if (options.getPreferredProtocolVersion() != null) {
           version = options.getPreferredProtocolVersion().getValue();
         }
         Request hello = Request.cmd(Command.HELLO).arg(version);

--- a/src/main/java/io/vertx/redis/client/impl/RedisReplicationClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisReplicationClient.java
@@ -15,19 +15,35 @@
  */
 package io.vertx.redis.client.impl;
 
-import io.vertx.core.*;
+import io.vertx.core.Completable;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.tracing.TracingPolicy;
-import io.vertx.redis.client.*;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.PoolOptions;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisConnection;
+import io.vertx.redis.client.RedisReplicationConnectOptions;
+import io.vertx.redis.client.RedisTopology;
+import io.vertx.redis.client.Response;
 
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.vertx.redis.client.Command.*;
+import static io.vertx.redis.client.Command.INFO;
+import static io.vertx.redis.client.Command.WAIT;
 import static io.vertx.redis.client.Request.cmd;
 
 public class RedisReplicationClient extends BaseRedisClient implements Redis {
@@ -136,18 +152,17 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
       })
       .onSuccess(conn -> {
         // fetch slots from the cluster immediately to ensure slots are correct
-        getReplicas(conn, endpoints, index, getReplicas -> {
-          if (getReplicas.failed()) {
+        getReplicas(conn, endpoints, index, (replicas, err) -> {
+          if (err != null) {
             // the slots command failed.
             conn.close();
             // try with the next one
-            failures.add(getReplicas.cause());
+            failures.add(err);
             connectWithDiscoverTopology(endpoints, index + 1, failures, onConnect);
             return;
           }
 
           // create a cluster connection
-          final List<Node> replicas = getReplicas.result();
           final AtomicInteger counter = new AtomicInteger();
           final List<PooledRedisConnection> replicaConnections = new ArrayList<>();
 
@@ -162,9 +177,9 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
 
             // we don't send `READONLY` setup to replica nodes, because that's a cluster-only command
             connectionManager.getConnection(replica.endpoint(), null)
-              .onFailure(err -> {
+              .onFailure(error -> {
                 // failed try with the next endpoint
-                LOG.warn("Skipping failed replica: " + replica.ip + ":" + replica.port, err);
+                LOG.warn("Skipping failed replica: " + replica.ip + ":" + replica.port, error);
                 if (counter.incrementAndGet() == replicas.size()) {
                   onConnect.succeed(new RedisReplicationConnection(vertx, connectOptions, conn, replicaConnections));
                 }
@@ -185,17 +200,17 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
       });
   }
 
-  private void getReplicas(RedisConnection conn, List<String> endpoints, int index, Handler<AsyncResult<List<Node>>> onGetReplicas) {
+  private void getReplicas(RedisConnection conn, List<String> endpoints, int index, Completable<List<Node>> onGetReplicas) {
 
     conn.send(cmd(INFO).arg("REPLICATION"))
-      .onFailure(err -> onGetReplicas.handle(Future.failedFuture(err)))
+      .onFailure(onGetReplicas::fail)
       .onSuccess(info -> {
 
         final Map<String, String> reply = parseInfo(info);
 
         if (reply.isEmpty()) {
           // no slots available we can't really proceed
-          onGetReplicas.handle(Future.failedFuture("INFO REPLICATION No config available in the node."));
+          onGetReplicas.fail("INFO REPLICATION No config available in the node.");
           return;
         }
 
@@ -210,10 +225,10 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
               for (int i = 0; i < totalNodes; i++) {
                 nodes.add(new Node(uri, reply.get("slave" + i)));
               }
-              onGetReplicas.handle(Future.succeededFuture(nodes));
+              onGetReplicas.succeed(nodes);
               return;
             } catch (RuntimeException e) {
-              onGetReplicas.handle(Future.failedFuture(e));
+              onGetReplicas.fail(e);
               return;
             }
           case "slave":
@@ -224,20 +239,20 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
               // push it to the list
               endpoints.add(index + 1, uri.protocol() + "://" + uri.userinfo() + masterHost + ":" + masterPort);
               // so it will be run on the next try
-              onGetReplicas.handle(Future.failedFuture("Connected to replica, retrying with master"));
+              onGetReplicas.fail("Connected to replica, retrying with master");
               return;
             } catch (RuntimeException e) {
-              onGetReplicas.handle(Future.failedFuture(e));
+              onGetReplicas.fail(e);
               return;
             }
           default:
-            onGetReplicas.handle(Future.failedFuture("INFO REPLICATION invalid role: " + reply.get("role")));
+            onGetReplicas.fail("INFO REPLICATION invalid role: " + reply.get("role"));
             break;
         }
       });
   }
 
-  private void connectWithStaticTopology(String master, List<String> replicas, Promise<RedisConnection> promise) {
+  private void connectWithStaticTopology(String master, List<String> replicas, Completable<RedisConnection> promise) {
     connectionManager.getConnection(master, null)
       .onFailure(error -> {
         promise.fail(new RedisConnectException("Cannot connect to statically configured master: " + master + "\n- " + error));
@@ -252,7 +267,7 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
             .onFailure(err -> {
               LOG.warn("Skipping failed replica: " + replica, err);
               if (counter.incrementAndGet() == replicas.size()) {
-                promise.complete(new RedisReplicationConnection(vertx, connectOptions, masterConnection, replicaConnections));
+                promise.succeed(new RedisReplicationConnection(vertx, connectOptions, masterConnection, replicaConnections));
               }
             })
             .onSuccess(replicaConnection -> {
@@ -263,7 +278,7 @@ public class RedisReplicationClient extends BaseRedisClient implements Redis {
                 replicaConnections.add(replicaConnection);
               }
               if (counter.incrementAndGet() == replicas.size()) {
-                promise.complete(new RedisReplicationConnection(vertx, connectOptions, masterConnection, replicaConnections));
+                promise.succeed(new RedisReplicationConnection(vertx, connectOptions, masterConnection, replicaConnections));
               }
             });
         }

--- a/src/main/java/io/vertx/redis/client/impl/RedisReplicationConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisReplicationConnection.java
@@ -6,7 +6,12 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
-import io.vertx.redis.client.*;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.RedisConnection;
+import io.vertx.redis.client.RedisReplicas;
+import io.vertx.redis.client.RedisReplicationConnectOptions;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/io/vertx/redis/client/impl/RedisSentinelClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisSentinelClient.java
@@ -15,7 +15,10 @@
  */
 package io.vertx.redis.client.impl;
 
-import io.vertx.core.*;
+import io.vertx.core.Completable;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.NetClientOptions;
@@ -77,18 +80,18 @@ public class RedisSentinelClient extends BaseRedisClient implements Redis {
 
       if (connectOptions.getRole() == RedisRole.SENTINEL || connectOptions.getRole() == RedisRole.REPLICA) {
         // it is possible that a replica is later promoted to a master, but that shouldn't be too big of a deal
-        promise.complete(conn);
+        promise.succeed(conn);
         return;
       }
       if (!connectOptions.isAutoFailover()) {
         // no auto failover, return the master connection directly
-        promise.complete(conn);
+        promise.succeed(conn);
         return;
       }
 
       SentinelFailover failover = setupFailover();
       RedisSentinelConnection sentinelConn = new RedisSentinelConnection(conn, failover);
-      promise.complete(sentinelConn);
+      promise.succeed(sentinelConn);
     });
 
     return promise.future();
@@ -126,13 +129,12 @@ public class RedisSentinelClient extends BaseRedisClient implements Redis {
 
   private void createConnectionInternal(RedisSentinelConnectOptions options, RedisRole role, Completable<PooledRedisConnection> onCreate) {
 
-    final Handler<AsyncResult<RedisURI>> createAndConnect = resolve -> {
-      if (resolve.failed()) {
-        onCreate.fail(resolve.cause());
+    final Completable<RedisURI> createAndConnect = (uri, err) -> {
+      if (err != null) {
+        onCreate.fail(err);
         return;
       }
 
-      final RedisURI uri = resolve.result();
       final Request setup;
 
       // `SELECT` is only allowed on non-sentinel nodes
@@ -164,14 +166,13 @@ public class RedisSentinelClient extends BaseRedisClient implements Redis {
    * We use the algorithm from http://redis.io/topics/sentinel-clients
    * to get a sentinel client and then do 'stuff' with it
    */
-  private static void resolveClient(final Resolver checkEndpointFn, final RedisSentinelConnectOptions options, final Handler<AsyncResult<RedisURI>> callback) {
+  private static void resolveClient(final Resolver checkEndpointFn, final RedisSentinelConnectOptions options, final Completable<RedisURI> callback) {
     // Because finding the master is going to be an async list we will terminate
     // when we find one then use promises...
-    iterate(0, ConcurrentHashMap.newKeySet(), checkEndpointFn, options, iterate -> {
-      if (iterate.failed()) {
-        callback.handle(Future.failedFuture(iterate.cause()));
+    iterate(0, ConcurrentHashMap.newKeySet(), checkEndpointFn, options, (found, err) -> {
+      if (err != null) {
+        callback.fail(err);
       } else {
-        final Pair<Integer, RedisURI> found = iterate.result();
         // This is the endpoint that has responded so stick it on the top of
         // the list
         final List<String> endpoints = options.getEndpoints();
@@ -179,12 +180,12 @@ public class RedisSentinelClient extends BaseRedisClient implements Redis {
         endpoints.set(found.left, endpoints.get(0));
         endpoints.set(0, endpoint);
         // now return the right address
-        callback.handle(Future.succeededFuture(found.right));
+        callback.succeed(found.right);
       }
     });
   }
 
-  private static void iterate(final int idx, final Set<Throwable> failures, final Resolver checkEndpointFn, final RedisSentinelConnectOptions argument, final Handler<AsyncResult<Pair<Integer, RedisURI>>> resultHandler) {
+  private static void iterate(final int idx, final Set<Throwable> failures, final Resolver checkEndpointFn, final RedisSentinelConnectOptions argument, final Completable<Pair<Integer, RedisURI>> resultHandler) {
     // stop condition
     final List<String> endpoints = argument.getEndpoints();
 
@@ -193,17 +194,17 @@ public class RedisSentinelClient extends BaseRedisClient implements Redis {
       for (Throwable failure : failures) {
         message.append("\n- ").append(failure);
       }
-      resultHandler.handle(Future.failedFuture(new RedisConnectException(message.toString())));
+      resultHandler.fail(new RedisConnectException(message.toString()));
       return;
     }
 
     // attempt to perform operation
-    checkEndpointFn.resolve(endpoints.get(idx), argument, res -> {
-      if (res.succeeded()) {
-        resultHandler.handle(Future.succeededFuture(new Pair<>(idx, res.result())));
+    checkEndpointFn.resolve(endpoints.get(idx), argument, (res, err) -> {
+      if (err == null) {
+        resultHandler.succeed(new Pair<>(idx, res));
       } else {
         // try again with next endpoint
-        failures.add(res.cause());
+        failures.add(err);
         iterate(idx + 1, failures, checkEndpointFn, argument, resultHandler);
       }
     });
@@ -211,68 +212,68 @@ public class RedisSentinelClient extends BaseRedisClient implements Redis {
 
   // begin endpoint check methods
 
-  private void isSentinelOk(String endpoint, RedisConnectOptions argument, Handler<AsyncResult<RedisURI>> handler) {
+  private void isSentinelOk(String endpoint, RedisConnectOptions argument, Completable<RedisURI> handler) {
     // we can't use the endpoint as is, it should not contain a database selection,
     // but can contain authentication
     final RedisURI uri = new RedisURI(endpoint);
 
     connectionManager.getConnection(uri.baseUri(), null)
-      .onFailure(err -> handler.handle(Future.failedFuture(err)))
+      .onFailure(handler::fail)
       .onSuccess(conn -> {
         // Send a command just to check we have a working node
         conn
           .send(Request.cmd(Command.PING))
-          .onFailure(err -> handler.handle(Future.failedFuture(err)))
-          .onSuccess(ok -> handler.handle(Future.succeededFuture(uri)))
+          .onFailure(handler::fail)
+          .onSuccess(ok -> handler.succeed(uri))
           .eventually(() -> conn.close().onFailure(LOG::warn));
       });
   }
 
-  private void getMasterFromEndpoint(String endpoint, RedisSentinelConnectOptions options, Handler<AsyncResult<RedisURI>> handler) {
+  private void getMasterFromEndpoint(String endpoint, RedisSentinelConnectOptions options, Completable<RedisURI> handler) {
     // we can't use the endpoint as is, it should not contain a database selection,
     // but can contain authentication
     final RedisURI uri = new RedisURI(endpoint);
     connectionManager.getConnection(uri.baseUri(), null)
-      .onFailure(err -> handler.handle(Future.failedFuture(err)))
+      .onFailure(handler::fail)
       .onSuccess(conn -> {
         final String masterName = options.getMasterName();
         // Send a command just to check we have a working node
         conn
           .send(Request.cmd(Command.SENTINEL).arg("GET-MASTER-ADDR-BY-NAME").arg(masterName))
-          .onFailure(err -> handler.handle(Future.failedFuture(err)))
+          .onFailure(handler::fail)
           .onSuccess(response -> {
             if (response == null) {
-              handler.handle(Future.failedFuture("Failed to GET-MASTER-ADDR-BY-NAME " + masterName));
+              handler.fail("Failed to GET-MASTER-ADDR-BY-NAME " + masterName);
             } else {
               final String rHost = response.get(0).toString();
               final Integer rPort = response.get(1).toInteger();
-              handler.handle(Future.succeededFuture(new RedisURI(uri, rHost.contains(":") ? "[" + rHost + "]" : rHost, rPort)));
+              handler.succeed(new RedisURI(uri, rHost.contains(":") ? "[" + rHost + "]" : rHost, rPort));
             }
           })
           .eventually(() -> conn.close().onFailure(LOG::warn));
       });
   }
 
-  private void getReplicaFromEndpoint(String endpoint, RedisSentinelConnectOptions options, Handler<AsyncResult<RedisURI>> handler) {
+  private void getReplicaFromEndpoint(String endpoint, RedisSentinelConnectOptions options, Completable<RedisURI> handler) {
     // we can't use the endpoint as is, it should not contain a database selection,
     // but can contain authentication
     final RedisURI uri = new RedisURI(endpoint);
     connectionManager.getConnection(uri.baseUri(), null)
-      .onFailure(err -> handler.handle(Future.failedFuture(err)))
+      .onFailure(handler::fail)
       .onSuccess(conn -> {
         final String masterName = options.getMasterName();
         // Send a command just to check we have a working node
         conn
           .send(Request.cmd(Command.SENTINEL).arg("SLAVES").arg(masterName))
-          .onFailure(err -> handler.handle(Future.failedFuture(err)))
+          .onFailure(handler::fail)
           .onSuccess(response -> {
             // Test the response
             if (response == null || response.size() == 0) {
-              handler.handle(Future.failedFuture("No replicas linked to the master: " + masterName));
+              handler.fail("No replicas linked to the master: " + masterName);
             } else {
               Response replicaInfoArr = response.get(RANDOM.nextInt(response.size()));
               if ((replicaInfoArr.size() % 2) > 0) {
-                handler.handle(Future.failedFuture("Corrupted response from the sentinel"));
+                handler.fail("Corrupted response from the sentinel");
               } else {
                 int port = 6379;
                 String ip = null;
@@ -286,11 +287,11 @@ public class RedisSentinelClient extends BaseRedisClient implements Redis {
                 }
 
                 if (ip == null) {
-                  handler.handle(Future.failedFuture("No IP found for a REPLICA node!"));
+                  handler.fail("No IP found for a REPLICA node!");
                 } else {
                   final String host = ip.contains(":") ? "[" + ip + "]" : ip;
 
-                  handler.handle(Future.succeededFuture(new RedisURI(uri, host, port)));
+                  handler.succeed(new RedisURI(uri, host, port));
                 }
               }
             }

--- a/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisStandaloneConnection.java
@@ -16,7 +16,12 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.internal.pool.PoolConnector;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.tracing.TracingPolicy;
-import io.vertx.redis.client.*;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.PoolOptions;
+import io.vertx.redis.client.RedisConnection;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
+import io.vertx.redis.client.ResponseType;
 import io.vertx.redis.client.impl.types.ErrorType;
 import io.vertx.redis.client.impl.types.Multi;
 
@@ -264,7 +269,7 @@ public class RedisStandaloneConnection implements RedisConnectionInternal, Parse
 
     if (commands.isEmpty()) {
       LOG.debug("Empty batch");
-      promise.complete(Collections.emptyList());
+      promise.succeed(Collections.emptyList());
     } else {
       // will re-encode the handler into a list of promises
       final List<Promise<Response>> callbacks = new ArrayList<>(commands.size());

--- a/src/main/java/io/vertx/redis/client/impl/RequestImpl.java
+++ b/src/main/java/io/vertx/redis/client/impl/RequestImpl.java
@@ -20,7 +20,11 @@ import io.vertx.redis.client.Command;
 import io.vertx.redis.client.Request;
 
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 import static io.vertx.redis.client.impl.RESPEncoder.numToBytes;
 

--- a/src/main/java/io/vertx/redis/client/impl/Resolver.java
+++ b/src/main/java/io/vertx/redis/client/impl/Resolver.java
@@ -15,14 +15,11 @@
  */
 package io.vertx.redis.client.impl;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.redis.client.RedisConnectOptions;
-import io.vertx.redis.client.RedisOptions;
+import io.vertx.core.Completable;
 import io.vertx.redis.client.RedisSentinelConnectOptions;
 
 @FunctionalInterface
 interface Resolver {
 
-  void resolve(String endpoint, RedisSentinelConnectOptions parameter, Handler<AsyncResult<RedisURI>> callback);
+  void resolve(String endpoint, RedisSentinelConnectOptions parameter, Completable<RedisURI> callback);
 }

--- a/src/main/java/io/vertx/redis/client/impl/SharedSlots.java
+++ b/src/main/java/io/vertx/redis/client/impl/SharedSlots.java
@@ -1,8 +1,7 @@
 package io.vertx.redis.client.impl;
 
-import io.vertx.core.AsyncResult;
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.internal.logging.Logger;
@@ -55,14 +54,14 @@ class SharedSlots {
     }
   }
 
-  private void getSlots(List<String> endpoints, int index, Set<Throwable> failures, Promise<Slots> onGotSlots) {
+  private void getSlots(List<String> endpoints, int index, Set<Throwable> failures, Completable<Slots> onGotSlots) {
     if (index >= endpoints.size()) {
       // stop condition
       StringBuilder message = new StringBuilder("Cannot connect to any of the provided endpoints");
       for (Throwable failure : failures) {
         message.append("\n- ").append(failure);
       }
-      onGotSlots.handle(Future.failedFuture(new RedisConnectException(message.toString())));
+      onGotSlots.fail(new RedisConnectException(message.toString()));
       scheduleInvalidation();
       return;
     }
@@ -85,7 +84,7 @@ class SharedSlots {
             getSlots(endpoints, index + 1, failures, onGotSlots);
           } else {
             Slots slots = result.result();
-            onGotSlots.handle(Future.succeededFuture(slots));
+            onGotSlots.succeed(slots);
             scheduleInvalidation();
           }
         });

--- a/src/main/java/io/vertx/redis/client/impl/Slots.java
+++ b/src/main/java/io/vertx/redis/client/impl/Slots.java
@@ -18,7 +18,11 @@ package io.vertx.redis.client.impl;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.redis.client.Response;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 
 // see https://redis.io/commands/cluster-slots/
 class Slots {

--- a/src/main/java/io/vertx/redis/client/impl/types/MultiType.java
+++ b/src/main/java/io/vertx/redis/client/impl/types/MultiType.java
@@ -19,7 +19,11 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * A Redis MULTI response can represent a List/Set/Map type.

--- a/src/test/java/io/vertx/tests/redis/client/TestUtils.java
+++ b/src/test/java/io/vertx/tests/redis/client/TestUtils.java
@@ -1,5 +1,6 @@
 package io.vertx.tests.redis.client;
 
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -18,10 +19,10 @@ public class TestUtils {
     return promise.future();
   }
 
-  private static <T> void retryUntilSuccess(Vertx vertx, Supplier<Future<T>> action, int maxRetries, Promise<T> promise) {
+  private static <T> void retryUntilSuccess(Vertx vertx, Supplier<Future<T>> action, int maxRetries, Completable<T> promise) {
     action.get().onComplete(result -> {
       if (result.succeeded()) {
-        promise.complete(result.result());
+        promise.succeed(result.result());
       } else {
         if (maxRetries < 1) {
           promise.fail(result.cause());


### PR DESCRIPTION
In addition to that, this PR also adds `Redis[Connect]Options.getUser()` / `setUser()` and also support for the `protocol` query parameter in the Redis URI. Finally, this PR removes all the remaining usages of `Handler<AsyncResult<...>>` and replaces them with `Completable`.

Fixes #356
Closes #376
Closes #391
Closes #410
Fixes #364