### PR TITLE
Allow using only a username in Redis URL authinfo

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/RedisURI.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisURI.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 /**
  * Utility to parse Redis URLs. The URI should follow the general scheme:
- * {@code redis://[username:password@][host][:port][/[database]}
+ * {@code redis://[[username][:password]@][host][:port][/[database]]}
  *
  * <p>An example URI can be found at <a href="https://redis.io/topics/rediscli">Redis cli docs</a>.</p>
  *

--- a/src/main/java/io/vertx/redis/client/impl/RedisURI.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisURI.java
@@ -39,7 +39,7 @@ import java.util.Map;
  *   <ul>
  *     <li>{@code db}: database</li>
  *     <li>{@code user}: username</li>
- *     <li>{@code password}: username</li>
+ *     <li>{@code password}: password</li>
  *   </ul>
  * </p>
  *

--- a/src/test/java/io/vertx/tests/redis/internal/RedisURITest.java
+++ b/src/test/java/io/vertx/tests/redis/internal/RedisURITest.java
@@ -43,6 +43,18 @@ public class RedisURITest {
   }
 
   @Test
+  public void testOnlyLoginGiven() {
+    RedisURI redisURI = new RedisURI("redis://redisUs%65r@redis-1234.hosted.com:1234/0");
+    Assert.assertEquals("User is not correct", "redisUser", redisURI.user());
+  }
+
+  @Test
+  public void testTwoLoginsAreGiven() {
+    RedisURI redisURI = new RedisURI("redis://redisUs%65r:pass@redis-1234.hosted.com:1234/0?user=otherUs%65r");
+    Assert.assertEquals("User is not correct", "redisUser", redisURI.user());
+  }
+
+  @Test
   public void testPasswordNotGiven() {
     RedisURI redisURI = new RedisURI("redis://redis-1234.hosted.com:1234/0");
     Assert.assertNull("Password is not null", redisURI.password());


### PR DESCRIPTION
The `io.vertx.redis.client.impl.RedisURI` class parsed URIs with only a username in the URI userinfo component but silently dropped it afterwards.

`redis://my-user@example.com:6379/0` was accepted without throwing an exception but the user defaulted to `default` or alternatively to the given `user` query parameter.

This change set modifies the behavior so that the username from the example URI above (`my-user`) is being properly used and that the password is still unset.

Please note that `redis://my-user@example.com` (password is unset/null) and `redis://my-user:@example.com` (password is empty string) are different and both cover valid connection cases.

Additionally the Javadoc for `RedisURI` has been extended to cover the valid URI schems and query parameters.
