### PR TITLE
retain order in responses to cross-slot requests

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/Primitives.java
+++ b/src/main/java/io/vertx/redis/client/impl/Primitives.java
@@ -1,0 +1,38 @@
+package io.vertx.redis.client.impl;
+
+public final class Primitives {
+  public static final class Int {
+    public int value;
+
+    public Int(int value) {
+      this.value = value;
+    }
+  }
+
+  public static final class IntList {
+    private int[] array = new int[4];
+    private int size = 0; // one past the last used element in `array`
+
+    public int size() {
+      return size;
+    }
+
+    public int get(int index) {
+      if (index >= size) {
+        throw new IndexOutOfBoundsException(index);
+      }
+      return array[index];
+    }
+
+    public void add(int value) {
+      if (size == array.length) {
+        // perhaps should check for overflow here
+        int[] newArray = new int[array.length * 2];
+        System.arraycopy(array, 0, newArray, 0, array.length);
+        this.array = newArray;
+      }
+      array[size] = value;
+      size++;
+    }
+  }
+}

--- a/src/test/java/io/vertx/tests/redis/internal/ConnectionRecyclingTest.java
+++ b/src/test/java/io/vertx/tests/redis/internal/ConnectionRecyclingTest.java
@@ -10,6 +10,7 @@ import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisConnection;
 import io.vertx.redis.client.RedisOptions;
 import io.vertx.redis.client.Request;
+import io.vertx.redis.client.impl.Primitives.Int;
 import io.vertx.redis.client.impl.RedisClient;
 import io.vertx.redis.client.impl.RedisConnectionInternal;
 import io.vertx.redis.client.impl.RedisConnectionManager;
@@ -106,7 +107,7 @@ public class ConnectionRecyclingTest {
   }
 
   private void assertConnectionPool(VertxTestContext test, int expectedSize) {
-    IntBox size = new IntBox(0);
+    Int size = new Int(0);
 
     try {
       RedisConnectionManager connManager = ((RedisClient) client).connectionManager();
@@ -125,13 +126,5 @@ public class ConnectionRecyclingTest {
     test.verify(() -> {
       assertEquals(expectedSize, size.value);
     });
-  }
-
-  static class IntBox {
-    int value;
-
-    IntBox(int value) {
-      this.value = value;
-    }
   }
 }


### PR DESCRIPTION
By default, requests that target multiple cluster nodes are rejected. However, if there's a reducer registered for the command, such requests are allowed and are sent to all required cluster nodes. The responses are then combined using the reducer.

Until this commit, there was no guarantee on ordering of the responses, which makes the `MGET` command relatively useless in the cross-slot scenario. This commit makes sure that ordering of responses is identical to ordering of requests, making cross-slot `MGET` useful. (There's no other command for which we register a reducer and ordering matters.)

Fixes #537