### PR TITLE
cache sentinel topology

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -248,7 +248,10 @@ To work with the sentinel mode (also known as high availability), the connection
 {@link examples.RedisExamples#example5}
 ----
 
-The connection strings here point to the _sentinel_ nodes, which are used to discover the actual master and replica nodes.
+The connection strings here point to the _sentinel_ nodes, which are used to discover the actual topology (full set of sentinel nodes, master node, replica nodes).
+The sentinel Redis client holds a cache of the discovered topology.
+When the cache is empty, the first attempt to acquire a connection will execute 3 commands against one of the configured sentinel nodes (`SENTINEL SENTINELS <master name>`, `SENTINEL GET-MASTER-ADDR-BY-NAME <master name>`, `SENTINEL REPLICAS <master name>`).
+The cache has a configurable TTL (time to live), which defaults to 1 second.
 
 What is important to notice is that in this mode, when the selected role is `MASTER` (which is the default) and when automatic failover is enabled (`RedisOptions.setAutoFailover(true)`), there is an extra connection to one of the sentinels that listens for failover events.
 When the sentinel notifies that a new master was elected, all clients will close their connection to the old master and transparently reconnect to the new master.
@@ -273,7 +276,7 @@ It is recommended to read the Redis manual in order to understand how clustering
 The client operating in this mode will do a best effort to identify which slot is used by the executed command in order to execute it on the right node.
 There could be cases where this isn't possible to identify and in that case, as a best effort, the command will be run on a random node.
 
-To know which Redis node holds which slots, the clustered Redis client holds a cache of the hash slot assignment.
+To know which Redis node holds which slots, the clustered Redis client holds a cache of cluster topology (hash slot assignment).
 When the cache is empty, the first attempt to acquire a connection will execute `CLUSTER SLOTS`.
 The cache has a configurable TTL (time to live), which defaults to 1 second.
 The cache is also cleared whenever any command executed by the client receives the `MOVED` redirection.
@@ -380,7 +383,7 @@ It is possible to enable single-node transactions in Redis cluster by:
 ----
 
 In single-node transactions, the first command (if it is `WATCH`) or the second command (if the first one is `MULTI`) determines on which node the transaction should execute.
-The connection is bound to the selected node and all subsequent commands are sent to that node, regardless of the hash slot assignment.
+The connection is bound to the selected node and all subsequent commands are sent to that node, regardless of the cluster topology (hash slot assignment).
 When the final command of a transaction (`EXEC` or `DISCARD`) is executed, the connection is reset to default mode and is no longer bound to a single node.
 
 If the transaction starts with `WATCH`, that command has keys and so determines the target node.

--- a/src/main/generated/io/vertx/redis/client/RedisClusterConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisClusterConnectOptionsConverter.java
@@ -17,9 +17,9 @@ public class RedisClusterConnectOptionsConverter {
             obj.setUseReplicas(io.vertx.redis.client.RedisReplicas.valueOf((String)member.getValue()));
           }
           break;
-        case "hashSlotCacheTTL":
+        case "topologyCacheTTL":
           if (member.getValue() instanceof Number) {
-            obj.setHashSlotCacheTTL(((Number)member.getValue()).longValue());
+            obj.setTopologyCacheTTL(((Number)member.getValue()).longValue());
           }
           break;
         case "clusterTransactions":
@@ -39,7 +39,7 @@ public class RedisClusterConnectOptionsConverter {
     if (obj.getUseReplicas() != null) {
       json.put("useReplicas", obj.getUseReplicas().name());
     }
-    json.put("hashSlotCacheTTL", obj.getHashSlotCacheTTL());
+    json.put("topologyCacheTTL", obj.getTopologyCacheTTL());
     if (obj.getClusterTransactions() != null) {
       json.put("clusterTransactions", obj.getClusterTransactions().name());
     }

--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -122,9 +122,9 @@ public class RedisOptionsConverter {
             obj.setMetricsName((String)member.getValue());
           }
           break;
-        case "hashSlotCacheTTL":
+        case "topologyCacheTTL":
           if (member.getValue() instanceof Number) {
-            obj.setHashSlotCacheTTL(((Number)member.getValue()).longValue());
+            obj.setTopologyCacheTTL(((Number)member.getValue()).longValue());
           }
           break;
         case "autoFailover":
@@ -192,7 +192,7 @@ public class RedisOptionsConverter {
     if (obj.getMetricsName() != null) {
       json.put("metricsName", obj.getMetricsName());
     }
-    json.put("hashSlotCacheTTL", obj.getHashSlotCacheTTL());
+    json.put("topologyCacheTTL", obj.getTopologyCacheTTL());
     json.put("autoFailover", obj.isAutoFailover());
   }
 }

--- a/src/main/generated/io/vertx/redis/client/RedisSentinelConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisSentinelConnectOptionsConverter.java
@@ -27,6 +27,11 @@ public class RedisSentinelConnectOptionsConverter {
             obj.setAutoFailover((Boolean)member.getValue());
           }
           break;
+        case "topologyCacheTTL":
+          if (member.getValue() instanceof Number) {
+            obj.setTopologyCacheTTL(((Number)member.getValue()).longValue());
+          }
+          break;
       }
     }
   }
