### PR TITLE
downgrade to JUnit Jupiter 5.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <version.bouncycastle>1.82</version.bouncycastle>
-    <version.junit-jupiter>6.0.0</version.junit-jupiter>
+    <version.junit-jupiter>5.14.0</version.junit-jupiter>
     <version.testcontainers>2.0.1</version.testcontainers>
   </properties>
 


### PR DESCRIPTION
JUnit Jupiter 6.0 requires Java 17, while Vert.x 5 still supports Java 11. Fortunately, the Vert.x JUnit 5 integration has a BOM import of JUnit 5.14 which wins over the dependency on JUnit 6.0 in this project, but it's best to stay consistent and explicit.