### PR TITLE
[4.x] avoid NPE in MultiType.toString()

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/types/MultiType.java
+++ b/src/main/java/io/vertx/redis/client/impl/types/MultiType.java
@@ -234,7 +234,7 @@ public final class MultiType implements Multi {
 
         sb.append(kv.getKey());
         sb.append(": ");
-        sb.append(kv.getValue().toString());
+        sb.append(kv.getValue());
         more = true;
       }
       sb.append('}');

--- a/src/test/java/io/vertx/redis/client/impl/ConnectionRecyclingTest.java
+++ b/src/test/java/io/vertx/redis/client/impl/ConnectionRecyclingTest.java
@@ -83,7 +83,7 @@ public class ConnectionRecyclingTest {
     vertx.setTimer(2500, ignored -> {
       assertConnectionPool(test, 1);
 
-      vertx.setTimer(1000, ignored2 -> {
+      vertx.setTimer(1500, ignored2 -> {
         assertConnectionPool(test, 0);
         async.complete();
       });


### PR DESCRIPTION
Backport of #516 to `4.x`