### PR TITLE
Temporarily use bitnamilegacy repository

### DIFF
--- a/src/test/java/io/vertx/tests/redis/containers/RedisStandalone.java
+++ b/src/test/java/io/vertx/tests/redis/containers/RedisStandalone.java
@@ -66,7 +66,7 @@ public class RedisStandalone implements TestRule {
   }
 
   private RedisStandalone(Builder builder) {
-    String image = "docker.io/bitnami/redis:" + (builder.version != null ? builder.version : "7.2");
+    String image = "docker.io/bitnamilegacy/redis:" + (builder.version != null ? builder.version : "7.2");
 
     Map<String, String> env = new HashMap<>();
     if (builder.password != null) {


### PR DESCRIPTION
This gives us some time to plan a migration. Not sure how much.