### PR TITLE
Fix connection pool deadlock in cluster mode during slot refresh

### DIFF
--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterClient.java
@@ -218,7 +218,7 @@ public class RedisClusterClient extends BaseRedisClient<RedisClusterConnectOptio
         onConnected.fail(new RedisConnectException(message.toString()));
       } else {
         onConnected.succeed(new RedisClusterConnection(vertx, connectionManager,
-          connectOptions, sharedSlots, connections));
+          connectOptions, sharedSlots, slots, connections));
       }
     }
   }

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterConnection.java
@@ -88,6 +88,7 @@ public class RedisClusterConnection implements RedisConnection {
   private final RedisConnectionManager connectionManager;
   private final RedisClusterConnectOptions connectOptions;
   final SharedSlots sharedSlots;
+  private Slots lastSlots;
   private final Map<String, PooledRedisConnection> connections;
 
   // these fields are only used in `send()` and are ignored in `batch()`, because request batches
@@ -96,11 +97,12 @@ public class RedisClusterConnection implements RedisConnection {
   private String boundToEndpoint = null;
 
   RedisClusterConnection(Vertx vertx, RedisConnectionManager connectionManager, RedisClusterConnectOptions connectOptions,
-      SharedSlots sharedSlots, Map<String, PooledRedisConnection> connections) {
+      SharedSlots sharedSlots, Slots lastSlots, Map<String, PooledRedisConnection> connections) {
     this.vertx = (VertxInternal) vertx;
     this.connectionManager = connectionManager;
     this.connectOptions = connectOptions;
     this.sharedSlots = sharedSlots;
+    this.lastSlots = lastSlots;
     this.connections = connections;
   }
 
@@ -164,10 +166,22 @@ public class RedisClusterConnection implements RedisConnection {
     return this;
   }
 
+  /**
+   * Returns the best available slots: fresh slots from the shared cache if available,
+   * otherwise the last known slots. Triggers a refresh of the cache if it has been
+   * invalidated, but doesn't wait for the refresh to finish.
+   */
+  Slots currentSlots() {
+    Future<Slots> future = sharedSlots.get();
+    if (future.succeeded()) {
+      lastSlots = future.result();
+    }
+    return lastSlots;
+  }
+
   @Override
   public Future<Response> send(Request request) {
-    Future<Response> future = sharedSlots.get()
-      .compose(slots -> send(request, slots));
+    Future<Response> future = send(request, currentSlots());
 
     if (connectOptions.getClusterTransactions() == RedisClusterTransactions.SINGLE_NODE) {
       return future.andThen(ignored -> {
@@ -483,8 +497,7 @@ public class RedisClusterConnection implements RedisConnection {
 
   @Override
   public Future<List<Response>> batch(List<Request> requests) {
-    return sharedSlots.get()
-      .compose(slots -> batch(requests, slots));
+    return batch(requests, currentSlots());
   }
 
   private Future<List<Response>> batch(List<Request> requests, Slots slots) {

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterImpl.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterImpl.java
@@ -67,17 +67,15 @@ public class RedisClusterImpl implements RedisCluster {
   }
 
   private Future<List<Response>> onAllNodes(Request request, boolean mastersOnly, RedisClusterConnection conn) {
-    return conn.sharedSlots.get()
-      .compose(slots -> {
-        String[] endpoints = mastersOnly ? slots.masterEndpoints() : slots.endpoints();
-        HashSet<String> endpointsSet = new HashSet<>(endpoints.length);
-        Collections.addAll(endpointsSet, endpoints);
-        String[] uniqueEndpoints = endpointsSet.toArray(new String[0]);
+    Slots slots = conn.currentSlots();
+    String[] endpoints = mastersOnly ? slots.masterEndpoints() : slots.endpoints();
+    HashSet<String> endpointsSet = new HashSet<>(endpoints.length);
+    Collections.addAll(endpointsSet, endpoints);
+    String[] uniqueEndpoints = endpointsSet.toArray(new String[0]);
 
-        Promise<List<Response>> promise = conn.vertx.promise();
-        onAllNodes(uniqueEndpoints, 0, request, new ArrayList<>(uniqueEndpoints.length), conn, promise);
-        return promise.future();
-      });
+    Promise<List<Response>> promise = conn.vertx.promise();
+    onAllNodes(uniqueEndpoints, 0, request, new ArrayList<>(uniqueEndpoints.length), conn, promise);
+    return promise.future();
   }
 
   private void onAllNodes(String[] endpoints, int index, Request request, List<Response> result, RedisClusterConnection conn, Completable<List<Response>> promise) {
@@ -110,42 +108,40 @@ public class RedisClusterImpl implements RedisCluster {
   }
 
   private Future<RequestGrouping> groupByNodes(List<Request> requests, RedisClusterConnection conn) {
-    return conn.sharedSlots.get()
-      .compose(slots -> {
-        Map<String, List<Request>> grouping = new HashMap<>();
-        List<Request> ambiguous = null;
+    Slots slots = conn.currentSlots();
+    Map<String, List<Request>> grouping = new HashMap<>();
+    List<Request> ambiguous = null;
 
-        for (Request request : requests) {
-          RequestImpl req = (RequestImpl) request;
-          CommandImpl cmd = (CommandImpl) req.command();
-          List<byte[]> keys = req.keys();
+    for (Request request : requests) {
+      RequestImpl req = (RequestImpl) request;
+      CommandImpl cmd = (CommandImpl) req.command();
+      List<byte[]> keys = req.keys();
 
-          if (cmd.needsGetKeys() || keys.isEmpty()) {
-            if (ambiguous == null) {
-              ambiguous = new ArrayList<>();
-            }
-            ambiguous.add(request);
-          } else if (keys.size() == 1) {
-            int slot = ZModem.generate(keys.get(0));
-            String endpoint = slots.endpointsForKey(slot)[0];
-            grouping.computeIfAbsent(endpoint, ignored -> new ArrayList<>()).add(request);
-          } else {
-            String endpoint = null;
-            for (byte[] key : keys) {
-              int slot = ZModem.generate(key);
-              String endpointForSlot = slots.endpointsForKey(slot)[0];
-              if (endpoint == null) {
-                endpoint = endpointForSlot;
-              } else if (!endpointForSlot.equals(endpoint)) {
-                return Future.failedFuture(conn.buildCrossslotFailureMsg(req));
-              }
-            }
-
-            grouping.computeIfAbsent(endpoint, ignored -> new ArrayList<>()).add(request);
+      if (cmd.needsGetKeys() || keys.isEmpty()) {
+        if (ambiguous == null) {
+          ambiguous = new ArrayList<>();
+        }
+        ambiguous.add(request);
+      } else if (keys.size() == 1) {
+        int slot = ZModem.generate(keys.get(0));
+        String endpoint = slots.endpointsForKey(slot)[0];
+        grouping.computeIfAbsent(endpoint, ignored -> new ArrayList<>()).add(request);
+      } else {
+        String endpoint = null;
+        for (byte[] key : keys) {
+          int slot = ZModem.generate(key);
+          String endpointForSlot = slots.endpointsForKey(slot)[0];
+          if (endpoint == null) {
+            endpoint = endpointForSlot;
+          } else if (!endpointForSlot.equals(endpoint)) {
+            return Future.failedFuture(conn.buildCrossslotFailureMsg(req));
           }
         }
 
-        return Future.succeededFuture(new RequestGrouping(grouping.values(), ambiguous != null ? ambiguous : Collections.emptyList()));
-      });
+        grouping.computeIfAbsent(endpoint, ignored -> new ArrayList<>()).add(request);
+      }
+    }
+
+    return Future.succeededFuture(new RequestGrouping(grouping.values(), ambiguous != null ? ambiguous : Collections.emptyList()));
   }
 }

--- a/src/test/java/io/vertx/tests/redis/client/RedisClusterTest.java
+++ b/src/test/java/io/vertx/tests/redis/client/RedisClusterTest.java
@@ -1092,4 +1092,56 @@ public class RedisClusterTest {
         }));
     }));
   }
+
+  @Test
+  public void testPoolNotExhaustedDuringSlotRefresh(VertxTestContext test) {
+    // Reproduces a deadlock where slot refresh competes with user requests
+    // for pool connections. Steps:
+    // 1. connect() twice to exhaust the pool (maxPoolSize=2, each connect
+    //    acquires 1 connection per endpoint)
+    // 2. wait for the short topology cache TTL to expire (slots become null)
+    // 3. send() on the held connections -- RedisClusterConnection.send()
+    //    calls sharedSlots.get() which needs a pool connection for refresh,
+    //    but the pool is fully held -- deadlock
+    //
+    // For the deadlock to occur, the user-configured endpoint must match
+    // the cluster-discovered endpoints (same pool). We first query CLUSTER
+    // SLOTS to find the host the cluster announces, then use that host
+    // in the connection string.
+    Checkpoint checkpoint = test.checkpoint(2);
+
+    Redis standaloneClient = Redis.createClient(context.vertx(), new RedisOptions()
+      .addConnectionString(redis.getRedisNode0Uri()));
+
+    standaloneClient.send(cmd(CLUSTER).arg("SLOTS"))
+      .onComplete(test.succeeding(reply -> {
+        // extract the host that the cluster announces
+        String clusterHost = reply.get(0).get(2).get(0).toString();
+        standaloneClient.close();
+
+        final RedisOptions opts = new RedisOptions()
+          .setType(RedisClientType.CLUSTER)
+          .setUseReplicas(RedisReplicas.SHARE)
+          .addConnectionString("redis://" + clusterHost + ":7000")
+          .setMaxPoolSize(2)
+          .setMaxPoolWaiting(1024)
+          .setTopologyCacheTTL(1);
+
+        Redis clusterClient = Redis.createClient(context.vertx(), opts);
+
+        Future.all(clusterClient.connect(), clusterClient.connect())
+          .onComplete(test.succeeding(composite -> {
+            RedisConnection conn1 = composite.resultAt(0);
+            RedisConnection conn2 = composite.resultAt(1);
+
+            // wait for the topology cache TTL to expire
+            context.vertx().setTimer(100, t -> {
+              conn1.send(cmd(SET).arg(randomKey()).arg("value"))
+                .onComplete(test.succeeding(resp -> checkpoint.flag()));
+              conn2.send(cmd(SET).arg(randomKey()).arg("value"))
+                .onComplete(test.succeeding(resp -> checkpoint.flag()));
+            });
+          }));
+      }));
+  }
 }


### PR DESCRIPTION
`RedisClusterConnection.send()` and `batch()` used to call `sharedSlots.get()`, which would wait for a slot refresh that needs a pool connection. If all pool connections are held by `RedisClusterConnection` instances whose `send()` is waiting for the same slot refresh, a deadlock occurs.

Use the last known slots directly instead of blocking on slot refresh. Fresh slots from the shared cache are picked up when available, without waiting.

Fixes #541 