@@ -43,5 +48,6 @@ public class RedisSentinelConnectOptionsConverter {
       json.put("masterName", obj.getMasterName());
     }
     json.put("autoFailover", obj.isAutoFailover());
+    json.put("topologyCacheTTL", obj.getTopologyCacheTTL());
   }
 }

--- a/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
@@ -16,6 +16,7 @@
 package io.vertx.redis.client;
 
 import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
 
@@ -27,27 +28,27 @@ public class RedisClusterConnectOptions extends RedisConnectOptions {
 
   private RedisReplicas useReplicas;
   private RedisClusterTransactions clusterTransactions;
-  private long hashSlotCacheTTL;
+  private long topologyCacheTTL;
 
   public RedisClusterConnectOptions() {
     super();
     useReplicas = RedisReplicas.NEVER;
     clusterTransactions = RedisClusterTransactions.DISABLED;
-    hashSlotCacheTTL = 1000;
+    topologyCacheTTL = 1000;
   }
 
   public RedisClusterConnectOptions(RedisOptions options) {
     super(options);
     setUseReplicas(options.getUseReplicas());
     setClusterTransactions(options.getClusterTransactions());
-    setHashSlotCacheTTL(options.getHashSlotCacheTTL());
+    setTopologyCacheTTL(options.getTopologyCacheTTL());
   }
 
   public RedisClusterConnectOptions(RedisClusterConnectOptions other) {
     super(other);
     setUseReplicas(other.getUseReplicas());
     setClusterTransactions(other.getClusterTransactions());
-    setHashSlotCacheTTL(other.getHashSlotCacheTTL());
+    setTopologyCacheTTL(other.getTopologyCacheTTL());
   }
 
   public RedisClusterConnectOptions(JsonObject json) {
@@ -75,24 +76,36 @@ public class RedisClusterConnectOptions extends RedisConnectOptions {
     return this;
   }
 
+  @Deprecated
+  @GenIgnore
+  public long getHashSlotCacheTTL() {
+    return getTopologyCacheTTL();
+  }
+
   /**
-   * Returns the TTL of the hash slot cache. The TTL is expressed in milliseconds.
+   * Returns the TTL of the topology cache. The TTL is expressed in milliseconds.
    * Defaults to 1000 millis (1 second).
    *
-   * @return the TTL of the hash slot cache
+   * @return the TTL of the topology cache
    */
-  public long getHashSlotCacheTTL() {
-    return hashSlotCacheTTL;
+  public long getTopologyCacheTTL() {
+    return topologyCacheTTL;
+  }
+
+  @Deprecated
+  @GenIgnore
+  public RedisClusterConnectOptions setHashSlotCacheTTL(long hashSlotCacheTTL) {
+    return setTopologyCacheTTL(hashSlotCacheTTL);
   }
 
   /**
    * Sets the TTL of the hash slot cache. The TTL is expressed in milliseconds.
    * Defaults to 1000 millis (1 second).
    *
-   * @param hashSlotCacheTTL the TTL of the hash slot cache, in millis
+   * @param topologyCacheTTL the TTL of the hash slot cache, in millis
    */
-  public RedisClusterConnectOptions setHashSlotCacheTTL(long hashSlotCacheTTL) {
-    this.hashSlotCacheTTL = hashSlotCacheTTL;
+  public RedisClusterConnectOptions setTopologyCacheTTL(long topologyCacheTTL) {
+    this.topologyCacheTTL = topologyCacheTTL;
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -56,7 +56,7 @@ public class RedisOptions {
   private volatile String password;
   private boolean protocolNegotiation;
   private ProtocolVersion preferredProtocolVersion;
-  private long hashSlotCacheTTL;
+  private long topologyCacheTTL;
   private TracingPolicy tracingPolicy;
   private boolean autoFailover;
 
@@ -78,7 +78,7 @@ public class RedisOptions {
     useReplicas = RedisReplicas.NEVER;
     clusterTransactions = RedisClusterTransactions.DISABLED;
     protocolNegotiation = true;
-    hashSlotCacheTTL = 1000;
+    topologyCacheTTL = 1000;
   }
 
   /**
@@ -103,7 +103,7 @@ public class RedisOptions {
     this.password = other.password;
     this.protocolNegotiation = other.protocolNegotiation;
     this.preferredProtocolVersion = other.preferredProtocolVersion;
-    this.hashSlotCacheTTL = other.hashSlotCacheTTL;
+    this.topologyCacheTTL = other.topologyCacheTTL;
     this.tracingPolicy = other.tracingPolicy;
     this.autoFailover = other.autoFailover;
   }
@@ -706,33 +706,45 @@ public class RedisOptions {
     return this;
   }
 
-  /**
-   * Returns the TTL of the hash slot cache. The TTL is expressed in milliseconds.
-   * Defaults to 1000 millis (1 second).
-   * <p>
-   * This is only meaningful in case of a {@linkplain RedisClientType#CLUSTER cluster} Redis client
-   * and is ignored otherwise.
-   * </p>
-   *
-   * @return the TTL of the hash slot cache
-   */
+  @Deprecated
+  @GenIgnore
   public long getHashSlotCacheTTL() {
-    return hashSlotCacheTTL;
+    return getTopologyCacheTTL();
   }
 
   /**
-   * Sets the TTL of the hash slot cache. The TTL is expressed in milliseconds.
+   * Returns the TTL of the topology cache. The TTL is expressed in milliseconds.
    * Defaults to 1000 millis (1 second).
    * <p>
-   * This is only meaningful in case of a {@linkplain RedisClientType#CLUSTER cluster} Redis client
-   * and is ignored otherwise.
+   * This is only meaningful in case of a {@linkplain RedisClientType#CLUSTER cluster}
+   * or {@linkplain RedisClientType#SENTINEL sentinel} Redis client and is ignored otherwise.
    * </p>
    *
-   * @param hashSlotCacheTTL the TTL of the hash slot cache, in millis
+   * @return the TTL of the topology cache
+   */
+  public long getTopologyCacheTTL() {
+    return topologyCacheTTL;
+  }
+
+  @Deprecated
+  @GenIgnore
+  public RedisOptions setHashSlotCacheTTL(long hashSlotCacheTTL) {
+    return setTopologyCacheTTL(hashSlotCacheTTL);
+  }
+
+  /**
+   * Sets the TTL of the topology cache. The TTL is expressed in milliseconds.
+   * Defaults to 1000 millis (1 second).
+   * <p>
+   * This is only meaningful in case of a {@linkplain RedisClientType#CLUSTER cluster}
+   * or {@linkplain RedisClientType#SENTINEL sentinel} Redis client and is ignored otherwise.
+   * </p>
+   *
+   * @param topologyCacheTTL the TTL of the topology cache, in millis
    * @return fluent self
    */
-  public RedisOptions setHashSlotCacheTTL(long hashSlotCacheTTL) {
-    this.hashSlotCacheTTL = hashSlotCacheTTL;
+  public RedisOptions setTopologyCacheTTL(long topologyCacheTTL) {
+    this.topologyCacheTTL = topologyCacheTTL;
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
@@ -30,11 +30,13 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
   private RedisRole role;
   private String masterName;
   private boolean autoFailover;
+  private long topologyCacheTTL;
 
   public RedisSentinelConnectOptions() {
     super();
     role = RedisRole.MASTER;
     masterName = "mymaster";
+    topologyCacheTTL = 1000;
   }
 
   public RedisSentinelConnectOptions(RedisOptions options) {
@@ -42,6 +44,7 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
     setRole(options.getRole());
     setMasterName(options.getMasterName());
     setAutoFailover(options.isAutoFailover());
+    setTopologyCacheTTL(options.getTopologyCacheTTL());
   }
 
   public RedisSentinelConnectOptions(RedisSentinelConnectOptions other) {
@@ -49,6 +52,7 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
     setRole(other.getRole());
     setMasterName(other.getMasterName());
     setAutoFailover(other.isAutoFailover());
+    setTopologyCacheTTL(other.getTopologyCacheTTL());
   }
 
   public RedisSentinelConnectOptions(JsonObject json) {
@@ -125,7 +129,7 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
   }
 
   /**
-   * Returns whether automatic failover is enabled. This only makes sense for sentinel clients
+   * Sets whether automatic failover is enabled. This only makes sense for sentinel clients
    * with role of {@link RedisRole#MASTER} and is ignored otherwise.
    * <p>
    * If enabled, the sentinel client will additionally create a connection to one sentinel node
@@ -151,6 +155,27 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
    */
   public RedisSentinelConnectOptions setAutoFailover(boolean autoFailover) {
     this.autoFailover = autoFailover;
+    return this;
+  }
+
+  /**
+   * Returns the TTL of the topology cache. The TTL is expressed in milliseconds.
+   * Defaults to 1000 millis (1 second).
+   *
+   * @return the TTL of the topology cache
+   */
+  public long getTopologyCacheTTL() {
+    return topologyCacheTTL;
+  }
+
+  /**
+   * Sets the TTL of the topology cache. The TTL is expressed in milliseconds.
+   * Defaults to 1000 millis (1 second).
+   *
+   * @param topologyCacheTTL the TTL of the hash topology cache, in millis
+   */
+  public RedisSentinelConnectOptions setTopologyCacheTTL(long topologyCacheTTL) {
+    this.topologyCacheTTL = topologyCacheTTL;
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisSentinelConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisSentinelConnection.java
@@ -10,6 +10,11 @@ import io.vertx.redis.client.Response;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+// in the Sentinel mode, a plain connection is used:
+// - when connecting to a sentinel
+// - when connecting to a replica
+// - when connecting to a master node and automatic failover is disabled
+// this class is only used when connecting to a master node and automatic failover is enabled
 public class RedisSentinelConnection implements RedisConnection {
 
   private final AtomicReference<PooledRedisConnection> connection;

--- a/src/main/java/io/vertx/redis/client/impl/SentinelFailover.java
+++ b/src/main/java/io/vertx/redis/client/impl/SentinelFailover.java
@@ -1,6 +1,8 @@
 package io.vertx.redis.client.impl;
 
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.redis.client.Command;
@@ -18,29 +20,30 @@ class SentinelFailover {
 
   private static final int RETRIES = 3;
 
+  private final Vertx vertx;
   private final String masterSetName;
   private final Function<RedisRole, Future<PooledRedisConnection>> connectionFactory;
 
   private final AtomicReference<PooledRedisConnection> sentinelConnection = new AtomicReference<>();
   private final Set<RedisSentinelConnection> masterConnections = ConcurrentHashMap.newKeySet();
 
-  SentinelFailover(String masterSetName, Function<RedisRole, Future<PooledRedisConnection>> connectionFactory) {
+  private volatile boolean closed;
+
+  SentinelFailover(Vertx vertx, String masterSetName, Function<RedisRole, Future<PooledRedisConnection>> connectionFactory) {
+    this.vertx = vertx;
     this.masterSetName = masterSetName;
     this.connectionFactory = connectionFactory;
   }
 
   void start() {
-    start(RETRIES);
-  }
+    if (closed) {
+      return;
+    }
 
-  private void start(int retries) {
     connectionFactory.apply(RedisRole.SENTINEL)
       .onFailure(t -> {
-        if (retries == 0) {
-          LOG.error("Failed to obtain a connection to Redis sentinel, automatic failover will not work: " + t);
-        } else {
-          start(retries - 1);
-        }
+        LOG.error("Failed to obtain a connection to Redis sentinel, will retry in 1 second: " + t);
+        vertx.setTimer(1000, ignored -> start());
       })
       .onSuccess(sentinel -> {
         PooledRedisConnection old = sentinelConnection.getAndSet(sentinel);
@@ -57,17 +60,15 @@ class SentinelFailover {
           }
         });
         sentinel.exceptionHandler(t -> {
+          LOG.error("Connection to Redis sentinel failed, will start over in 1 second: " + t);
           sentinel.close();
-          start(RETRIES);
+          vertx.setTimer(1000, ignored -> start());
         });
         sentinel.send(Request.cmd(Command.SUBSCRIBE).arg("+switch-master"))
           .onFailure(t -> {
+            LOG.error("Failed subscribing to +switch-master, will start over in 1 second: " + t);
             sentinel.close();
-            if (retries == 0) {
-              LOG.error("Failed to subscribe +switch-master on Redis sentinel connection, reconnection to new master on failover will not work: " + t);
-            } else {
-              start(retries - 1);
-            }
+            vertx.setTimer(1000, ignored -> start());
           });
       });
   }
@@ -93,6 +94,7 @@ class SentinelFailover {
   }
 
   void close() {
+    closed = true;
     PooledRedisConnection sentinelConnection = this.sentinelConnection.get();
     if (sentinelConnection != null) {
       sentinelConnection.close()

--- a/src/main/java/io/vertx/redis/client/impl/SentinelTopology.java
+++ b/src/main/java/io/vertx/redis/client/impl/SentinelTopology.java
@@ -1,0 +1,30 @@
+package io.vertx.redis.client.impl;
+
+import java.util.Random;
+
+class SentinelTopology {
+  // we need some randomness, it doesn't need to be cryptographically secure
+  private static final Random RANDOM = new Random();
+
+  private final RedisURI[] sentinels;
+  private final RedisURI master;
+  private final RedisURI[] replicas;
+
+  public SentinelTopology(RedisURI[] sentinels, RedisURI master, RedisURI[] replicas) {
+    this.sentinels = sentinels;
+    this.master = master;
+    this.replicas = replicas;
+  }
+
+  public RedisURI getRandomSentinel() {
+    return sentinels[RANDOM.nextInt(sentinels.length)];
+  }
+
+  public RedisURI getMaster() {
+    return master;
+  }
+
+  public RedisURI getRandomReplica() {
+    return replicas[RANDOM.nextInt(replicas.length)];
+  }
+}

--- a/src/main/java/io/vertx/redis/client/impl/SharedSentinelTopology.java
+++ b/src/main/java/io/vertx/redis/client/impl/SharedSentinelTopology.java
@@ -1,0 +1,182 @@
+package io.vertx.redis.client.impl;
+
+import io.vertx.core.Completable;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.RedisConnection;
+import io.vertx.redis.client.RedisSentinelConnectOptions;
+import io.vertx.redis.client.Request;
+import io.vertx.redis.client.Response;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Exactly one instance of this class exists for each instance of {@link RedisSentinelClient}.
+ */
+class SharedSentinelTopology {
+  private static final Logger LOG = LoggerFactory.getLogger(SharedSentinelTopology.class);
+
+  private final Vertx vertx;
+  private final Supplier<Future<RedisSentinelConnectOptions>> connectOptions;
+  private final RedisConnectionManager connectionManager;
+
+  private final AtomicReference<Future<SentinelTopology>> topology = new AtomicReference<>();
+
+  SharedSentinelTopology(Vertx vertx, Supplier<Future<RedisSentinelConnectOptions>> connectOptions, RedisConnectionManager connectionManager) {
+    this.vertx = vertx;
+    this.connectOptions = connectOptions;
+    this.connectionManager = connectionManager;
+  }
+
+  Future<SentinelTopology> get() {
+    while (true) {
+      Future<SentinelTopology> topology = this.topology.get();
+      if (topology != null) {
+        return topology;
+      }
+
+      Promise<SentinelTopology> promise = Promise.promise();
+      Future<SentinelTopology> future = promise.future();
+      if (this.topology.compareAndSet(null, future)) {
+        LOG.debug("Obtaining sentinel topology");
+        // attempt to load the topology from the first good endpoint
+        connectOptions.get()
+          .onSuccess(opts -> getTopology(opts, 0, ConcurrentHashMap.newKeySet(), promise))
+          .onFailure(promise::fail);
+        return future;
+      }
+    }
+  }
+
+  private void getTopology(RedisSentinelConnectOptions connectOptions, int index, Set<Throwable> failures, Completable<SentinelTopology> onGotTopology) {
+    List<String> endpoints = connectOptions.getEndpoints();
+    if (index >= endpoints.size()) {
+      // stop condition
+      StringBuilder message = new StringBuilder("Cannot connect to any of the provided endpoints");
+      for (Throwable failure : failures) {
+        message.append("\n- ").append(failure);
+      }
+      onGotTopology.fail(new RedisConnectException(message.toString()));
+      scheduleInvalidation(connectOptions);
+      return;
+    }
+
+    RedisURI uri = new RedisURI(endpoints.get(index));
+    connectionManager.getConnection(uri.baseUri(), null)
+      .onFailure(err -> {
+        // try with the next endpoint
+        failures.add(err);
+        getTopology(connectOptions, index + 1, failures, onGotTopology);
+      })
+      .onSuccess(conn -> {
+        getTopology(conn, uri, connectOptions.getMasterName()).onComplete(result -> {
+          // the connection is not needed anymore, regardless of success or failure
+          // (on success, we just finish, on failure, we'll try another endpoint)
+          conn.close().onFailure(LOG::warn);
+
+          if (result.failed()) {
+            // one of the `SENTINEL ...` commands failed, try with next endpoint
+            failures.add(result.cause());
+            getTopology(connectOptions, index + 1, failures, onGotTopology);
+          } else {
+            SentinelTopology topology = result.result();
+            onGotTopology.succeed(topology);
+            scheduleInvalidation(connectOptions);
+          }
+        });
+      });
+  }
+
+  private Future<SentinelTopology> getTopology(RedisConnection conn, RedisURI uri, String masterName) {
+    return conn
+      .batch(List.of(
+        Request.cmd(Command.SENTINEL).arg("SENTINELS").arg(masterName),
+        Request.cmd(Command.SENTINEL).arg("GET-MASTER-ADDR-BY-NAME").arg(masterName),
+        Request.cmd(Command.SENTINEL).arg("SLAVES").arg(masterName)))
+      .compose(replies -> {
+        if (replies == null || replies.size() != 3) {
+          return Future.failedFuture("Could not obtain sentinel topology");
+        }
+
+        List<RedisURI> sentinels = new ArrayList<>();
+        // `SENTINEL SENTINELS <master set>` doesn't return the "current" sentinel we're connected to
+        sentinels.add(uri);
+        String failure = parseUris(uri, replies.get(0), sentinels, "SENTINELS " + masterName);
+        if (failure != null) {
+          return Future.failedFuture(failure);
+        }
+
+        RedisURI master;
+        Response masterResponse = replies.get(1);
+        if (masterResponse == null) {
+          return Future.failedFuture("Failed to get SENTINEL GET-MASTER-ADDR-BY-NAME " + masterName);
+        } else {
+          String ip = masterResponse.get(0).toString();
+          Integer port = masterResponse.get(1).toInteger();
+          master = new RedisURI(uri, ip.contains(":") ? "[" + ip + "]" : ip, port);
+        }
+
+        List<RedisURI> replicas = new ArrayList<>();
+        failure = parseUris(uri, replies.get(2), replicas, "REPLICAS " + masterName);
+        if (failure != null) {
+          return Future.failedFuture(failure);
+        }
+
+        return Future.succeededFuture(
+          new SentinelTopology(sentinels.toArray(RedisURI[]::new), master, replicas.toArray(RedisURI[]::new)));
+      });
+  }
+
+  // `uri` and `hostsResponse` are input
+  // `uris` is output
+  // `command` is used only to construct an error message, if necessary
+  // returns a `String` describing an error, or `null` if successful
+  private static String parseUris(RedisURI uri, Response hostsResponse, List<RedisURI> uris, String command) {
+    if (hostsResponse == null) {
+      return "Failed to get SENTINEL " + command;
+    }
+
+    for (int i = 0; i < hostsResponse.size(); i++) {
+      Response hostResponse = hostsResponse.get(i);
+      if (hostResponse.size() % 2 != 0) {
+        return "Corrupted response " + i + " from SENTINEL " + command;
+      } else {
+        String ip = null;
+        int port = 6379;
+
+        if (hostResponse.containsKey("ip")) {
+          ip = hostResponse.get("ip").toString();
+        }
+        if (hostResponse.containsKey("port")) {
+          port = hostResponse.get("port").toInteger();
+        }
+
+        if (ip == null) {
+          return "No IP found in response " + i + " from SENTINEL " + command;
+        } else {
+          String host = ip.contains(":") ? "[" + ip + "]" : ip;
+          uris.add(new RedisURI(uri, host, port));
+        }
+      }
+    }
+
+    return null;
+  }
+
+  void invalidate() {
+    topology.set(null);
+  }
+
+  private void scheduleInvalidation(RedisSentinelConnectOptions connectOptions) {
+    vertx.setTimer(connectOptions.getTopologyCacheTTL(), ignored -> invalidate());
+  }
+}

--- a/src/main/java/io/vertx/redis/client/impl/SharedSlots.java
+++ b/src/main/java/io/vertx/redis/client/impl/SharedSlots.java
@@ -119,6 +119,6 @@ class SharedSlots {
   }
 
   private void scheduleInvalidation(RedisClusterConnectOptions connectOptions) {
-    vertx.setTimer(connectOptions.getHashSlotCacheTTL(), ignored -> invalidate());
+    vertx.setTimer(connectOptions.getTopologyCacheTTL(), ignored -> invalidate());
   }
 }

--- a/src/test/java/io/vertx/tests/redis/client/RedisClusterTest.java
+++ b/src/test/java/io/vertx/tests/redis/client/RedisClusterTest.java
@@ -95,7 +95,7 @@ public class RedisClusterTest {
     .addConnectionString(redis.getRedisNode5Uri())
     .setMaxPoolSize(8)
     .setMaxPoolWaiting(16)
-    .setHashSlotCacheTTL(10_000);
+    .setTopologyCacheTTL(10_000);
 
   private Redis client;
 

--- a/src/test/java/io/vertx/tests/redis/client/RedisConnectOptionsTest.java
+++ b/src/test/java/io/vertx/tests/redis/client/RedisConnectOptionsTest.java
@@ -45,6 +45,8 @@ public class RedisConnectOptionsTest {
     RedisClusterConnectOptions options = new RedisClusterConnectOptions();
     assertTrue(options.isProtocolNegotiation()); // default value
     assertEquals(RedisReplicas.NEVER, options.getUseReplicas()); // default value
+    assertEquals(1000L, options.getTopologyCacheTTL());
+    assertEquals(1000L, options.getHashSlotCacheTTL());
   }
 
   @Test
@@ -52,11 +54,15 @@ public class RedisConnectOptionsTest {
     RedisClusterConnectOptions original = new RedisClusterConnectOptions();
     original.setPassword("password");
     original.setUseReplicas(RedisReplicas.ALWAYS);
+    original.setHashSlotCacheTTL(1234L); // overwritten by the next call
+    original.setTopologyCacheTTL(2500L);
 
     RedisClusterConnectOptions copy = new RedisClusterConnectOptions(original);
     assertTrue(copy.isProtocolNegotiation()); // default value
     assertEquals("password", copy.getPassword());
     assertEquals(RedisReplicas.ALWAYS, copy.getUseReplicas());
+    assertEquals(2500L, copy.getTopologyCacheTTL());
+    assertEquals(2500L, copy.getHashSlotCacheTTL());
   }
 
   @Test
@@ -64,11 +70,15 @@ public class RedisConnectOptionsTest {
     RedisClusterConnectOptions original = new RedisClusterConnectOptions();
     original.setPassword("password");
     original.setUseReplicas(RedisReplicas.SHARE);
+    original.setHashSlotCacheTTL(2468L); // overwritten by the next call
+    original.setTopologyCacheTTL(3333L);
 
     RedisClusterConnectOptions copy = new RedisClusterConnectOptions(original.toJson());
     assertTrue(copy.isProtocolNegotiation()); // default value
     assertEquals("password", copy.getPassword());
     assertEquals(RedisReplicas.SHARE, copy.getUseReplicas());
+    assertEquals(3333L, copy.getTopologyCacheTTL());
+    assertEquals(3333L, copy.getHashSlotCacheTTL());
   }
 
   // ---
@@ -111,6 +121,7 @@ public class RedisConnectOptionsTest {
     RedisSentinelConnectOptions options = new RedisSentinelConnectOptions();
     assertTrue(options.isProtocolNegotiation()); // default value
     assertEquals(RedisRole.MASTER, options.getRole()); // default value
+    assertEquals(1000L, options.getTopologyCacheTTL()); // default value
   }
 
   @Test
@@ -118,11 +129,13 @@ public class RedisConnectOptionsTest {
     RedisSentinelConnectOptions previousOptions = new RedisSentinelConnectOptions();
     previousOptions.setPassword("password");
     previousOptions.setRole(RedisRole.SENTINEL);
+    previousOptions.setTopologyCacheTTL(2500L);
 
     RedisSentinelConnectOptions options = new RedisSentinelConnectOptions(previousOptions);
     assertTrue(options.isProtocolNegotiation()); // default value
     assertEquals("password", options.getPassword());
     assertEquals(RedisRole.SENTINEL, options.getRole());
+    assertEquals(2500L, options.getTopologyCacheTTL());
   }
 
   @Test
@@ -130,10 +143,12 @@ public class RedisConnectOptionsTest {
     RedisSentinelConnectOptions previousOptions = new RedisSentinelConnectOptions();
     previousOptions.setPassword("password");
     previousOptions.setRole(RedisRole.REPLICA);
+    previousOptions.setTopologyCacheTTL(3333L);
 
     RedisSentinelConnectOptions options = new RedisSentinelConnectOptions(previousOptions.toJson());
     assertTrue(options.isProtocolNegotiation()); // default value
     assertEquals("password", options.getPassword());
     assertEquals(RedisRole.REPLICA, options.getRole());
+    assertEquals(3333L, options.getTopologyCacheTTL());
   }
 }

--- a/src/test/java/io/vertx/tests/redis/client/RedisOptionsTest.java
+++ b/src/test/java/io/vertx/tests/redis/client/RedisOptionsTest.java
@@ -22,6 +22,8 @@ public class RedisOptionsTest {
     assertEquals(6, options.getMaxPoolSize()); // default value
     assertEquals("redis://localhost:6379", options.getEndpoint()); // default value
     assertEquals(Collections.singletonList("redis://localhost:6379"), options.getEndpoints()); // default value
+    assertEquals(1000L, options.getTopologyCacheTTL()); // default value
+    assertEquals(1000L, options.getHashSlotCacheTTL()); // default value
   }
 
   @Test
@@ -37,7 +39,9 @@ public class RedisOptionsTest {
       .setMasterName("someOtherMaster")
       .setRole(RedisRole.SENTINEL)
       .setPassword("myPassword")
-      .setTracingPolicy(TracingPolicy.ALWAYS);
+      .setTracingPolicy(TracingPolicy.ALWAYS)
+      .setHashSlotCacheTTL(1234L) // overwritten by the next call
+      .setTopologyCacheTTL(2500L);
 
     RedisOptions copy = new RedisOptions(original);
 
@@ -48,6 +52,8 @@ public class RedisOptionsTest {
     assertEquals(RedisRole.SENTINEL, copy.getRole());
     assertEquals("myPassword", copy.getPassword());
     assertEquals(TracingPolicy.ALWAYS, copy.getTracingPolicy());
+    assertEquals(2500L, copy.getTopologyCacheTTL());
+    assertEquals(2500L, copy.getHashSlotCacheTTL());
   }
 
   @Test
@@ -62,7 +68,9 @@ public class RedisOptionsTest {
       .setMasterName("someOtherMaster")
       .setRole(RedisRole.SENTINEL)
       .setPassword("myPassword")
-      .setTracingPolicy(TracingPolicy.ALWAYS);
+      .setTracingPolicy(TracingPolicy.ALWAYS)
+      .setHashSlotCacheTTL(2468L) // overwritten by the next call
+      .setTopologyCacheTTL(3333L);
 
     RedisOptions copy = new RedisOptions(original.toJson());
 
@@ -73,6 +81,8 @@ public class RedisOptionsTest {
     assertEquals(RedisRole.SENTINEL, copy.getRole());
     assertEquals("myPassword", copy.getPassword());
     assertEquals(TracingPolicy.ALWAYS, copy.getTracingPolicy());
+    assertEquals(3333L, copy.getTopologyCacheTTL());
+    assertEquals(3333L, copy.getHashSlotCacheTTL());
   }
 
 }

--- a/src/test/java/io/vertx/tests/redis/client/RedisSentinelMasterFailoverTest.java
+++ b/src/test/java/io/vertx/tests/redis/client/RedisSentinelMasterFailoverTest.java
@@ -18,6 +18,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static io.vertx.tests.redis.client.TestUtils.retryUntilSuccess;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(VertxExtension.class)
 @Testcontainers
@@ -42,13 +44,28 @@ public class RedisSentinelMasterFailoverTest {
       .connect()
       .onComplete(test.succeeding(conn -> {
         conn.send(Request.cmd(Command.SET).arg("key").arg("value"))
-          .compose(ignored -> conn.send(Request.cmd(Command.SHUTDOWN)))
-          .onComplete(test.failing(ignored -> { // connection closed
-            retryUntilSuccess(context.vertx(), () -> conn.send(Request.cmd(Command.GET).arg("key")), 50)
-              .onComplete(test.succeeding(response -> {
-                assertEquals("value", response.toString());
-                test.completeNow();
-              }));
+          .compose(ignored -> {
+            // shutdown current master, promote one replica out of two (the other replica remains)
+            return conn.send(Request.cmd(Command.SHUTDOWN));
+          })
+          .transform((value, error) -> {
+            assertNull(value);
+            assertNotNull(error); // connection closed
+            return retryUntilSuccess(context.vertx(), () -> conn.send(Request.cmd(Command.GET).arg("key")), 50);
+          })
+          .compose(response -> {
+            assertEquals("value", response.toString());
+            // shutdown current master, promote the remaining replica (no other replica exists)
+            return conn.send(Request.cmd(Command.SHUTDOWN));
+          })
+          .transform((value, error) -> {
+            assertNull(value);
+            assertNotNull(error); // connection closed
+            return retryUntilSuccess(context.vertx(), () -> conn.send(Request.cmd(Command.GET).arg("key")), 50);
+          })
+          .onComplete(test.succeeding(response -> {
+            assertEquals("value", response.toString());
+            test.completeNow();
           }));
       }));
   }

--- a/src/test/java/io/vertx/tests/redis/client/TestUtils.java
+++ b/src/test/java/io/vertx/tests/redis/client/TestUtils.java
@@ -23,9 +23,9 @@ public class TestUtils {
   }
 
   /**
-   * Waits until the given {@code condition} is {@code true} and then invokes the given {@code action} once,
-   * returning its result. Waiting is not active, it uses the Vert.x {@linkplain Vertx#setTimer(long, Handler) timer}
-   * facility.
+   * Waits until the given {@code condition} is {@code true} and then invokes the given {@code action} once.
+   * Waiting is not active, it uses the Vert.x {@linkplain Vertx#setTimer(long, Handler) timer} facility.
+   * The delay between retries is 5 millis.
    */
   public static void executeWhenConditionSatisfied(Vertx vertx, BooleanSupplier condition, Runnable action) {
     if (condition.getAsBoolean()) {
@@ -39,6 +39,7 @@ public class TestUtils {
 
   /**
    * Retries the given {@code action} until it succeeds or until the number of retries reaches the given maximum.
+   * The delay between retries is 500 millis.
    */
   public static <T> Future<T> retryUntilSuccess(Vertx vertx, Supplier<Future<T>> action, int maxRetries) {
     Promise<T> promise = Promise.promise();


### PR DESCRIPTION
Similarly to how the Redis cluster client caches the cluster topology (hash slot assignment), the Redis sentinel client now caches the sentinel topology (sentinels, master, replicas). The default TTL of the cache is the same as in the cluster client: 1 second.

When creating a sentinel connection, we just take the address from the cache, instead of contacting one of the sentinels for an address. This means that when creating a connection of role `SENTINEL`, we no longer "validate" that the other side exists by pinging it. The cache should be relatively fresh, so there's minuscule chance that the sentinel went down in the mean time. Also, validating the address has always been an outlier; no other Redis client does it.

On the configuration front, we unify the "topology cache TTL" option between sentinel and cluster. The cluster-only `hashSlotCacheTTL` option is now deprecated and is not [expected to be] present in the JSON form.

Fixes #519