### PR TITLE
fix the EventBusHandler

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -381,6 +381,8 @@ The message sent to the Vert.x event bus is a `JsonObject` with the following fo
 <3> For `pmessage`, `psubscribe` and `punsubscribe`.
 <4> For `[p]subscribe` and `[p]unsubscribe`.
 
+The event bus address is `<prefix>.<the channel>` for `message`, `subscribe` and `unsubscribe` messages, and `<prefix>.<the pattern>` for `pmessage`, `psubscribe` and `punsubscribe` messages.
+
 == Tracing commands
 
 The Redis client can trace command execution when Vert.x has tracing enabled.

--- a/src/main/java/io/vertx/redis/client/EventBusHandler.java
+++ b/src/main/java/io/vertx/redis/client/EventBusHandler.java
@@ -80,7 +80,7 @@ public class EventBusHandler implements Handler<Response> {
       }
 
       if (reply.size() == 4 && "pmessage".equals(type)) {
-        eventBus.send(prefix + "." + reply.get(2).toString(),
+        eventBus.send(prefix + "." + reply.get(1).toString(),
           new JsonObject()
             .put("status", "OK")
             .put("type", type)

--- a/src/test/java/io/vertx/tests/redis/client/RedisPubSubTest.java
+++ b/src/test/java/io/vertx/tests/redis/client/RedisPubSubTest.java
@@ -68,9 +68,9 @@ public class RedisPubSubTest {
 
   @Test
   public void publishSubscribe_withHandler(TestContext test) {
-    Async async = test.async();
+    Async async = test.async(2);
 
-    rule.vertx().eventBus().consumer("io.vertx.redis.news", msg -> async.complete());
+    rule.vertx().eventBus().consumer("io.vertx.redis.news", msg -> async.countDown());
 
     subConn.handler(EventBusHandler.create(rule.vertx()));
     subConn.send(Request.cmd(Command.SUBSCRIBE).arg("news")).onComplete(test.asyncAssertSuccess(result -> {
@@ -80,9 +80,9 @@ public class RedisPubSubTest {
 
   @Test
   public void publishPSubscribe_withHandler(TestContext test) {
-    Async async = test.async();
+    Async async = test.async(2);
 
-    rule.vertx().eventBus().consumer("io.vertx.redis.new*", msg -> async.complete());
+    rule.vertx().eventBus().consumer("io.vertx.redis.new*", msg -> async.countDown());
 
     subConn.handler(EventBusHandler.create(rule.vertx()));
     subConn.send(Request.cmd(Command.PSUBSCRIBE).arg("new*")).onComplete(test.asyncAssertSuccess(result -> {


### PR DESCRIPTION
When we extracted the Redis subscription -> Vert.x event bus handler, we made a breaking change in how we transfer the `pmessage` messages to the event bus: instead of the original `<prefix>.<pattern>` address, we used `<prefix>.<channel>`. This commit moves the address back.

In addition to that, this commit also fixes the `RedisPubSubTest` to also account for `[p]subscribe` messages.