### PR TITLE
[4.x] initial support for single-node Redis transactions in cluster

### DIFF
--- a/.github/workflows/ci-4.x.yml
+++ b/.github/workflows/ci-4.x.yml
@@ -19,7 +19,7 @@ jobs:
         jdk: [8, 17]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: maven-java-${{ matrix.jdk }}
@@ -41,7 +41,7 @@ jobs:
       VERTX_NEXUS_USERNAME: ${{ secrets.VERTX_NEXUS_USERNAME }}
       VERTX_NEXUS_PASSWORD: ${{ secrets.VERTX_NEXUS_PASSWORD }}
     steps:
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: maven-java-${{ matrix.jdk }}

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -214,6 +214,42 @@ This form of DNS-based load balancing does not work well with DNS resolution cac
 As a result, some replicas are likely to be underutilized.
 Elasticache for Redis (Cluster Mode Enabled) doesn't suffer from this problem, because it uses classic round-robin DNS.
 
+== Redis transactions
+
+The Vert.x Redis client supports Redis transactions.
+You simply have to issue the corresponding commands: `MULTI`, `EXEC`, `DISCARD`, `WATCH` or `UNWATCH`.
+Note that transactions in Redis are _not_ classic ACID transactions from SQL databases; they merely allow queueing multiple commands for later execution.
+
+Transactions must be executed on a single connection.
+Trying to execute a transactional command in a connection-less mode (`Redis.send()`) will fail.
+It is possible to execute a transaction in a connection-less batch (`Redis.batch()`), but the batch must contain the entire transaction; it must not be split in multiple batches.
+
+It is recommended to always obtain a connection (`Redis.connect()`) and execute all commands of a transaction on that connection.
+
+=== Transactions in cluster
+
+By default, transactions in Redis cluster are disabled.
+Attempting to execute a transactional command leads to a failure.
+
+It is possible to enable single-node transactions in Redis cluster by:
+
+[source,$lang]
+----
+{@link examples.RedisExamples#example16}
+----
+
+In single-node transactions, the first command (if it is `WATCH`) or the second command (if the first one is `MULTI`) determines on which node the transaction should execute.
+The connection is bound to the selected node and all subsequent commands are sent to that node, regardless of the hash slot assignment.
+When the final command of a transaction (`EXEC` or `DISCARD`) is executed, the connection is reset to default mode and is no longer bound to a single node.
+
+If the transaction starts with `WATCH`, that command has keys and so determines the target node.
+If the transaction starts with `MULTI`, that command is not sent to Redis directly but is rather queued until the next command is executed.
+It is that command that determines the target node (so it should have keys, otherwise the target node is random).
+
+WARNING: Note that all this only applies to `RedisConnection.send()`.
+Command batches (`RedisConnection.batch()`) are always executed on a single node in the cluster, so there is no special support for transactions (they are not even disabled by default).
+Again, the batch must contain the entire transaction; it must not be split in multiple batches.
+
 == Pub/Sub mode
 
 Redis supports queues and pub/sub mode, when operated in this mode once a connection invokes a subscriber mode then

--- a/src/main/generated/io/vertx/redis/client/RedisClusterConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisClusterConnectOptionsConverter.java
@@ -20,6 +20,11 @@ public class RedisClusterConnectOptionsConverter {
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, RedisClusterConnectOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "clusterTransactions":
+          if (member.getValue() instanceof String) {
+            obj.setClusterTransactions(io.vertx.redis.client.RedisClusterTransactions.valueOf((String)member.getValue()));
+          }
+          break;
         case "hashSlotCacheTTL":
           if (member.getValue() instanceof Number) {
             obj.setHashSlotCacheTTL(((Number)member.getValue()).longValue());
@@ -39,6 +44,9 @@ public class RedisClusterConnectOptionsConverter {
   }
 
    static void toJson(RedisClusterConnectOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getClusterTransactions() != null) {
+      json.put("clusterTransactions", obj.getClusterTransactions().name());
+    }
     json.put("hashSlotCacheTTL", obj.getHashSlotCacheTTL());
     if (obj.getUseReplicas() != null) {
       json.put("useReplicas", obj.getUseReplicas().name());

--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -25,6 +25,11 @@ public class RedisOptionsConverter {
             obj.setAutoFailover((Boolean)member.getValue());
           }
           break;
+        case "clusterTransactions":
+          if (member.getValue() instanceof String) {
+            obj.setClusterTransactions(io.vertx.redis.client.RedisClusterTransactions.valueOf((String)member.getValue()));
+          }
+          break;
         case "connectionString":
           if (member.getValue() instanceof String) {
             obj.setConnectionString((String)member.getValue());
@@ -158,6 +163,9 @@ public class RedisOptionsConverter {
 
    static void toJson(RedisOptions obj, java.util.Map<String, Object> json) {
     json.put("autoFailover", obj.isAutoFailover());
+    if (obj.getClusterTransactions() != null) {
+      json.put("clusterTransactions", obj.getClusterTransactions().name());
+    }
     if (obj.getEndpoint() != null) {
       json.put("endpoint", obj.getEndpoint());
     }

--- a/src/main/java/examples/RedisExamples.java
+++ b/src/main/java/examples/RedisExamples.java
@@ -283,6 +283,10 @@ public class RedisExamples {
       });
   }
 
+  public void example16(RedisOptions options) {
+    options.setClusterTransactions(RedisClusterTransactions.SINGLE_NODE);
+  }
+
   public void tracing1(RedisOptions options) {
     options.setTracingPolicy(TracingPolicy.ALWAYS);
   }

--- a/src/main/java/io/vertx/redis/client/RedisClientType.java
+++ b/src/main/java/io/vertx/redis/client/RedisClientType.java
@@ -38,7 +38,8 @@ public enum RedisClientType {
   /**
    * The client should work in cluster mode. When this mode is active,
    * use the {@link RedisReplicas} to define when replica nodes can be
-   * used for read only queries.
+   * used for read only queries, and use {@link RedisClusterTransactions}
+   * to define how transactions should be handled.
    */
   CLUSTER,
 

--- a/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
@@ -26,23 +26,27 @@ import java.util.List;
 public class RedisClusterConnectOptions extends RedisConnectOptions {
 
   private RedisReplicas useReplicas;
+  private RedisClusterTransactions clusterTransactions;
   private long hashSlotCacheTTL;
 
   public RedisClusterConnectOptions() {
     super();
     useReplicas = RedisReplicas.NEVER;
+    clusterTransactions = RedisClusterTransactions.DISABLED;
     hashSlotCacheTTL = 1000;
   }
 
   public RedisClusterConnectOptions(RedisOptions options) {
     super(options);
     setUseReplicas(options.getUseReplicas());
+    setClusterTransactions(options.getClusterTransactions());
     setHashSlotCacheTTL(options.getHashSlotCacheTTL());
   }
 
   public RedisClusterConnectOptions(RedisClusterConnectOptions other) {
     super(other);
     setUseReplicas(other.getUseReplicas());
+    setClusterTransactions(other.getClusterTransactions());
     setHashSlotCacheTTL(other.getHashSlotCacheTTL());
   }
 
@@ -89,6 +93,26 @@ public class RedisClusterConnectOptions extends RedisConnectOptions {
    */
   public RedisClusterConnectOptions setHashSlotCacheTTL(long hashSlotCacheTTL) {
     this.hashSlotCacheTTL = hashSlotCacheTTL;
+    return this;
+  }
+
+  /**
+   * Get how Redis transactions are handled in cluster mode.
+   *
+   * @return how transactions are handled
+   */
+  public RedisClusterTransactions getClusterTransactions() {
+    return clusterTransactions;
+  }
+
+  /**
+   * Set how Redis transactions are handled in cluster mode.
+   *
+   * @param clusterTransactions transaction handling mode
+   * @return fluent self
+   */
+  public RedisClusterConnectOptions setClusterTransactions(RedisClusterTransactions clusterTransactions) {
+    this.clusterTransactions = clusterTransactions;
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/RedisClusterTransactions.java
+++ b/src/main/java/io/vertx/redis/client/RedisClusterTransactions.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ * <p>
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.redis.client;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * Define how Redis transactions are handled in a clustered Redis client.
+ * <p>
+ * This is only meaningful in case of a {@linkplain RedisClientType#CLUSTER cluster} Redis client.
+ */
+@VertxGen
+public enum RedisClusterTransactions {
+  /**
+   * Redis transactions are not supported in the cluster. Transaction
+   * commands lead to an error.
+   */
+  DISABLED,
+
+  /**
+   * Redis transactions are supported in the cluster, but only when they
+   * target a single node. The {@code MULTI} command is queued and is only
+   * issued when the next command is executed. This next command binds
+   * the connection to the corresponding node of the Redis cluster (so it should
+   * have keys, otherwise the target node is random). All subsequent commands
+   * are targeted to that node. If some of the subsequent commands have a key
+   * that belongs to another node, the command fails on the server side.
+   * <p>
+   * If {@code WATCH} is used before {@code MULTI}, its key(s) determine to which
+   * node the connection is bound and the subsequent {@code MULTI} is not queued.
+   * If {@code WATCH} keys belong to multiple nodes, the command fails on the client side.
+   */
+  SINGLE_NODE,
+}

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -51,6 +51,7 @@ public class RedisOptions {
   private String masterName;
   private RedisRole role;
   private RedisReplicas useReplicas;
+  private RedisClusterTransactions clusterTransactions;
   private volatile String password;
   private boolean protocolNegotiation;
   private ProtocolVersion preferredProtocolVersion;
@@ -74,6 +75,7 @@ public class RedisOptions {
     masterName = "mymaster";
     role = RedisRole.MASTER;
     useReplicas = RedisReplicas.NEVER;
+    clusterTransactions = RedisClusterTransactions.DISABLED;
     protocolNegotiation = true;
     hashSlotCacheTTL = 1000;
   }
@@ -95,6 +97,7 @@ public class RedisOptions {
     this.masterName = other.masterName;
     this.role = other.role;
     this.useReplicas = other.useReplicas;
+    this.clusterTransactions = other.clusterTransactions;
     this.password = other.password;
     this.protocolNegotiation = other.protocolNegotiation;
     this.preferredProtocolVersion = other.preferredProtocolVersion;
@@ -405,6 +408,25 @@ public class RedisOptions {
     return this;
   }
 
+  /**
+   * Get how Redis transactions are handled in cluster mode.
+   *
+   * @return how transactions are handled
+   */
+  public RedisClusterTransactions getClusterTransactions() {
+    return clusterTransactions;
+  }
+
+  /**
+   * Set how Redis transactions are handled in cluster mode.
+   *
+   * @param clusterTransactions transaction handling mode
+   * @return fluent self
+   */
+  public RedisOptions setClusterTransactions(RedisClusterTransactions clusterTransactions) {
+    this.clusterTransactions = clusterTransactions;
+    return this;
+  }
 
   /**
    * Tune how much nested arrays are allowed on a redis response. This affects the parser performance.

--- a/src/main/java/io/vertx/redis/client/impl/BaseRedisClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/BaseRedisClient.java
@@ -37,6 +37,8 @@ public abstract class BaseRedisClient implements Redis {
     if (cmd.isPubSub()) {
       // mixing pubSub cannot be used on a one-shot operation
       return Future.failedFuture("PubSub command in connection-less mode not allowed");
+    } else if (cmd.isTransactional()) {
+      return vertx.getOrCreateContext().failedFuture("Transactional command in connection-less mode not allowed");
     }
 
     return connect()
@@ -60,6 +62,9 @@ public abstract class BaseRedisClient implements Redis {
           // mixing pubSub cannot be used on a one-shot operation
           return Future.failedFuture("PubSub command in connection-less batch not allowed");
         }
+        // someone might expect that for symmetry with `send()`, we'll also check the commands here
+        // and fail if any of them is transactional, but that would be wrong -- a batch is always
+        // executed on a single connection and can therefore contain the whole transaction
       }
 
       return connect()

--- a/src/main/java/io/vertx/redis/client/impl/CommandImpl.java
+++ b/src/main/java/io/vertx/redis/client/impl/CommandImpl.java
@@ -36,6 +36,7 @@ public class CommandImpl implements Command {
   private final boolean needGetKeys;
   private final Boolean readOnly;
   private final boolean pubsub;
+  private final boolean transactional;
 
   public CommandImpl(String command, int arity, Boolean readOnly, boolean pubsub, boolean needGetKeys, KeyLocator... keyLocators) {
     this.command = command;
@@ -45,6 +46,11 @@ public class CommandImpl implements Command {
     this.keyLocators = keyLocators;
     this.readOnly = readOnly;
     this.pubsub = pubsub;
+    this.transactional = "multi".equals(command)
+      || "exec".equals(command)
+      || "discard".equals(command)
+      || "watch".equals(command)
+      || "unwatch".equals(command);
   }
 
   public byte[] getBytes() {
@@ -87,6 +93,10 @@ public class CommandImpl implements Command {
 
   public boolean isPubSub() {
     return pubsub;
+  }
+
+  public boolean isTransactional() {
+    return transactional;
   }
 
   public boolean needsGetKeys() {

--- a/src/test/java/io/vertx/redis/client/test/Pair.java
+++ b/src/test/java/io/vertx/redis/client/test/Pair.java
@@ -1,0 +1,11 @@
+package io.vertx.redis.client.test;
+
+final class Pair<A, B> {
+  final A a;
+  final B b;
+
+  Pair(A a, B b) {
+    this.a = a;
+    this.b = b;
+  }
+}

--- a/src/test/java/io/vertx/redis/client/test/RedisClusterTransactionsTest.java
+++ b/src/test/java/io/vertx/redis/client/test/RedisClusterTransactionsTest.java
@@ -1,0 +1,231 @@
+package io.vertx.redis.client.test;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisClientType;
+import io.vertx.redis.client.RedisClusterTransactions;
+import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.RedisReplicas;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.containers.RedisCluster;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class RedisClusterTransactionsTest {
+  @ClassRule
+  public static final RedisCluster redis = new RedisCluster();
+
+  @Rule
+  public final RunTestOnContext rule = new RunTestOnContext();
+
+  private final RedisOptions options = new RedisOptions()
+    .addConnectionString(redis.getRedisNode0Uri())
+    .addConnectionString(redis.getRedisNode1Uri())
+    .addConnectionString(redis.getRedisNode2Uri())
+    .addConnectionString(redis.getRedisNode3Uri())
+    .addConnectionString(redis.getRedisNode4Uri())
+    .addConnectionString(redis.getRedisNode5Uri())
+    .setType(RedisClientType.CLUSTER)
+    .setUseReplicas(RedisReplicas.SHARE)
+    .setClusterTransactions(RedisClusterTransactions.SINGLE_NODE);
+
+  private Redis client;
+
+  @Before
+  public void createClient() {
+    client = Redis.createClient(rule.vertx(), options);
+  }
+
+  @After
+  public void cleanRedis() {
+    client.close();
+  }
+
+  @Test
+  public void simpleTransaction_success(TestContext test) {
+    String key1 = "x";
+    String key2 = "exs";
+    String key3 = "fubar"; // [hopefully] targets different node than key1 and key2
+
+    Async async = test.async();
+    client.connect().onComplete(test.asyncAssertSuccess(conn -> {
+      conn.send(Request.cmd(Command.SET).arg(key1).arg(1))
+        .compose(result -> {
+          return conn.send(Request.cmd(Command.SET).arg(key2).arg(5));
+        }).compose(result -> {
+          return conn.send(Request.cmd(Command.MULTI));
+        }).compose(result -> {
+          return conn.send(Request.cmd(Command.INCR).arg(key1));
+        }).compose(result -> {
+          test.assertEquals("QUEUED", result.toString());
+          return conn.send(Request.cmd(Command.INCR).arg(key2));
+        }).compose(result -> {
+          test.assertEquals("QUEUED", result.toString());
+          return conn.send(Request.cmd(Command.EXEC));
+        }).compose(result -> {
+          test.assertNotNull(result);
+          test.assertTrue(result.isArray());
+          test.assertEquals(2, result.get(0).toInteger());
+          test.assertEquals(6, result.get(1).toInteger());
+          return conn.send(Request.cmd(Command.DEL).arg(key1));
+        }).compose(result -> {
+          // transaction has ended, we can target a different node now
+          return conn.send(Request.cmd(Command.SET).arg(key3).arg(true));
+        }).compose(result -> {
+          return conn.send(Request.cmd(Command.DEL).arg(key2));
+        }).compose(result -> {
+          return conn.send(Request.cmd(Command.DEL).arg(key3));
+        }).onComplete(test.asyncAssertSuccess(result -> {
+          async.complete();
+        }));
+    }));
+  }
+
+  @Test
+  public void simpleTransaction_failure(TestContext test) {
+    // failure because these keys [hopefully] target different nodes
+    String key1 = "foo";
+    String key2 = "bar";
+
+    Async async = test.async();
+    client.connect().onComplete(test.asyncAssertSuccess(conn -> {
+      conn.send(Request.cmd(Command.SET).arg(key1).arg(1))
+        .compose(result -> {
+          return conn.send(Request.cmd(Command.SET).arg(key2).arg(5));
+        }).compose(result -> {
+          return conn.send(Request.cmd(Command.MULTI));
+        }).compose(result -> {
+          return conn.send(Request.cmd(Command.INCR).arg(key1));
+        }).compose(result -> {
+          test.assertEquals("QUEUED", result.toString());
+          return conn.send(Request.cmd(Command.INCR).arg(key2));
+        }).recover(err -> {
+          test.assertTrue(err.getMessage().contains("Redirect inside a transaction"));
+          return conn.send(Request.cmd(Command.INCR).arg(key1));
+        }).compose(result -> {
+          test.assertEquals("QUEUED", result.toString());
+          return conn.send(Request.cmd(Command.EXEC));
+        }).recover(err -> {
+          test.assertTrue(err.getMessage().contains("Transaction discarded"));
+          return conn.send(Request.cmd(Command.GET).arg(key1));
+        }).compose(result -> {
+          test.assertNotNull(result);
+          test.assertEquals(1, result.toInteger());
+          // transaction has ended, we can target a different node now
+          return conn.send(Request.cmd(Command.GET).arg(key2));
+        }).onComplete(test.asyncAssertSuccess(result -> {
+          test.assertNotNull(result);
+          test.assertEquals(5, result.toInteger());
+          async.complete();
+        }));
+    }));
+  }
+
+  @Test
+  public void optimisticLocking_success(TestContext test) {
+    String key = "mykey";
+
+    Async async = test.async();
+    client.connect().onComplete(test.asyncAssertSuccess(conn -> {
+      conn.send(Request.cmd(Command.SET).arg(key).arg(7))
+        .compose(result -> {
+          return conn.send(Request.cmd(Command.WATCH).arg(key));
+        }).compose(result -> {
+          return conn.send(Request.cmd(Command.GET).arg(key));
+        }).compose(result -> {
+          int newValue = result.toInteger() + 1;
+          return conn.send(Request.cmd(Command.MULTI))
+            .map(res -> new Pair<>(newValue, res));
+        }).compose(result -> {
+          return conn.send(Request.cmd(Command.SET).arg(key).arg(result.a));
+        }).compose(result -> {
+          test.assertEquals("QUEUED", result.toString());
+          return conn.send(Request.cmd(Command.EXEC));
+        }).compose(result -> {
+          test.assertNotNull(result);
+          test.assertTrue(result.isArray());
+          test.assertEquals("OK", result.get(0).toString());
+          return conn.send(Request.cmd(Command.GET).arg(key));
+        }).onComplete(test.asyncAssertSuccess(result -> {
+          test.assertEquals(8, result.toInteger());
+          async.complete();
+        }));
+    }));
+  }
+
+  @Test
+  public void optimisticLocking_casFailure(TestContext test) {
+    // CAS failure on this key, because 2 connections mutate it
+    String key = "mykey";
+
+    Async async = test.async();
+    client.connect().onComplete(test.asyncAssertSuccess(conn -> {
+      client.connect().onComplete(test.asyncAssertSuccess(conn2 -> {
+        conn.send(Request.cmd(Command.SET).arg(key).arg(7))
+          .compose(result -> {
+            return conn.send(Request.cmd(Command.WATCH).arg(key));
+          }).compose(result -> {
+            return conn.send(Request.cmd(Command.GET).arg(key));
+          }).compose(result -> {
+            int newValue = result.toInteger() + 1;
+            return conn.send(Request.cmd(Command.MULTI))
+              .map(res -> new Pair<>(newValue, res));
+          }).compose(result -> {
+            return conn.send(Request.cmd(Command.SET).arg(key).arg(result.a));
+          }).compose(result -> {
+            test.assertEquals("QUEUED", result.toString());
+            return conn2.send(Request.cmd(Command.INCR).arg(key));
+          }).compose(result -> {
+            test.assertEquals(8, result.toInteger());
+            return conn.send(Request.cmd(Command.EXEC));
+          }).onComplete(test.asyncAssertSuccess(result -> {
+            test.assertNull(result);
+            async.complete();
+          }));
+      }));
+    }));
+  }
+
+  @Test
+  public void optimisticLocking_txFailure(TestContext test) {
+    // failure because these keys [hopefully] target different nodes
+    String key1 = "mykey";
+    String key2 = "anotherKey";
+
+    Async async = test.async();
+    client.connect().onComplete(test.asyncAssertSuccess(conn -> {
+      conn.send(Request.cmd(Command.SET).arg(key1).arg(7))
+        .compose(result -> {
+          return conn.send(Request.cmd(Command.SET).arg(key2).arg(3));
+        }).compose(result -> {
+          return conn.send(Request.cmd(Command.WATCH).arg(key1));
+        }).compose(result -> {
+          return conn.send(Request.cmd(Command.GET).arg(key1));
+        }).compose(result -> {
+          int newValue = result.toInteger() + 1;
+          return conn.send(Request.cmd(Command.MULTI))
+            .map(res -> new Pair<>(newValue, res));
+        }).compose(result -> {
+          return conn.send(Request.cmd(Command.SET).arg(key1).arg(result.a));
+        }).compose(result -> {
+          test.assertEquals("QUEUED", result.toString());
+          return conn.send(Request.cmd(Command.INCR).arg(key2));
+        }).recover(err -> {
+          test.assertTrue(err.getMessage().contains("Redirect inside a transaction"));
+          return conn.send(Request.cmd(Command.EXEC));
+        }).onComplete(test.asyncAssertFailure(err -> {
+          test.assertTrue(err.getMessage().contains("Transaction discarded"));
+          async.complete();
+        }));
+    }));
+  }
+}


### PR DESCRIPTION
Backport of #479 to 4.x as agreed in https://github.com/quarkusio/quarkus/issues/32361.