### PR TITLE
avoid NPE in MultiType.toString()

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/types/MultiType.java
+++ b/src/main/java/io/vertx/redis/client/impl/types/MultiType.java
@@ -238,7 +238,7 @@ public final class MultiType implements Multi {
 
         sb.append(kv.getKey());
         sb.append(": ");
-        sb.append(kv.getValue().toString());
+        sb.append(kv.getValue());
         more = true;
       }
       sb.append('}');


### PR DESCRIPTION
Backport of #516 to `5.0`