### PR TITLE
502 map bin keys

### DIFF
--- a/src/main/java/io/vertx/redis/client/Response.java
+++ b/src/main/java/io/vertx/redis/client/Response.java
@@ -278,7 +278,53 @@ public interface Response extends Iterable<Response> {
   }
 
   /**
-   * Get this size of this multi response.
+   * Get this Multi response value at a binary key.
+   * <p>
+   * This is a variant of {@link #get(String)} that accepts binary keys. Use
+   * this method when the map contains binary keys that may not be interpreted
+   * as valid UTF-8 chars. For example, redis HASH with binary field names
+   * like UUIDs, IPs in binary form, hashes of some data, etc.
+   *
+   * @param key the required key.
+   * @return Response value.
+   */
+  default Response get(Buffer key) {
+    throw new UnsupportedOperationException("This type doesn't hold a Map type");
+  }
+
+  /**
+   * Check if this Multi response contains a binary key.
+   * <p>
+   * This is a variant of {@link #containsKey(String)} that accepts binary keys.
+   * Use this method when the map contains binary keys that may not be
+   * interpreted as valid UTF-8 chars. For example, redis HASH with binary
+   * field names like UUIDs, IPs in binary form, hashes of some data, etc.
+   *
+   * @param key the required key.
+   * @return whether the response contains the key.
+   */
+  default boolean containsKey(Buffer key) {
+    throw new UnsupportedOperationException("This type doesn't hold a Map type");
+  }
+
+  /**
+   * Get binary keys of this multi response.
+   * <p>
+   * This is a variant of {@link #getKeys()} that returns binary keys. Use this
+   * method when the map contains binary keys that may not be interpreted as
+   * valid UTF-8 chars. For example, redis HASH with binary field names like
+   * UUIDs, IPs in binary form, hashes of some data, etc.
+   *
+   * @return the set of binary keys.
+   */
+  default Set<Buffer> getBinaryKeys() {
+    throw new UnsupportedOperationException("This type doesn't hold a Map type");
+  }
+
+  /**
+   * Get the size of this multi response, which is the number of elements in the array.
+   * In case of a map, it is the number of keys <em>plus</em> the number of values, or
+   * in other words <em>twice</em> the number of key/value mappings.
    *
    * @return the size of the multi.
    */

--- a/src/main/java/io/vertx/redis/client/impl/types/MultiType.java
+++ b/src/main/java/io/vertx/redis/client/impl/types/MultiType.java
@@ -16,56 +16,54 @@
 package io.vertx.redis.client.impl.types;
 
 import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * A Redis MULTI response can represent a List/Set/Map type.
