### PR TITLE
Add spotless plugin and remove unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,16 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <java>
+            <removeUnusedImports />
+          </java>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>

--- a/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
@@ -19,7 +19,6 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
-import io.vertx.redis.client.impl.RedisSentinelConnection;
 
 import java.util.List;
 

--- a/src/main/java/io/vertx/redis/client/impl/RedisClusterImpl.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClusterImpl.java
@@ -13,7 +13,6 @@ import io.vertx.redis.client.RequestGrouping;
 import io.vertx.redis.client.Response;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/main/java/io/vertx/redis/client/impl/SentinelFailover.java
+++ b/src/main/java/io/vertx/redis/client/impl/SentinelFailover.java
@@ -2,7 +2,6 @@ package io.vertx.redis.client.impl;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.redis.client.Command;

--- a/src/main/java/io/vertx/redis/client/impl/types/MultiType.java
+++ b/src/main/java/io/vertx/redis/client/impl/types/MultiType.java
@@ -15,12 +15,10 @@
  */
 package io.vertx.redis.client.impl.types;
 
-import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;

--- a/src/test/java/io/vertx/tests/redis/client/RedisSentinelTest.java
+++ b/src/test/java/io/vertx/tests/redis/client/RedisSentinelTest.java
@@ -7,7 +7,6 @@ import io.vertx.redis.client.Command;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisClientType;
 import io.vertx.redis.client.RedisOptions;
-import io.vertx.redis.client.RedisReplicas;
 import io.vertx.redis.client.RedisRole;
 import io.vertx.redis.client.Request;
 import io.vertx.tests.redis.containers.RedisSentinel;
@@ -17,9 +16,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static io.vertx.tests.redis.client.TestUtils.randomKey;
-import static io.vertx.tests.redis.client.TestUtils.retryUntilSuccess;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(VertxExtension.class)


### PR DESCRIPTION
Added spotless plugin to remove unused imports. I have just added the goal of removing unused imports, this can be further extended to impose a code style, import order etc.

cc @vietj I believe this will help with checks. You can use goal = `spotless:apply` to remove unused imports now.