### PR TITLE
[4.x] use the Bitnami legacy image for now

### DIFF
--- a/src/test/java/io/vertx/redis/containers/RedisStandalone.java
+++ b/src/test/java/io/vertx/redis/containers/RedisStandalone.java
@@ -66,7 +66,7 @@ public class RedisStandalone implements TestRule {
   }
 
   private RedisStandalone(Builder builder) {
-    String image = "docker.io/bitnami/redis:" + (builder.version != null ? builder.version : "7.2");
+    String image = "docker.io/bitnamilegacy/redis:" + (builder.version != null ? builder.version : "7.2");
 
     Map<String, String> env = new HashMap<>();
     if (builder.password != null) {


### PR DESCRIPTION
Backport of #510 to `4.x`