+ * <p>
+ * Not thread safe.
  */
 public final class MultiType implements Multi {
+  // shorthand aliases for better readability
+  private static final Function<Response, String> AS_STRING = Response::toString;
+  private static final Function<Response, Buffer> AS_BUFFER = Response::toBuffer;
 
   public static final MultiType EMPTY_MULTI = new MultiType(0, false);
   public static final MultiType EMPTY_MAP = new MultiType(0, true);
 
-  public static MultiType create(long length, boolean asMap) {
-    if (asMap) {
-      return new MultiType((int) length * 2, true);
-    } else {
-      return new MultiType((int) length, false);
-    }
+  public static MultiType create(long length, boolean isMap) {
+    return new MultiType((int) length, isMap);
   }
 
-  // only one of these will be not null
-  private final Map<String, Response> map;
+  // elements of this Multi are stored in this array
   private final Response[] multi;
-  // the expected size
-  private final int size;
+  private final boolean isMap;
+  // these maps are built on demand from the `multi` array
+  private Map<String, Response> strMap;
+  private Map<Buffer, Response> binMap;
   // mutable temporary state
-  private int count;
-  private String key;
+  private int count = 0;
 
-  private MultiType(int size, boolean asMap) {
-    if (asMap) {
-      this.multi = null;
-      this.map = new HashMap<>(size, 1.0f);
-    } else {
-      this.multi = new Response[size];
-      this.map = null;
-    }
-    this.size = size;
-    this.count = 0;
+  private MultiType(int size, boolean isMap) {
+    this.isMap = isMap;
+    // if `isMap`, then the `size` is the number of key-value pairs,
+    // so we need to allocate double size for the array
+    this.multi = new Response[isMap ? size * 2 : size];
   }
 
-  private MultiType(String key, Response value) {
-    this.map = null;
-    this.multi = new Response[]{SimpleStringType.create(key), value};
-    this.size = 2;
+  private MultiType(Response key, Response value) {
+    this.isMap = true;
+    this.multi = new Response[]{key, value};
   }
 
   @Override
@@ -75,142 +73,108 @@ public final class MultiType implements Multi {
 
   @Override
   public void add(Response reply) {
-    // if this Multi was created as a Map
-    if (map != null) {
-      if (count % 2 == 0) {
-        if (reply == null || reply.type() == null) {
-          throw new IllegalArgumentException("Map key is NULL or untyped");
-        }
-
-        switch (reply.type()) {
-          case BULK:
-          case SIMPLE:
-            key = reply.toString();
-            break;
-          default:
-            throw new IllegalArgumentException("Map key is not BULK or SIMPLE");
-        }
-      } else {
-        if (key != null) {
-          map.put(key, reply);
-        }
-        // clear the key
-        key = null;
-      }
-    }
-    // if this Multi was created as a Collection
-    if (multi != null) {
-      this.multi[this.count] = reply;
-    }
-    // increment the counter
+    this.multi[this.count] = reply;
     count++;
   }
 
   public boolean complete() {
-    return count == size;
+    return count == multi.length;
   }
 
   @Override
   public Response get(int index) {
-    if (multi != null) {
-      return multi[index];
+    if (isMap) {
+      throw new RuntimeException("Multi is a Map");
     }
-    throw new RuntimeException("Multi is a Map");
+    return multi[index];
   }
 
   @Override
-  public @Nullable Response get(String key) {
-    if (map != null) {
-      return map.get(key);
+  public Response get(String key) {
+    if (isMap) {
+      buildStrMapIfNeeded();
+      return strMap.get(key);
     }
 
-    if (multi != null) {
-      // fallback (emulate old behavior)
-      if (multi.length % 2 == 0) {
-        // if the size is even we assume we can handle it as Map
-        for (int i = 0; i < multi.length; i += 2) {
-          if (key.equals(multi[i].toString())) {
-            return multi[i + 1];
-          }
-        }
-        // not found
-        return null;
-      }
-    }
-
-    throw new RuntimeException("Number of key is not even can't handle as Map");
+    // fallback (emulate old behavior)
+    return findInMultiArray(key, AS_STRING);
   }
 
   @Override
   public boolean containsKey(String key) {
-    if (map != null) {
-      return map.containsKey(key);
+    if (isMap) {
+      buildStrMapIfNeeded();
+      return strMap.containsKey(key);
     }
 
-    if (multi != null) {
-      // fallback (emulate old behavior)
-      if (multi.length % 2 == 0) {
-        // if the size is even we assume we can handle it as Map
-        for (int i = 0; i < multi.length; i += 2) {
-          if (key.equals(multi[i].toString())) {
-            return true;
-          }
-        }
-        // not found
-        return false;
-      }
-    }
-
-    throw new RuntimeException("Number of key is not even can't handle as Map");
+    // fallback (emulate old behavior)
+    return findInMultiArray(key, AS_STRING) != null;
   }
 
   @Override
   public Set<String> getKeys() {
-    if (map != null) {
-      return map.keySet();
+    if (isMap) {
+      buildStrMapIfNeeded();
+      return strMap.keySet();
     }
 
-    if (multi != null) {
-      // fallback (emulate old behavior)
-      if (multi.length % 2 == 0) {
-        final Set<String> keys = new HashSet<>();
-        // if the size is even we assume we can handle it as Map
-        for (int i = 0; i < multi.length; i += 2) {
-          switch (multi[i].type()) {
-            case BULK:
-            case SIMPLE:
-              keys.add(multi[i].toString());
-              break;
-          }
-        }
+    // fallback (emulate old behavior)
+    return getKeysOfMultiArray(AS_STRING);
+  }
 
-        return keys;
-      }
+  @Override
+  public Response get(Buffer key) {
+    if (isMap) {
+      buildBinMapIfNeeded();
+      return binMap.get(key);
     }
 
-    throw new RuntimeException("Number of key is not even can't handle as Map");
+    // fallback (emulate old behavior)
+    return findInMultiArray(key, AS_BUFFER);
+  }
+
+  @Override
+  public boolean containsKey(Buffer key) {
+    if (isMap) {
+      buildBinMapIfNeeded();
+      return binMap.containsKey(key);
+    }
+
+    // fallback (emulate old behavior)
+    return findInMultiArray(key, AS_BUFFER) != null;
+  }
+
+  @Override
+  public Set<Buffer> getBinaryKeys() {
+    if (isMap) {
+      buildBinMapIfNeeded();
+      return binMap.keySet();
+    }
+
+    // fallback (emulate old behavior)
+    return getKeysOfMultiArray(AS_BUFFER);
   }
 
   @Override
   public int size() {
-    return size;
+    return multi.length;
   }
 
   @Override
   public boolean isArray() {
-    return multi != null;
+    return !isMap;
   }
 
   @Override
   public boolean isMap() {
-    return map != null;
+    return isMap;
   }
 
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder();
 
-    if (multi != null) {
+    if (!isMap) {
       sb.append('[');
       boolean more = false;
       for (Response r : multi) {
@@ -226,22 +190,15 @@ public final class MultiType implements Multi {
         more = true;
       }
       sb.append(']');
-    }
-
-    if (map != null) {
-      sb.append('{');
-      boolean more = false;
-      for (Map.Entry<String, Response> kv : map.entrySet()) {
-        if (more) {
-          sb.append(", ");
-        }
-
-        sb.append(kv.getKey());
-        sb.append(": ");
-        sb.append(kv.getValue());
-        more = true;
+    } else {
+      // if binMap is built, then the caller interprets keys as binary
+      if (binMap != null) {
+        // encode buffers in base64 ready for usage in JSON
+        mapToString(sb, binMap, Buffer::toJson);
+      } else {
+        buildStrMapIfNeeded();
+        mapToString(sb, strMap, Function.identity());
       }
-      sb.append('}');
     }
 
     return sb.toString();
@@ -249,40 +206,101 @@ public final class MultiType implements Multi {
 
   @Override
   public Iterator<Response> iterator() {
-    if (multi != null) {
-      return new Iterator<Response>() {
-        private int idx = 0;
+    return new Iterator<>() {
+      private int idx = 0;
 
-        @Override
-        public boolean hasNext() {
-          return idx < size;
-        }
+      @Override
+      public boolean hasNext() {
+        return idx < multi.length;
+      }
 
-        @Override
-        public Response next() {
+      @Override
+      public Response next() {
+        if (isMap) {
+          // wrap the key/value pair into a single multi response
+          return new MultiType(multi[idx++], multi[idx++]);
+        } else {
           return multi[idx++];
         }
-      };
+      }
+    };
+  }
+
+  private void assertCanInterpretMultiAsMap() {
+    // if the size is even, we assume we can handle it as Map
+    if (multi.length % 2 != 0) {
+      throw new RuntimeException("Number of elements is not even, can't handle as Map");
     }
+  }
 
-    if (map != null) {
-      return new Iterator<Response>() {
-        private final Iterator<Map.Entry<String, Response>> it = map.entrySet().iterator();
+  private <K> Set<K> getKeysOfMultiArray(Function<Response, K> converter) {
+    assertCanInterpretMultiAsMap();
 
-        @Override
-        public boolean hasNext() {
-          return it.hasNext();
-        }
-
-        @Override
-        public Response next() {
-          // wrap the kv into a single multi response
-          final Map.Entry<String, Response> kv = it.next();
-          return new MultiType(kv.getKey(), kv.getValue());
-        }
-      };
+    Set<K> convertedKeys = new LinkedHashSet<>();
+    // if the size is even, we assume we can handle it as Map
+    for (int i = 0; i < multi.length; i += 2) {
+      switch (multi[i].type()) {
+        case BULK:
+        case SIMPLE:
+          convertedKeys.add(converter.apply(multi[i]));
+          break;
+      }
     }
+    return convertedKeys;
+  }
 
-    throw new UnsupportedOperationException("Cannot iterator over NULL");
+  private <K> Response findInMultiArray(K key, Function<Response, K> converter) {
+    assertCanInterpretMultiAsMap();
+
+    for (int i = 0; i < multi.length; i += 2) {
+      K respInKeyFormat = converter.apply(multi[i]);
+      if (key.equals(respInKeyFormat)) {
+        return multi[i + 1];
+      }
+    }
+    // not found
+    return null;
+  }
+
+  private void buildStrMapIfNeeded() {
+    if (!isMap || strMap != null) {
+      return;
+    }
+    // redis tracks the order of entries in hashes, for some use-cases it may
+    // be important to preserve it, so we use LinkedHashMap
+    strMap = new LinkedHashMap<>(multi.length / 2);
+    for (int i = 0; i < multi.length; i += 2) {
+      // Response.toString() triggers the conversion of the response to UTF-8 String
+      strMap.put(multi[i].toString(), multi[i + 1]);
+    }
+  }
+
+  private void buildBinMapIfNeeded() {
+    if (!isMap || binMap != null) {
+      return;
+    }
+    // redis tracks the order of entries in hashes, for some use-cases it may
+    // be important to preserve it, so we use LinkedHashMap
+    binMap = new LinkedHashMap<>(multi.length / 2);
+    for (int i = 0; i < multi.length; i += 2) {
+      // Response.toBuffer() triggers the conversion of the response to Buffer
+      binMap.put(multi[i].toBuffer(), multi[i + 1]);
+    }
+  }
+
+  private static <T> void mapToString(StringBuilder sb, Map<T, Response> map, Function<T, String> keyToString) {
+    sb.append('{');
+    boolean more = false;
+    for (Map.Entry<T, Response> kv : map.entrySet()) {
+      if (more) {
+        sb.append(", ");
+      }
+
+      sb.append(keyToString.apply(kv.getKey()));
+      sb.append(": ");
+      sb.append(kv.getValue());
+      more = true;
+    }
+    sb.append('}');
   }
 }

--- a/src/test/java/io/vertx/tests/redis/internal/MultiTypeTest.java
+++ b/src/test/java/io/vertx/tests/redis/internal/MultiTypeTest.java
@@ -1,0 +1,194 @@
+package io.vertx.tests.redis.internal;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.redis.client.ResponseType;
+import io.vertx.redis.client.impl.types.BulkType;
+import io.vertx.redis.client.impl.types.MultiType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MultiTypeTest {
+  String strKey1 = "test-key-1";
+  String strValue1 = "test-value-1";
+
+  String strKey2 = "test-key-2";
+  String strValue2 = "test-value-2";
+
+  Buffer binKey1 = Buffer.buffer(new byte[]{0x10, 0x20, 0x30, 0x40, 0x50, 0x60});
+  String binValue1 = "bin-value-1";
+
+  Buffer binKey2 = Buffer.buffer(new byte[]{-0x10, -0x20, -0x30, -0x40, -0x50, -0x60});
+  String binValue2 = "bin-value-2";
+
+  MultiType multi;
+
+  @BeforeEach
+  void setup() {
+    // multi isMap=true with two string keys and two binary keys
+    multi = MultiType.create(4, true);
+    multi.add(BulkType.create(Buffer.buffer(strKey1), false));
+    multi.add(BulkType.create(Buffer.buffer(strValue1), false));
+    multi.add(BulkType.create(binKey1, false));
+    multi.add(BulkType.create(Buffer.buffer(binValue1), false));
+    multi.add(BulkType.create(binKey2, false));
+    multi.add(BulkType.create(Buffer.buffer(binValue2), false));
+    multi.add(BulkType.create(Buffer.buffer(strKey2), false));
+    multi.add(BulkType.create(Buffer.buffer(strValue2), false));
+  }
+
+  @Test
+  void map_GetByStringKey() {
+    // when: get value from map multi by string key
+    var strKeyToGet = new String(strKey1); // ensure lookup by content, not by ref
+    var retrieved = multi.get(strKeyToGet);
+
+    // then: associated bulk value is retrieved correctly
+    assertNotNull(retrieved);
+    assertEquals(ResponseType.BULK, retrieved.type());
+    assertEquals(strValue1, retrieved.toString());
+  }
+
+  @Test
+  void map_GetByStringKey_NotFound() {
+    // when: get value from map multi by a string key that is not present
+    var nonExistingStrKey = "non-existing-key";
+    var retrieved = multi.get(nonExistingStrKey);
+
+    // then: null is returned
+    assertNull(retrieved);
+  }
+
+  @Test
+  void map_GetByBinaryKey() {
+    // when: get value from map multi by binary key
+    var binKeyToGet = binKey1.copy(); // ensure lookup by content, not by ref
+    var retrieved = multi.get(binKeyToGet);
+
+    // then: associated bulk value is retrieved correctly
+    assertNotNull(retrieved);
+    assertEquals(ResponseType.BULK, retrieved.type());
+    assertEquals(binValue1, retrieved.toString());
+  }
+
+  @Test
+  void map_GetByBinaryKey_NotFound() {
+    // when: get value from map multi by a binary key that is not present
+    var nonExistingBinKey = Buffer.buffer(new byte[]{0x01, 0x02, 0x03});
+    var retrieved = multi.get(nonExistingBinKey);
+
+    // then: null is returned
+    assertNull(retrieved);
+  }
+
+  @Test
+  void map_ContainsStrKey() {
+    // when: check if map multi contains a string key
+    var strKeyToCheck = new String(strKey2); // ensure lookup by content, not by ref
+    var contains = multi.containsKey(strKeyToCheck);
+
+    // then: key is found
+    assertTrue(contains);
+  }
+
+  @Test
+  void map_ContainsStrKey_NotFound() {
+    // when: check if map multi contains a string key that is not present
+    var nonExistingStrKey = "another-non-existing-key";
+    var contains = multi.containsKey(nonExistingStrKey);
+
+    // then: key is not found
+    assertFalse(contains);
+  }
+
+  @Test
+  void map_ContainsBinKey() {
+    // when: check if map multi contains a binary key
+    var binKeyToCheck = binKey2.copy(); // ensure lookup by content, not by ref
+    var contains = multi.containsKey(binKeyToCheck);
+
+    // then: key is found
+    assertTrue(contains);
+  }
+
+  @Test
+  void map_ContainsBinKey_NotFound() {
+    // when: check if map multi contains a binary key that is not present
+    var nonExistingBinKey = Buffer.buffer(new byte[]{-0x01, -0x02, -0x03});
+    var contains = multi.containsKey(nonExistingBinKey);
+
+    // then: key is not found
+    assertFalse(contains);
+  }
+
+  @Test
+  void map_GetKeys() {
+    // when: get all str keys from the map multi
+    var keys = multi.getKeys();
+
+    // then: all four keys are returned
+    assertEquals(4, keys.size());
+
+    // and: binary keys are converted to UTF-8 strings
+    assertTrue(keys.contains(strKey1));
+    assertTrue(keys.contains(strKey2));
+    assertTrue(keys.contains(binKey1.toString(UTF_8)));
+    // note: (negative bytes become replacement char => �, i.e. U+FFFD)
+    assertTrue(keys.contains(binKey2.toString(UTF_8)));
+  }
+
+  @Test
+  void map_GetBinaryKeys() {
+    // when: get all binary keys from the map multi
+    var keys = multi.getBinaryKeys();
+
+    // then: all four keys are returned
+    assertEquals(4, keys.size());
+
+    // and: string keys are converted to binary using UTF-8 encoding
+    assertTrue(keys.contains(Buffer.buffer(strKey1)));
+    assertTrue(keys.contains(Buffer.buffer(strKey2)));
+    assertTrue(keys.contains(binKey1));
+    assertTrue(keys.contains(binKey2));
+  }
+
+  @Test
+  void map_ToStringEncodesKeysAsBase64_WhenBinaryKeysAreUsed() {
+    // given: any method that generates binary keys representation was invoked
+    // on the map multi
+    multi.containsKey(binKey1);
+
+    // when: toString is called on the map multi
+    var str = multi.toString();
+
+    // then: all keys are represented as base64 strings with the same format
+    // as used in JSON format for binary values (URL-safe without padding)
+    assertTrue(str.contains(binKey1.toJson()));
+    assertTrue(str.contains(binKey2.toJson()));
+    assertTrue(str.contains(Buffer.buffer(strKey1).toJson()));
+    assertTrue(str.contains(Buffer.buffer(strKey2).toJson()));
+  }
+
+  @Test
+  void map_ToStringEncodesKeysAsStrings_WhenOnlyStringKeysAreUsed() {
+    // given: no method that generates binary keys representation was invoked
+    // on a map multi
+
+    // when: toString is called on the map multi
+    var str = multi.toString();
+
+    // then: all keys are represented as normal strings
+    assertTrue(str.contains(strKey1));
+    assertTrue(str.contains(strKey2));
+    assertTrue(str.contains(binKey1.toString(UTF_8)));
+    // note: illegal UTF-8 bytes in binary keys are converted to replacement char
+    assertTrue(str.contains(binKey2.toString(UTF_8)));
+  }
+
+}


### PR DESCRIPTION
Implements #502 . Adds support for binary keys in MultiType. Specifically, this is needed for reading binary fields (keys) of HASH-es with HGETALL command.

The approach is to always store elements of multi in `multi` array, and evaluate corresponding map with string or/and binary keys when either is requested. This approach makes this class NOT thread safe, but it is not a really useful feature since under typical usage scenarios there won't be concurrent access. Hence, it's better to keep this class simple and not-thread-safe, and if the need to use it concurrently arises in some exotic use cases, then let the callers deal with it externally.

NOTE: I had to decide whether to keep using un-ordered HashMap for binary keys too, or change both strMap and binMap to be LinkedHashMap. In fact, Redis preserves order of fields in HASH-es, and relevant commands like HKEYS, HVALS, HSCAN and HGETALL particularly, return values in their respective order. With this change, the existing method `MultiType#getKeys()` will also preserve order, which was not the case due to usage of HashMap. Even though technically this is a change of behavior, it can not affect any existing users, as they were unable to rely on the order anyway prior to this change.