### PR TITLE
Add client self-identification via CLIENT SETINFO

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -565,6 +565,28 @@ This means that each connection to the server will use at least this amount of m
 As the client works in pipeline mode, keeping the number of connections low provides best results, which means `16 KB * nconn` memory will be used.
 If the application will require a large number of connections, then reducing the watermark value to a smaller value or even disable it entirely is advisable.
 
+== Client identification
+
+On servers that support it (Redis 7.2+), the client identifies itself after the handshake using `CLIENT SETINFO`, so that connections can be attributed in `CLIENT INFO` and `CLIENT LIST`.
+By default it reports `lib-name=vertx-redis-client` and `lib-ver` resolved from the client JAR.
+On older servers that do not support `CLIENT SETINFO`, identification is skipped silently and the connection remains fully usable.
+
+Upstream frameworks (for example Quarkus) can attribute themselves on top of the base name by adding one or more suffixes with {@link io.vertx.redis.client.RedisOptions#addLibrarySuffix}.
+The composed name has the form `vertx-redis-client(suffix1;suffix2)`.
+Suffixes must not contain whitespace, `(`, `)` or `;`; invalid or blank suffixes are ignored.
+
+[source,$lang]
+----
+{@link examples.RedisExamples#clientIdentification}
+----
+
+Self-identification can be turned off entirely with {@link io.vertx.redis.client.RedisOptions#setClientIdentification}:
+
+[source,$lang]
+----
+{@link examples.RedisExamples#clientIdentificationDisabled}
+----
+
 == Valkey
 
 This client also supports https://valkey.io/[Valkey].

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -571,20 +571,20 @@ On servers that support it (Redis 7.2+), the client identifies itself after the 
 By default it reports `lib-name=vertx-redis-client` and `lib-ver` resolved from the client JAR.
 On older servers that do not support `CLIENT SETINFO`, identification is skipped silently and the connection remains fully usable.
 
-Upstream frameworks (for example Quarkus) can attribute themselves on top of the base name by adding one or more suffixes with {@link io.vertx.redis.client.RedisOptions#addLibrarySuffix}.
+Upstream frameworks can attribute themselves on top of the base name by adding one or more suffixes with {@link io.vertx.redis.client.RedisOptions#addClientIdSuffix}.
 The composed name has the form `vertx-redis-client(suffix1;suffix2)`.
-Suffixes must not contain whitespace, `(`, `)` or `;`; invalid or blank suffixes are ignored.
+Suffixes must consist of printable ASCII characters and must not contain `(`, `)` or `;`; invalid or blank suffixes are ignored.
 
 [source,$lang]
 ----
-{@link examples.RedisExamples#clientIdentification}
+{@link examples.RedisExamples#clientId}
 ----
 
-Self-identification can be turned off entirely with {@link io.vertx.redis.client.RedisOptions#setClientIdentification}:
+Self-identification can be turned off entirely with {@link io.vertx.redis.client.RedisOptions#setClientId}:
 
 [source,$lang]
 ----
-{@link examples.RedisExamples#clientIdentificationDisabled}
+{@link examples.RedisExamples#clientIdDisabled}
 ----
 
 == Valkey

--- a/src/main/generated/io/vertx/redis/client/RedisConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisConnectOptionsConverter.java
@@ -52,6 +52,21 @@ public class RedisConnectOptionsConverter {
             obj.setMaxWaitingHandlers(((Number)member.getValue()).intValue());
           }
           break;
+        case "clientIdentification":
+          if (member.getValue() instanceof Boolean) {
+            obj.setClientIdentification((Boolean)member.getValue());
+          }
+          break;
+        case "librarySuffixes":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                list.add((String)item);
+            });
+            obj.setLibrarySuffixes(list);
+          }
+          break;
       }
     }
   }
@@ -78,5 +93,11 @@ public class RedisConnectOptionsConverter {
       json.put("endpoints", array);
     }
     json.put("maxWaitingHandlers", obj.getMaxWaitingHandlers());
+    json.put("clientIdentification", obj.isClientIdentification());
+    if (obj.getLibrarySuffixes() != null) {
+      JsonArray array = new JsonArray();
+      obj.getLibrarySuffixes().forEach(item -> array.add(item));
+      json.put("librarySuffixes", array);
+    }
   }
 }

--- a/src/main/generated/io/vertx/redis/client/RedisConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisConnectOptionsConverter.java
@@ -52,19 +52,19 @@ public class RedisConnectOptionsConverter {
             obj.setMaxWaitingHandlers(((Number)member.getValue()).intValue());
           }
           break;
-        case "clientIdentification":
+        case "clientId":
           if (member.getValue() instanceof Boolean) {
-            obj.setClientIdentification((Boolean)member.getValue());
+            obj.setClientId((Boolean)member.getValue());
           }
           break;
-        case "librarySuffixes":
+        case "clientIdSuffixes":
           if (member.getValue() instanceof JsonArray) {
             java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
                 list.add((String)item);
             });
-            obj.setLibrarySuffixes(list);
+            obj.setClientIdSuffixes(list);
           }
           break;
       }
@@ -93,11 +93,11 @@ public class RedisConnectOptionsConverter {
       json.put("endpoints", array);
     }
     json.put("maxWaitingHandlers", obj.getMaxWaitingHandlers());
-    json.put("clientIdentification", obj.isClientIdentification());
-    if (obj.getLibrarySuffixes() != null) {
+    json.put("clientId", obj.isClientId());
+    if (obj.getClientIdSuffixes() != null) {
       JsonArray array = new JsonArray();
-      obj.getLibrarySuffixes().forEach(item -> array.add(item));
-      json.put("librarySuffixes", array);
+      obj.getClientIdSuffixes().forEach(item -> array.add(item));
+      json.put("clientIdSuffixes", array);
     }
   }
 }

--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -137,6 +137,21 @@ public class RedisOptionsConverter {
             obj.setAutoFailover((Boolean)member.getValue());
           }
           break;
+        case "clientIdentification":
+          if (member.getValue() instanceof Boolean) {
+            obj.setClientIdentification((Boolean)member.getValue());
+          }
+          break;
+        case "librarySuffixes":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                list.add((String)item);
+            });
+            obj.setLibrarySuffixes(list);
+          }
+          break;
       }
     }
   }
@@ -200,5 +215,11 @@ public class RedisOptionsConverter {
     }
     json.put("topologyCacheTTL", obj.getTopologyCacheTTL());
     json.put("autoFailover", obj.isAutoFailover());
+    json.put("clientIdentification", obj.isClientIdentification());
+    if (obj.getLibrarySuffixes() != null) {
+      JsonArray array = new JsonArray();
+      obj.getLibrarySuffixes().forEach(item -> array.add(item));
+      json.put("librarySuffixes", array);
+    }
   }
 }

--- a/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
+++ b/src/main/generated/io/vertx/redis/client/RedisOptionsConverter.java
@@ -137,19 +137,19 @@ public class RedisOptionsConverter {
             obj.setAutoFailover((Boolean)member.getValue());
           }
           break;
-        case "clientIdentification":
+        case "clientId":
           if (member.getValue() instanceof Boolean) {
-            obj.setClientIdentification((Boolean)member.getValue());
+            obj.setClientId((Boolean)member.getValue());
           }
           break;
-        case "librarySuffixes":
+        case "clientIdSuffixes":
           if (member.getValue() instanceof JsonArray) {
             java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
                 list.add((String)item);
             });
-            obj.setLibrarySuffixes(list);
+            obj.setClientIdSuffixes(list);
           }
           break;
       }
@@ -215,11 +215,11 @@ public class RedisOptionsConverter {
     }
     json.put("topologyCacheTTL", obj.getTopologyCacheTTL());
     json.put("autoFailover", obj.isAutoFailover());
-    json.put("clientIdentification", obj.isClientIdentification());
-    if (obj.getLibrarySuffixes() != null) {
+    json.put("clientId", obj.isClientId());
+    if (obj.getClientIdSuffixes() != null) {
       JsonArray array = new JsonArray();
-      obj.getLibrarySuffixes().forEach(item -> array.add(item));
-      json.put("librarySuffixes", array);
+      obj.getClientIdSuffixes().forEach(item -> array.add(item));
+      json.put("clientIdSuffixes", array);
     }
   }
 }

--- a/src/main/java/examples/RedisExamples.java
+++ b/src/main/java/examples/RedisExamples.java
@@ -316,4 +316,21 @@ public class RedisExamples {
   public void preferredProtocolVersion1(RedisOptions options) {
     options.setPreferredProtocolVersion(ProtocolVersion.RESP2);
   }
+
+  public void clientIdentification(Vertx vertx) {
+    Redis.createClient(
+        vertx,
+        new RedisOptions()
+          .setConnectionString("redis://localhost:6379")
+          // upstream frameworks can attribute themselves on top of the base name
+          .addLibrarySuffix("quarkus-redis_v3.x"))
+      .connect()
+      .onSuccess(conn -> {
+        // the server now reports lib-name=vertx-redis-client(quarkus-redis_v3.x)
+      });
+  }
+
+  public void clientIdentificationDisabled(RedisOptions options) {
+    options.setClientIdentification(false);
+  }
 }

--- a/src/main/java/examples/RedisExamples.java
+++ b/src/main/java/examples/RedisExamples.java
@@ -317,20 +317,20 @@ public class RedisExamples {
     options.setPreferredProtocolVersion(ProtocolVersion.RESP2);
   }
 
-  public void clientIdentification(Vertx vertx) {
+  public void clientId(Vertx vertx) {
     Redis.createClient(
         vertx,
         new RedisOptions()
           .setConnectionString("redis://localhost:6379")
           // upstream frameworks can attribute themselves on top of the base name
-          .addLibrarySuffix("quarkus-redis_v3.x"))
+          .addClientIdSuffix("my-framework_v1.0"))
       .connect()
       .onSuccess(conn -> {
-        // the server now reports lib-name=vertx-redis-client(quarkus-redis_v3.x)
+        // the server now reports lib-name=vertx-redis-client(my-framework_v1.0)
       });
   }
 
-  public void clientIdentificationDisabled(RedisOptions options) {
-    options.setClientIdentification(false);
+  public void clientIdDisabled(RedisOptions options) {
+    options.setClientId(false);
   }
 }

--- a/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
@@ -174,6 +174,21 @@ public class RedisClusterConnectOptions extends RedisConnectOptions {
     return (RedisClusterConnectOptions) super.setMaxWaitingHandlers(maxWaitingHandlers);
   }
 
+  @Override
+  public RedisClusterConnectOptions setClientIdentification(boolean clientIdentification) {
+    return (RedisClusterConnectOptions) super.setClientIdentification(clientIdentification);
+  }
+
+  @Override
+  public RedisClusterConnectOptions setLibrarySuffixes(List<String> librarySuffixes) {
+    return (RedisClusterConnectOptions) super.setLibrarySuffixes(librarySuffixes);
+  }
+
+  @Override
+  public RedisClusterConnectOptions addLibrarySuffix(String librarySuffix) {
+    return (RedisClusterConnectOptions) super.addLibrarySuffix(librarySuffix);
+  }
+
   /**
    * Converts this object to JSON notation.
    *

--- a/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisClusterConnectOptions.java
@@ -175,18 +175,18 @@ public class RedisClusterConnectOptions extends RedisConnectOptions {
   }
 
   @Override
-  public RedisClusterConnectOptions setClientIdentification(boolean clientIdentification) {
-    return (RedisClusterConnectOptions) super.setClientIdentification(clientIdentification);
+  public RedisClusterConnectOptions setClientId(boolean clientId) {
+    return (RedisClusterConnectOptions) super.setClientId(clientId);
   }
 
   @Override
-  public RedisClusterConnectOptions setLibrarySuffixes(List<String> librarySuffixes) {
-    return (RedisClusterConnectOptions) super.setLibrarySuffixes(librarySuffixes);
+  public RedisClusterConnectOptions setClientIdSuffixes(List<String> clientIdSuffixes) {
+    return (RedisClusterConnectOptions) super.setClientIdSuffixes(clientIdSuffixes);
   }
 
   @Override
-  public RedisClusterConnectOptions addLibrarySuffix(String librarySuffix) {
-    return (RedisClusterConnectOptions) super.addLibrarySuffix(librarySuffix);
+  public RedisClusterConnectOptions addClientIdSuffix(String clientIdSuffix) {
+    return (RedisClusterConnectOptions) super.addClientIdSuffix(clientIdSuffix);
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
@@ -35,14 +35,14 @@ public abstract class RedisConnectOptions {
   private boolean protocolNegotiation;
   private ProtocolVersion preferredProtocolVersion;
   private int maxWaitingHandlers;
-  private boolean clientIdentification;
-  private List<String> librarySuffixes;
+  private boolean clientId;
+  private List<String> clientIdSuffixes;
 
   public RedisConnectOptions() {
     maxNestedArrays = 32;
     protocolNegotiation = true;
     maxWaitingHandlers = 2048;
-    clientIdentification = true;
+    clientId = true;
   }
 
   public RedisConnectOptions(RedisOptions options) {
@@ -54,8 +54,8 @@ public abstract class RedisConnectOptions {
     setProtocolNegotiation(options.isProtocolNegotiation());
     setPreferredProtocolVersion(options.getPreferredProtocolVersion());
     setMaxWaitingHandlers(options.getMaxWaitingHandlers());
-    setClientIdentification(options.isClientIdentification());
-    setLibrarySuffixes(options.getLibrarySuffixes() == null ? null : new ArrayList<>(options.getLibrarySuffixes()));
+    setClientId(options.isClientId());
+    setClientIdSuffixes(options.getClientIdSuffixes() == null ? null : new ArrayList<>(options.getClientIdSuffixes()));
   }
 
   public RedisConnectOptions(RedisConnectOptions other) {
@@ -67,8 +67,8 @@ public abstract class RedisConnectOptions {
     setProtocolNegotiation(other.isProtocolNegotiation());
     setPreferredProtocolVersion(other.getPreferredProtocolVersion());
     setMaxWaitingHandlers(other.getMaxWaitingHandlers());
-    setClientIdentification(other.isClientIdentification());
-    setLibrarySuffixes(other.getLibrarySuffixes() == null ? null : new ArrayList<>(other.getLibrarySuffixes()));
+    setClientId(other.isClientId());
+    setClientIdSuffixes(other.getClientIdSuffixes() == null ? null : new ArrayList<>(other.getClientIdSuffixes()));
   }
 
   public RedisConnectOptions(JsonObject json) {
@@ -290,73 +290,72 @@ public abstract class RedisConnectOptions {
    *
    * @return true when self-identification is enabled.
    */
-  public boolean isClientIdentification() {
-    return clientIdentification;
+  public boolean isClientId() {
+    return clientId;
   }
 
   /**
    * Sets whether the client identifies itself to the server after the handshake using
    * {@code CLIENT SETINFO} (Redis 7.2+). Disabling this skips the identification commands entirely.
    *
-   * @param clientIdentification false to disable self-identification.
+   * @param clientId false to disable self-identification.
    * @return fluent self.
    */
-  public RedisConnectOptions setClientIdentification(boolean clientIdentification) {
-    this.clientIdentification = clientIdentification;
+  public RedisConnectOptions setClientId(boolean clientId) {
+    this.clientId = clientId;
     return this;
   }
 
   /**
    * Gets the framework suffixes appended to the reported {@code lib-name}. These allow upstream
-   * libraries (for example Quarkus) to attribute themselves on top of the base
-   * {@code vertx-redis-client} name.
+   * libraries to attribute themselves on top of the base {@code vertx-redis-client} name.
    *
    * @return the configured library suffixes, may be {@code null}.
    */
-  public List<String> getLibrarySuffixes() {
-    return librarySuffixes;
+  public List<String> getClientIdSuffixes() {
+    return clientIdSuffixes;
   }
 
   /**
    * Sets the framework suffixes appended to the reported {@code lib-name}. The composed name has the
-   * form {@code vertx-redis-client(suffix1;suffix2)}. Suffixes must not contain whitespace, {@code (},
-   * {@code )} or {@code ;}.
+   * form {@code vertx-redis-client(suffix1;suffix2)}. Suffixes must consist of printable ASCII
+   * characters and must not contain {@code (}, {@code )} or {@code ;}.
    *
-   * @param librarySuffixes the library suffixes, may be {@code null} to report only the base name.
+   * @param clientIdSuffixes the library suffixes, may be {@code null} to report only the base name.
    * @return fluent self.
    * @throws IllegalArgumentException if any suffix contains an illegal character.
    */
-  public RedisConnectOptions setLibrarySuffixes(List<String> librarySuffixes) {
-    if (librarySuffixes != null) {
-      for (String suffix : librarySuffixes) {
+  public RedisConnectOptions setClientIdSuffixes(List<String> clientIdSuffixes) {
+    if (clientIdSuffixes != null) {
+      for (String suffix : clientIdSuffixes) {
         validateSuffix(suffix);
       }
     }
-    this.librarySuffixes = librarySuffixes;
+    this.clientIdSuffixes = clientIdSuffixes;
     return this;
   }
 
   /**
    * Adds a single framework suffix appended to the reported {@code lib-name}.
    *
-   * @param librarySuffix the library suffix, must not contain whitespace, {@code (}, {@code )} or {@code ;}.
+   * @param clientIdSuffix the library suffix, must consist of printable ASCII characters and must not contain {@code (}, {@code )} or {@code ;}.
    * @return fluent self.
    * @throws IllegalArgumentException if the suffix contains an illegal character.
    */
   @GenIgnore
-  public RedisConnectOptions addLibrarySuffix(String librarySuffix) {
-    validateSuffix(librarySuffix);
-    if (librarySuffixes == null) {
-      librarySuffixes = new ArrayList<>();
+  public RedisConnectOptions addClientIdSuffix(String clientIdSuffix) {
+    validateSuffix(clientIdSuffix);
+    if (clientIdSuffixes == null) {
+      clientIdSuffixes = new ArrayList<>();
     }
-    librarySuffixes.add(librarySuffix);
+    clientIdSuffixes.add(clientIdSuffix);
     return this;
   }
 
   private static void validateSuffix(String suffix) {
     if (suffix != null && !RedisClientVersion.isValidSuffix(suffix)) {
       throw new IllegalArgumentException(
-        "Library suffix must not contain whitespace, '(', ')' or ';': " + suffix);
+        "Library suffix must consist of printable ASCII characters and must not contain '(', ')' or ';': " + suffix);
     }
   }
 

--- a/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
@@ -352,7 +352,7 @@ public abstract class RedisConnectOptions {
     return this;
   }
 
-  private static void validateSuffix(String suffix) {
+  static void validateSuffix(String suffix) {
     if (suffix != null && !RedisClientVersion.isValidSuffix(suffix)) {
       throw new IllegalArgumentException(
         "Library suffix must consist of printable ASCII characters and must not contain '(', ')' or ';': " + suffix);

--- a/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisConnectOptions.java
@@ -19,6 +19,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
+import io.vertx.redis.client.impl.RedisClientVersion;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,11 +35,14 @@ public abstract class RedisConnectOptions {
   private boolean protocolNegotiation;
   private ProtocolVersion preferredProtocolVersion;
   private int maxWaitingHandlers;
+  private boolean clientIdentification;
+  private List<String> librarySuffixes;
 
   public RedisConnectOptions() {
     maxNestedArrays = 32;
     protocolNegotiation = true;
     maxWaitingHandlers = 2048;
+    clientIdentification = true;
   }
 
   public RedisConnectOptions(RedisOptions options) {
@@ -50,6 +54,8 @@ public abstract class RedisConnectOptions {
     setProtocolNegotiation(options.isProtocolNegotiation());
     setPreferredProtocolVersion(options.getPreferredProtocolVersion());
     setMaxWaitingHandlers(options.getMaxWaitingHandlers());
+    setClientIdentification(options.isClientIdentification());
+    setLibrarySuffixes(options.getLibrarySuffixes() == null ? null : new ArrayList<>(options.getLibrarySuffixes()));
   }
 
   public RedisConnectOptions(RedisConnectOptions other) {
@@ -61,6 +67,8 @@ public abstract class RedisConnectOptions {
     setProtocolNegotiation(other.isProtocolNegotiation());
     setPreferredProtocolVersion(other.getPreferredProtocolVersion());
     setMaxWaitingHandlers(other.getMaxWaitingHandlers());
+    setClientIdentification(other.isClientIdentification());
+    setLibrarySuffixes(other.getLibrarySuffixes() == null ? null : new ArrayList<>(other.getLibrarySuffixes()));
   }
 
   public RedisConnectOptions(JsonObject json) {
@@ -273,6 +281,83 @@ public abstract class RedisConnectOptions {
   public RedisConnectOptions setMaxWaitingHandlers(int maxWaitingHandlers) {
     this.maxWaitingHandlers = maxWaitingHandlers;
     return this;
+  }
+
+  /**
+   * Whether the client identifies itself to the server after the handshake using {@code CLIENT SETINFO}
+   * (Redis 7.2+), so that connections are attributable in {@code CLIENT INFO} / {@code CLIENT LIST}.
+   * Defaults to {@code true}.
+   *
+   * @return true when self-identification is enabled.
+   */
+  public boolean isClientIdentification() {
+    return clientIdentification;
+  }
+
+  /**
+   * Sets whether the client identifies itself to the server after the handshake using
+   * {@code CLIENT SETINFO} (Redis 7.2+). Disabling this skips the identification commands entirely.
+   *
+   * @param clientIdentification false to disable self-identification.
+   * @return fluent self.
+   */
+  public RedisConnectOptions setClientIdentification(boolean clientIdentification) {
+    this.clientIdentification = clientIdentification;
+    return this;
+  }
+
+  /**
+   * Gets the framework suffixes appended to the reported {@code lib-name}. These allow upstream
+   * libraries (for example Quarkus) to attribute themselves on top of the base
+   * {@code vertx-redis-client} name.
+   *
+   * @return the configured library suffixes, may be {@code null}.
+   */
+  public List<String> getLibrarySuffixes() {
+    return librarySuffixes;
+  }
+
+  /**
+   * Sets the framework suffixes appended to the reported {@code lib-name}. The composed name has the
+   * form {@code vertx-redis-client(suffix1;suffix2)}. Suffixes must not contain whitespace, {@code (},
+   * {@code )} or {@code ;}.
+   *
+   * @param librarySuffixes the library suffixes, may be {@code null} to report only the base name.
+   * @return fluent self.
+   * @throws IllegalArgumentException if any suffix contains an illegal character.
+   */
+  public RedisConnectOptions setLibrarySuffixes(List<String> librarySuffixes) {
+    if (librarySuffixes != null) {
+      for (String suffix : librarySuffixes) {
+        validateSuffix(suffix);
+      }
+    }
+    this.librarySuffixes = librarySuffixes;
+    return this;
+  }
+
+  /**
+   * Adds a single framework suffix appended to the reported {@code lib-name}.
+   *
+   * @param librarySuffix the library suffix, must not contain whitespace, {@code (}, {@code )} or {@code ;}.
+   * @return fluent self.
+   * @throws IllegalArgumentException if the suffix contains an illegal character.
+   */
+  @GenIgnore
+  public RedisConnectOptions addLibrarySuffix(String librarySuffix) {
+    validateSuffix(librarySuffix);
+    if (librarySuffixes == null) {
+      librarySuffixes = new ArrayList<>();
+    }
+    librarySuffixes.add(librarySuffix);
+    return this;
+  }
+
+  private static void validateSuffix(String suffix) {
+    if (suffix != null && !RedisClientVersion.isValidSuffix(suffix)) {
+      throw new IllegalArgumentException(
+        "Library suffix must not contain whitespace, '(', ')' or ';': " + suffix);
+    }
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -27,6 +27,8 @@ import io.vertx.redis.client.impl.RedisURI;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.vertx.redis.client.RedisConnectOptions.validateSuffix;
+
 /**
  * Redis Client Configuration options.
  *
@@ -891,6 +893,11 @@ public class RedisOptions {
    * @return fluent self.
    */
   public RedisOptions setClientIdSuffixes(List<String> clientIdSuffixes) {
+    if (clientIdSuffixes != null) {
+      for (String suffix : clientIdSuffixes) {
+        validateSuffix(suffix);
+      }
+    }
     this.clientIdSuffixes = clientIdSuffixes;
     return this;
   }
@@ -903,6 +910,7 @@ public class RedisOptions {
    */
   @GenIgnore
   public RedisOptions addClientIdSuffix(String clientIdSuffix) {
+    validateSuffix(clientIdSuffix);
     if (clientIdSuffixes == null) {
       clientIdSuffixes = new ArrayList<>();
     }

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -59,6 +59,8 @@ public class RedisOptions {
   private long topologyCacheTTL;
   private TracingPolicy tracingPolicy;
   private boolean autoFailover;
+  private boolean clientIdentification;
+  private List<String> librarySuffixes;
 
   /**
    * Creates a default configuration object using Redis server defaults
@@ -79,6 +81,7 @@ public class RedisOptions {
     clusterTransactions = RedisClusterTransactions.DISABLED;
     protocolNegotiation = true;
     topologyCacheTTL = 1000;
+    clientIdentification = true;
   }
 
   /**
@@ -106,6 +109,8 @@ public class RedisOptions {
     this.topologyCacheTTL = other.topologyCacheTTL;
     this.tracingPolicy = other.tracingPolicy;
     this.autoFailover = other.autoFailover;
+    this.clientIdentification = other.clientIdentification;
+    this.librarySuffixes = other.librarySuffixes == null ? null : new ArrayList<>(other.librarySuffixes);
   }
 
   /**
@@ -841,6 +846,68 @@ public class RedisOptions {
    */
   public RedisOptions setAutoFailover(boolean autoFailover) {
     this.autoFailover = autoFailover;
+    return this;
+  }
+
+  /**
+   * Whether the client identifies itself to the server after the handshake using {@code CLIENT SETINFO}
+   * (Redis 7.2+), so that connections are attributable in {@code CLIENT INFO} / {@code CLIENT LIST}.
+   * Defaults to {@code true}.
+   *
+   * @return true when self-identification is enabled.
+   */
+  public boolean isClientIdentification() {
+    return clientIdentification;
+  }
+
+  /**
+   * Sets whether the client identifies itself to the server after the handshake using
+   * {@code CLIENT SETINFO} (Redis 7.2+). Disabling this skips the identification commands entirely.
+   *
+   * @param clientIdentification false to disable self-identification.
+   * @return fluent self.
+   */
+  public RedisOptions setClientIdentification(boolean clientIdentification) {
+    this.clientIdentification = clientIdentification;
+    return this;
+  }
+
+  /**
+   * Gets the framework suffixes appended to the reported {@code lib-name}. These allow upstream
+   * libraries (for example Quarkus) to attribute themselves on top of the base
+   * {@code vertx-redis-client} name.
+   *
+   * @return the configured library suffixes, may be {@code null}.
+   */
+  public List<String> getLibrarySuffixes() {
+    return librarySuffixes;
+  }
+
+  /**
+   * Sets the framework suffixes appended to the reported {@code lib-name}. The composed name has the
+   * form {@code vertx-redis-client(suffix1;suffix2)}. Suffixes must not contain whitespace, {@code (},
+   * {@code )} or {@code ;}.
+   *
+   * @param librarySuffixes the library suffixes, may be {@code null} to report only the base name.
+   * @return fluent self.
+   */
+  public RedisOptions setLibrarySuffixes(List<String> librarySuffixes) {
+    this.librarySuffixes = librarySuffixes;
+    return this;
+  }
+
+  /**
+   * Adds a single framework suffix appended to the reported {@code lib-name}.
+   *
+   * @param librarySuffix the library suffix, must not contain whitespace, {@code (}, {@code )} or {@code ;}.
+   * @return fluent self.
+   */
+  @GenIgnore
+  public RedisOptions addLibrarySuffix(String librarySuffix) {
+    if (librarySuffixes == null) {
+      librarySuffixes = new ArrayList<>();
+    }
+    librarySuffixes.add(librarySuffix);
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/RedisOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisOptions.java
@@ -59,8 +59,8 @@ public class RedisOptions {
   private long topologyCacheTTL;
   private TracingPolicy tracingPolicy;
   private boolean autoFailover;
-  private boolean clientIdentification;
-  private List<String> librarySuffixes;
+  private boolean clientId;
+  private List<String> clientIdSuffixes;
 
   /**
    * Creates a default configuration object using Redis server defaults
@@ -81,7 +81,7 @@ public class RedisOptions {
     clusterTransactions = RedisClusterTransactions.DISABLED;
     protocolNegotiation = true;
     topologyCacheTTL = 1000;
-    clientIdentification = true;
+    clientId = true;
   }
 
   /**
@@ -109,8 +109,8 @@ public class RedisOptions {
     this.topologyCacheTTL = other.topologyCacheTTL;
     this.tracingPolicy = other.tracingPolicy;
     this.autoFailover = other.autoFailover;
-    this.clientIdentification = other.clientIdentification;
-    this.librarySuffixes = other.librarySuffixes == null ? null : new ArrayList<>(other.librarySuffixes);
+    this.clientId = other.clientId;
+    this.clientIdSuffixes = other.clientIdSuffixes == null ? null : new ArrayList<>(other.clientIdSuffixes);
   }
 
   /**
@@ -856,58 +856,57 @@ public class RedisOptions {
    *
    * @return true when self-identification is enabled.
    */
-  public boolean isClientIdentification() {
-    return clientIdentification;
+  public boolean isClientId() {
+    return clientId;
   }
 
   /**
    * Sets whether the client identifies itself to the server after the handshake using
    * {@code CLIENT SETINFO} (Redis 7.2+). Disabling this skips the identification commands entirely.
    *
-   * @param clientIdentification false to disable self-identification.
+   * @param clientId false to disable self-identification.
    * @return fluent self.
    */
-  public RedisOptions setClientIdentification(boolean clientIdentification) {
-    this.clientIdentification = clientIdentification;
+  public RedisOptions setClientId(boolean clientId) {
+    this.clientId = clientId;
     return this;
   }
 
   /**
    * Gets the framework suffixes appended to the reported {@code lib-name}. These allow upstream
-   * libraries (for example Quarkus) to attribute themselves on top of the base
-   * {@code vertx-redis-client} name.
+   * libraries to attribute themselves on top of the base {@code vertx-redis-client} name.
    *
    * @return the configured library suffixes, may be {@code null}.
    */
-  public List<String> getLibrarySuffixes() {
-    return librarySuffixes;
+  public List<String> getClientIdSuffixes() {
+    return clientIdSuffixes;
   }
 
   /**
    * Sets the framework suffixes appended to the reported {@code lib-name}. The composed name has the
-   * form {@code vertx-redis-client(suffix1;suffix2)}. Suffixes must not contain whitespace, {@code (},
-   * {@code )} or {@code ;}.
+   * form {@code vertx-redis-client(suffix1;suffix2)}. Suffixes must consist of printable ASCII
+   * characters and must not contain {@code (}, {@code )} or {@code ;}.
    *
-   * @param librarySuffixes the library suffixes, may be {@code null} to report only the base name.
+   * @param clientIdSuffixes the library suffixes, may be {@code null} to report only the base name.
    * @return fluent self.
    */
-  public RedisOptions setLibrarySuffixes(List<String> librarySuffixes) {
-    this.librarySuffixes = librarySuffixes;
+  public RedisOptions setClientIdSuffixes(List<String> clientIdSuffixes) {
+    this.clientIdSuffixes = clientIdSuffixes;
     return this;
   }
 
   /**
    * Adds a single framework suffix appended to the reported {@code lib-name}.
    *
-   * @param librarySuffix the library suffix, must not contain whitespace, {@code (}, {@code )} or {@code ;}.
+   * @param clientIdSuffix the library suffix, must consist of printable ASCII characters and must not contain {@code (}, {@code )} or {@code ;}.
    * @return fluent self.
    */
   @GenIgnore
-  public RedisOptions addLibrarySuffix(String librarySuffix) {
-    if (librarySuffixes == null) {
-      librarySuffixes = new ArrayList<>();
+  public RedisOptions addClientIdSuffix(String clientIdSuffix) {
+    if (clientIdSuffixes == null) {
+      clientIdSuffixes = new ArrayList<>();
     }
-    librarySuffixes.add(librarySuffix);
+    clientIdSuffixes.add(clientIdSuffix);
     return this;
   }
 

--- a/src/main/java/io/vertx/redis/client/RedisReplicationConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisReplicationConnectOptions.java
@@ -139,18 +139,18 @@ public class RedisReplicationConnectOptions extends RedisConnectOptions {
   }
 
   @Override
-  public RedisReplicationConnectOptions setClientIdentification(boolean clientIdentification) {
-    return (RedisReplicationConnectOptions) super.setClientIdentification(clientIdentification);
+  public RedisReplicationConnectOptions setClientId(boolean clientId) {
+    return (RedisReplicationConnectOptions) super.setClientId(clientId);
   }
 
   @Override
-  public RedisReplicationConnectOptions setLibrarySuffixes(List<String> librarySuffixes) {
-    return (RedisReplicationConnectOptions) super.setLibrarySuffixes(librarySuffixes);
+  public RedisReplicationConnectOptions setClientIdSuffixes(List<String> clientIdSuffixes) {
+    return (RedisReplicationConnectOptions) super.setClientIdSuffixes(clientIdSuffixes);
   }
 
   @Override
-  public RedisReplicationConnectOptions addLibrarySuffix(String librarySuffix) {
-    return (RedisReplicationConnectOptions) super.addLibrarySuffix(librarySuffix);
+  public RedisReplicationConnectOptions addClientIdSuffix(String clientIdSuffix) {
+    return (RedisReplicationConnectOptions) super.addClientIdSuffix(clientIdSuffix);
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/RedisReplicationConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisReplicationConnectOptions.java
@@ -138,6 +138,21 @@ public class RedisReplicationConnectOptions extends RedisConnectOptions {
     return (RedisReplicationConnectOptions) super.setMaxWaitingHandlers(maxWaitingHandlers);
   }
 
+  @Override
+  public RedisReplicationConnectOptions setClientIdentification(boolean clientIdentification) {
+    return (RedisReplicationConnectOptions) super.setClientIdentification(clientIdentification);
+  }
+
+  @Override
+  public RedisReplicationConnectOptions setLibrarySuffixes(List<String> librarySuffixes) {
+    return (RedisReplicationConnectOptions) super.setLibrarySuffixes(librarySuffixes);
+  }
+
+  @Override
+  public RedisReplicationConnectOptions addLibrarySuffix(String librarySuffix) {
+    return (RedisReplicationConnectOptions) super.addLibrarySuffix(librarySuffix);
+  }
+
   /**
    * Converts this object to JSON notation.
    *

--- a/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
@@ -224,18 +224,18 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
   }
 
   @Override
-  public RedisSentinelConnectOptions setClientIdentification(boolean clientIdentification) {
-    return (RedisSentinelConnectOptions) super.setClientIdentification(clientIdentification);
+  public RedisSentinelConnectOptions setClientId(boolean clientId) {
+    return (RedisSentinelConnectOptions) super.setClientId(clientId);
   }
 
   @Override
-  public RedisSentinelConnectOptions setLibrarySuffixes(List<String> librarySuffixes) {
-    return (RedisSentinelConnectOptions) super.setLibrarySuffixes(librarySuffixes);
+  public RedisSentinelConnectOptions setClientIdSuffixes(List<String> clientIdSuffixes) {
+    return (RedisSentinelConnectOptions) super.setClientIdSuffixes(clientIdSuffixes);
   }
 
   @Override
-  public RedisSentinelConnectOptions addLibrarySuffix(String librarySuffix) {
-    return (RedisSentinelConnectOptions) super.addLibrarySuffix(librarySuffix);
+  public RedisSentinelConnectOptions addClientIdSuffix(String clientIdSuffix) {
+    return (RedisSentinelConnectOptions) super.addClientIdSuffix(clientIdSuffix);
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisSentinelConnectOptions.java
@@ -223,6 +223,21 @@ public class RedisSentinelConnectOptions extends RedisConnectOptions {
     return (RedisSentinelConnectOptions) super.setMaxWaitingHandlers(maxWaitingHandlers);
   }
 
+  @Override
+  public RedisSentinelConnectOptions setClientIdentification(boolean clientIdentification) {
+    return (RedisSentinelConnectOptions) super.setClientIdentification(clientIdentification);
+  }
+
+  @Override
+  public RedisSentinelConnectOptions setLibrarySuffixes(List<String> librarySuffixes) {
+    return (RedisSentinelConnectOptions) super.setLibrarySuffixes(librarySuffixes);
+  }
+
+  @Override
+  public RedisSentinelConnectOptions addLibrarySuffix(String librarySuffix) {
+    return (RedisSentinelConnectOptions) super.addLibrarySuffix(librarySuffix);
+  }
+
   /**
    * Converts this object to JSON notation.
    *

--- a/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
@@ -88,18 +88,18 @@ public class RedisStandaloneConnectOptions extends RedisConnectOptions {
   }
 
   @Override
-  public RedisStandaloneConnectOptions setClientIdentification(boolean clientIdentification) {
-    return (RedisStandaloneConnectOptions) super.setClientIdentification(clientIdentification);
+  public RedisStandaloneConnectOptions setClientId(boolean clientId) {
+    return (RedisStandaloneConnectOptions) super.setClientId(clientId);
   }
 
   @Override
-  public RedisStandaloneConnectOptions setLibrarySuffixes(List<String> librarySuffixes) {
-    return (RedisStandaloneConnectOptions) super.setLibrarySuffixes(librarySuffixes);
+  public RedisStandaloneConnectOptions setClientIdSuffixes(List<String> clientIdSuffixes) {
+    return (RedisStandaloneConnectOptions) super.setClientIdSuffixes(clientIdSuffixes);
   }
 
   @Override
-  public RedisStandaloneConnectOptions addLibrarySuffix(String librarySuffix) {
-    return (RedisStandaloneConnectOptions) super.addLibrarySuffix(librarySuffix);
+  public RedisStandaloneConnectOptions addClientIdSuffix(String clientIdSuffix) {
+    return (RedisStandaloneConnectOptions) super.addClientIdSuffix(clientIdSuffix);
   }
 
   /**

--- a/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
+++ b/src/main/java/io/vertx/redis/client/RedisStandaloneConnectOptions.java
@@ -87,6 +87,21 @@ public class RedisStandaloneConnectOptions extends RedisConnectOptions {
     return (RedisStandaloneConnectOptions) super.setMaxWaitingHandlers(maxWaitingHandlers);
   }
 
+  @Override
+  public RedisStandaloneConnectOptions setClientIdentification(boolean clientIdentification) {
+    return (RedisStandaloneConnectOptions) super.setClientIdentification(clientIdentification);
+  }
+
+  @Override
+  public RedisStandaloneConnectOptions setLibrarySuffixes(List<String> librarySuffixes) {
+    return (RedisStandaloneConnectOptions) super.setLibrarySuffixes(librarySuffixes);
+  }
+
+  @Override
+  public RedisStandaloneConnectOptions addLibrarySuffix(String librarySuffix) {
+    return (RedisStandaloneConnectOptions) super.addLibrarySuffix(librarySuffix);
+  }
+
   /**
    * Converts this object to JSON notation.
    *

--- a/src/main/java/io/vertx/redis/client/impl/RedisClientVersion.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClientVersion.java
@@ -30,8 +30,9 @@ public final class RedisClientVersion {
 
   /**
    * The library version reported to the server as {@code lib-ver}. Resolved from the JAR manifest
-   * at runtime, falling back to {@code "unknown"} when the implementation version is not available
-   * (for example, when running from class files rather than a packaged JAR).
+   * at runtime, or {@code null} when the implementation version is not available (for example, when
+   * running from class files rather than a packaged JAR), in which case {@code lib-ver} is not
+   * reported to the server.
    */
   public static final String VERSION = resolveVersion();
 
@@ -39,18 +40,17 @@ public final class RedisClientVersion {
   }
 
   private static String resolveVersion() {
-    String version = RedisClientVersion.class.getPackage().getImplementationVersion();
-    return version != null ? version : "unknown";
+    return RedisClientVersion.class.getPackage().getImplementationVersion();
   }
 
   /**
    * Composes the {@code lib-name} reported to the server from the base library name and the optional
-   * framework suffixes provided by upstream libraries (for example Quarkus).
+   * framework suffixes provided by upstream libraries.
    * <p>
    * With no suffixes the result is just {@link #NAME}. When suffixes are present they are joined with
-   * {@code ;} and wrapped in parentheses, for example {@code vertx-redis-client(quarkus-redis_v3.x)}.
-   * Blank suffixes and suffixes containing characters rejected by {@code CLIENT SETINFO}
-   * (whitespace, {@code (}, {@code )} or {@code ;}) are ignored.
+   * {@code ;} and wrapped in parentheses, for example {@code vertx-redis-client(my-framework_v1.0)}.
+   * Blank suffixes and suffixes containing characters rejected by {@code CLIENT SETINFO} (anything
+   * other than printable ASCII, or {@code (}, {@code )} or {@code ;}) are ignored.
    * <p>
    * Each suffix is treated as an opaque string; callers are expected to follow the {@code name_vversion}
    * convention recommended by the Redis {@code CLIENT SETINFO} documentation, but the convention is
@@ -80,8 +80,10 @@ public final class RedisClientVersion {
   }
 
   /**
-   * A suffix is valid when it contains no characters that {@code CLIENT SETINFO} rejects or that would
-   * break the composed {@code lib-name} grammar: whitespace, {@code (}, {@code )} and {@code ;}.
+   * A suffix is valid when it consists solely of printable ASCII characters (code points {@code 33} to
+   * {@code 126}) and contains none of {@code (}, {@code )} or {@code ;}, which would break the composed
+   * {@code lib-name} grammar or be rejected by {@code CLIENT SETINFO}. Restricting to ASCII also avoids
+   * the ambiguity of characters outside the Basic Multilingual Plane.
    *
    * @param suffix the suffix to validate
    * @return {@code true} if the suffix is safe to include in the {@code lib-name}
@@ -92,7 +94,7 @@ public final class RedisClientVersion {
     }
     for (int i = 0; i < suffix.length(); i++) {
       char c = suffix.charAt(i);
-      if (Character.isWhitespace(c) || c == '(' || c == ')' || c == ';') {
+      if (c <= 32 || c >= 127 || c == '(' || c == ')' || c == ';') {
         return false;
       }
     }

--- a/src/main/java/io/vertx/redis/client/impl/RedisClientVersion.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisClientVersion.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ * <p>
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.redis.client.impl;
+
+import java.util.List;
+
+/**
+ * Identification of this client library, reported to the server via {@code CLIENT SETINFO}
+ * (Redis 7.2+) so that connections are attributable in {@code CLIENT INFO} / {@code CLIENT LIST}.
+ */
+public final class RedisClientVersion {
+
+  /**
+   * The library name reported to the server as {@code lib-name}.
+   */
+  public static final String NAME = "vertx-redis-client";
+
+  /**
+   * The library version reported to the server as {@code lib-ver}. Resolved from the JAR manifest
+   * at runtime, falling back to {@code "unknown"} when the implementation version is not available
+   * (for example, when running from class files rather than a packaged JAR).
+   */
+  public static final String VERSION = resolveVersion();
+
+  private RedisClientVersion() {
+  }
+
+  private static String resolveVersion() {
+    String version = RedisClientVersion.class.getPackage().getImplementationVersion();
+    return version != null ? version : "unknown";
+  }
+
+  /**
+   * Composes the {@code lib-name} reported to the server from the base library name and the optional
+   * framework suffixes provided by upstream libraries (for example Quarkus).
+   * <p>
+   * With no suffixes the result is just {@link #NAME}. When suffixes are present they are joined with
+   * {@code ;} and wrapped in parentheses, for example {@code vertx-redis-client(quarkus-redis_v3.x)}.
+   * Blank suffixes and suffixes containing characters rejected by {@code CLIENT SETINFO}
+   * (whitespace, {@code (}, {@code )} or {@code ;}) are ignored.
+   * <p>
+   * Each suffix is treated as an opaque string; callers are expected to follow the {@code name_vversion}
+   * convention recommended by the Redis {@code CLIENT SETINFO} documentation, but the convention is
+   * not enforced.
+   *
+   * @param suffixes the framework suffixes, may be {@code null} or empty
+   * @return the composed {@code lib-name}
+   */
+  public static String formatLibraryName(List<String> suffixes) {
+    if (suffixes == null || suffixes.isEmpty()) {
+      return NAME;
+    }
+    StringBuilder joined = new StringBuilder();
+    for (String suffix : suffixes) {
+      if (suffix == null || suffix.trim().isEmpty() || !isValidSuffix(suffix)) {
+        continue;
+      }
+      if (joined.length() > 0) {
+        joined.append(';');
+      }
+      joined.append(suffix.trim());
+    }
+    if (joined.length() == 0) {
+      return NAME;
+    }
+    return NAME + "(" + joined + ")";
+  }
+
+  /**
+   * A suffix is valid when it contains no characters that {@code CLIENT SETINFO} rejects or that would
+   * break the composed {@code lib-name} grammar: whitespace, {@code (}, {@code )} and {@code ;}.
+   *
+   * @param suffix the suffix to validate
+   * @return {@code true} if the suffix is safe to include in the {@code lib-name}
+   */
+  public static boolean isValidSuffix(String suffix) {
+    if (suffix == null) {
+      return false;
+    }
+    for (int i = 0; i < suffix.length(); i++) {
+      char c = suffix.charAt(i);
+      if (Character.isWhitespace(c) || c == '(' || c == ')' || c == ';') {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
@@ -304,27 +304,34 @@ public class RedisConnectionManager implements Function<RedisConnectionManager.C
     }
 
     private Future<Void> clientSetInfo(ContextInternal ctx, RedisConnection connection, RedisConnectOptions options) {
-      if (!options.isClientIdentification()) {
+      if (!options.isClientId()) {
         return ctx.succeededFuture();
       }
 
-      String libName = RedisClientVersion.formatLibraryName(options.getLibrarySuffixes());
+      String libName = RedisClientVersion.formatLibraryName(options.getClientIdSuffixes());
 
       // `CLIENT SETINFO` was added in Redis 7.2; older servers reject it, in which case the error
-      // is ignored so the connection stays usable
-      Request setLibName = Request.cmd(Command.CLIENT).arg("SETINFO").arg("lib-name").arg(libName);
-      Request setLibVer = Request.cmd(Command.CLIENT).arg("SETINFO").arg("lib-ver").arg(RedisClientVersion.VERSION);
+      // is ignored so the connection stays usable. When both commands are sent they are written
+      // before awaiting any reply so they are pipelined (single round-trip).
+      Future<Response> libNameSent = connection.send(
+        Request.cmd(Command.CLIENT).arg("SETINFO").arg("lib-name").arg(libName));
 
-      // both commands are written before awaiting any reply so they are pipelined (single round-trip)
-      Future<Response> libNameSent = connection.send(setLibName);
-      Future<Response> libVerSent = connection.send(setLibVer);
-      return Future.all(libNameSent, libVerSent)
-        .transform(ar -> {
-          if (ar.failed()) {
-            LOG.debug("CLIENT SETINFO failed (server likely predates Redis 7.2), ignoring", ar.cause());
-          }
-          return ctx.succeededFuture();
-        });
+      Future<?> sent;
+      if (RedisClientVersion.VERSION != null) {
+        Future<Response> libVerSent = connection.send(
+          Request.cmd(Command.CLIENT).arg("SETINFO").arg("lib-ver").arg(RedisClientVersion.VERSION));
+        sent = Future.all(libNameSent, libVerSent);
+      } else {
+        // lib-ver is omitted when the version cannot be resolved from the JAR manifest
+        sent = libNameSent;
+      }
+
+      return sent.transform(ar -> {
+        if (ar.failed()) {
+          LOG.debug("CLIENT SETINFO failed (server likely predates Redis 7.2), ignoring", ar.cause());
+        }
+        return ctx.succeededFuture();
+      });
     }
 
     private Future<Void> ping(ContextInternal ctx, RedisConnection connection, RedisConnectOptions options) {

--- a/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
+++ b/src/main/java/io/vertx/redis/client/impl/RedisConnectionManager.java
@@ -226,6 +226,10 @@ public class RedisConnectionManager implements Function<RedisConnectionManager.C
       // initial handshake
       return hello(ctx, connection, redisURI, options)
         .compose(hello -> {
+          // self-identification (best effort, ignored by servers older than Redis 7.2)
+          return clientSetInfo(ctx, connection, options);
+        })
+        .compose(setInfo -> {
           // perform select
           return select(ctx, connection, redisURI.select());
         })
@@ -297,6 +301,30 @@ public class RedisConnectionManager implements Function<RedisConnectionManager.C
             return Future.failedFuture(err);
           });
       }
+    }
+
+    private Future<Void> clientSetInfo(ContextInternal ctx, RedisConnection connection, RedisConnectOptions options) {
+      if (!options.isClientIdentification()) {
+        return ctx.succeededFuture();
+      }
+
+      String libName = RedisClientVersion.formatLibraryName(options.getLibrarySuffixes());
+
+      // `CLIENT SETINFO` was added in Redis 7.2; older servers reject it, in which case the error
+      // is ignored so the connection stays usable
+      Request setLibName = Request.cmd(Command.CLIENT).arg("SETINFO").arg("lib-name").arg(libName);
+      Request setLibVer = Request.cmd(Command.CLIENT).arg("SETINFO").arg("lib-ver").arg(RedisClientVersion.VERSION);
+
+      // both commands are written before awaiting any reply so they are pipelined (single round-trip)
+      Future<Response> libNameSent = connection.send(setLibName);
+      Future<Response> libVerSent = connection.send(setLibVer);
+      return Future.all(libNameSent, libVerSent)
+        .transform(ar -> {
+          if (ar.failed()) {
+            LOG.debug("CLIENT SETINFO failed (server likely predates Redis 7.2), ignoring", ar.cause());
+          }
+          return ctx.succeededFuture();
+        });
     }
 
     private Future<Void> ping(ContextInternal ctx, RedisConnection connection, RedisConnectOptions options) {

--- a/src/test/java/io/vertx/tests/redis/client/RedisClientSelfIdentificationTest.java
+++ b/src/test/java/io/vertx/tests/redis/client/RedisClientSelfIdentificationTest.java
@@ -54,8 +54,12 @@ public class RedisClientSelfIdentificationTest {
         String reply = info.toString();
         assertTrue(reply.contains("lib-name=" + RedisClientVersion.NAME),
           "CLIENT INFO should contain lib-name, was: " + reply);
-        assertTrue(reply.contains("lib-ver=" + RedisClientVersion.VERSION),
-          "CLIENT INFO should contain lib-ver, was: " + reply);
+        // lib-ver is only reported when the version could be resolved from the JAR manifest;
+        // when running from class files it is null and intentionally not sent
+        if (RedisClientVersion.VERSION != null) {
+          assertTrue(reply.contains("lib-ver=" + RedisClientVersion.VERSION),
+            "CLIENT INFO should contain lib-ver, was: " + reply);
+        }
         test.completeNow();
       }));
   }
@@ -65,7 +69,7 @@ public class RedisClientSelfIdentificationTest {
   public void testClientInfoReportsLibNameWithSuffix(VertxTestContext test) {
     client = Redis.createClient(context.vertx(), new RedisOptions()
       .setConnectionString(redis.getRedisUri())
-      .addLibrarySuffix("quarkus-redis_v3.x"));
+      .addClientIdSuffix("quarkus-redis_v3.x"));
     client.connect()
       .compose(conn -> conn.send(cmd(CLIENT).arg("INFO")))
       .onComplete(test.succeeding(info -> {
@@ -81,7 +85,7 @@ public class RedisClientSelfIdentificationTest {
   public void testClientInfoReportsNoLibNameWhenDisabled(VertxTestContext test) {
     client = Redis.createClient(context.vertx(), new RedisOptions()
       .setConnectionString(redis.getRedisUri())
-      .setClientIdentification(false));
+      .setClientId(false));
     client.connect()
       .compose(conn -> conn.send(cmd(CLIENT).arg("INFO")))
       .onComplete(test.succeeding(info -> {

--- a/src/test/java/io/vertx/tests/redis/client/RedisClientSelfIdentificationTest.java
+++ b/src/test/java/io/vertx/tests/redis/client/RedisClientSelfIdentificationTest.java
@@ -1,0 +1,112 @@
+package io.vertx.tests.redis.client;
+
+import io.vertx.junit5.RunTestOnContext;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.impl.RedisClientVersion;
+import io.vertx.tests.redis.containers.RedisStandalone;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static io.vertx.redis.client.Command.CLIENT;
+import static io.vertx.redis.client.Command.GET;
+import static io.vertx.redis.client.Command.PING;
+import static io.vertx.redis.client.Command.SET;
+import static io.vertx.redis.client.Request.cmd;
+import static io.vertx.tests.redis.client.TestUtils.randomKey;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(VertxExtension.class)
+@Testcontainers
+public class RedisClientSelfIdentificationTest {
+
+  // CLIENT SETINFO is available since Redis 7.2
+  @Container
+  public static final RedisStandalone redis = RedisStandalone.builder().setVersion("7.2").build();
+
+  @RegisterExtension
+  public final RunTestOnContext context = new RunTestOnContext();
+
+  private Redis client;
+
+  @AfterEach
+  public void after() {
+    if (client != null) {
+      client.close();
+    }
+  }
+
+  // L3 native endpoint: assert the server reports our lib-name/lib-ver via CLIENT INFO
+  @Test
+  public void testClientInfoReportsLibNameAndVersion(VertxTestContext test) {
+    client = Redis.createClient(context.vertx(), new RedisOptions().setConnectionString(redis.getRedisUri()));
+    client.connect()
+      .compose(conn -> conn.send(cmd(CLIENT).arg("INFO")))
+      .onComplete(test.succeeding(info -> {
+        String reply = info.toString();
+        assertTrue(reply.contains("lib-name=" + RedisClientVersion.NAME),
+          "CLIENT INFO should contain lib-name, was: " + reply);
+        assertTrue(reply.contains("lib-ver=" + RedisClientVersion.VERSION),
+          "CLIENT INFO should contain lib-ver, was: " + reply);
+        test.completeNow();
+      }));
+  }
+
+  // L3 native endpoint: a framework suffix is appended to lib-name and visible via CLIENT INFO
+  @Test
+  public void testClientInfoReportsLibNameWithSuffix(VertxTestContext test) {
+    client = Redis.createClient(context.vertx(), new RedisOptions()
+      .setConnectionString(redis.getRedisUri())
+      .addLibrarySuffix("quarkus-redis_v3.x"));
+    client.connect()
+      .compose(conn -> conn.send(cmd(CLIENT).arg("INFO")))
+      .onComplete(test.succeeding(info -> {
+        String reply = info.toString();
+        assertTrue(reply.contains("lib-name=" + RedisClientVersion.NAME + "(quarkus-redis_v3.x)"),
+          "CLIENT INFO should contain the composed lib-name, was: " + reply);
+        test.completeNow();
+      }));
+  }
+
+  // L3 native endpoint: disabling identification means no lib-name is reported
+  @Test
+  public void testClientInfoReportsNoLibNameWhenDisabled(VertxTestContext test) {
+    client = Redis.createClient(context.vertx(), new RedisOptions()
+      .setConnectionString(redis.getRedisUri())
+      .setClientIdentification(false));
+    client.connect()
+      .compose(conn -> conn.send(cmd(CLIENT).arg("INFO")))
+      .onComplete(test.succeeding(info -> {
+        String reply = info.toString();
+        assertFalse(reply.contains("lib-name=" + RedisClientVersion.NAME),
+          "CLIENT INFO should not report a lib-name when identification is disabled, was: " + reply);
+        test.completeNow();
+      }));
+  }
+
+  // L2 integration: the connection remains fully usable once self-identification has run
+  @Test
+  public void testConnectionUsableAfterSelfIdentification(VertxTestContext test) {
+    final String key = randomKey();
+    client = Redis.createClient(context.vertx(), new RedisOptions().setConnectionString(redis.getRedisUri()));
+    client.connect()
+      .compose(conn -> conn.send(cmd(PING))
+        .compose(pong -> {
+          assertEquals("PONG", pong.toString());
+          return conn.send(cmd(SET).arg(key).arg("value"));
+        })
+        .compose(set -> conn.send(cmd(GET).arg(key))))
+      .onComplete(test.succeeding(value -> {
+        assertEquals("value", value.toString());
+        test.completeNow();
+      }));
+  }
+}

--- a/src/test/java/io/vertx/tests/redis/client/RedisClientSelfIdentificationToleranceTest.java
+++ b/src/test/java/io/vertx/tests/redis/client/RedisClientSelfIdentificationToleranceTest.java
@@ -1,0 +1,68 @@
+package io.vertx.tests.redis.client;
+
+import io.vertx.junit5.RunTestOnContext;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisOptions;
+import io.vertx.tests.redis.containers.RedisStandalone;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static io.vertx.redis.client.Command.GET;
+import static io.vertx.redis.client.Command.PING;
+import static io.vertx.redis.client.Command.SET;
+import static io.vertx.redis.client.Request.cmd;
+import static io.vertx.tests.redis.client.TestUtils.randomKey;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(VertxExtension.class)
+@Testcontainers
+public class RedisClientSelfIdentificationToleranceTest {
+
+  // CLIENT SETINFO does not exist before Redis 7.2; 6.2 must still connect and work
+  @Container
+  public static final RedisStandalone redis = RedisStandalone.builder().setVersion("6.2").build();
+
+  @RegisterExtension
+  public final RunTestOnContext context = new RunTestOnContext();
+
+  private Redis client;
+
+  @AfterEach
+  public void after() {
+    if (client != null) {
+      client.close();
+    }
+  }
+
+  // L2 tolerance: connecting to a server that rejects CLIENT SETINFO must still succeed
+  @Test
+  public void testConnectSucceedsOnOlderServer(VertxTestContext test) {
+    client = Redis.createClient(context.vertx(), new RedisOptions().setConnectionString(redis.getRedisUri()));
+    client.connect()
+      .compose(conn -> conn.send(cmd(PING)))
+      .onComplete(test.succeeding(pong -> {
+        assertEquals("PONG", pong.toString());
+        test.completeNow();
+      }));
+  }
+
+  // L2 tolerance: the connection remains fully usable despite the unsupported identification command
+  @Test
+  public void testConnectionUsableOnOlderServer(VertxTestContext test) {
+    final String key = randomKey();
+    client = Redis.createClient(context.vertx(), new RedisOptions().setConnectionString(redis.getRedisUri()));
+    client.connect()
+      .compose(conn -> conn.send(cmd(SET).arg(key).arg("value"))
+        .compose(set -> conn.send(cmd(GET).arg(key))))
+      .onComplete(test.succeeding(value -> {
+        assertEquals("value", value.toString());
+        test.completeNow();
+      }));
+  }
+}

--- a/src/test/java/io/vertx/tests/redis/internal/RedisClientVersionTest.java
+++ b/src/test/java/io/vertx/tests/redis/internal/RedisClientVersionTest.java
@@ -67,7 +67,7 @@ public class RedisClientVersionTest {
   public void testIsValidSuffixRejectsNonAscii() {
     // control characters and DEL
     assertFalse(RedisClientVersion.isValidSuffix("has\ttab"));
-    assertFalse(RedisClientVersion.isValidSuffix("hasdel"));
+    assertFalse(RedisClientVersion.isValidSuffix("has\u007Fdel"));
     // non-ASCII BMP characters
     assertFalse(RedisClientVersion.isValidSuffix("café"));
     // characters outside the Basic Multilingual Plane (encoded as a surrogate pair)

--- a/src/test/java/io/vertx/tests/redis/internal/RedisClientVersionTest.java
+++ b/src/test/java/io/vertx/tests/redis/internal/RedisClientVersionTest.java
@@ -1,0 +1,60 @@
+package io.vertx.tests.redis.internal;
+
+import io.vertx.redis.client.impl.RedisClientVersion;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RedisClientVersionTest {
+
+  @Test
+  public void testLibraryName() {
+    assertEquals("vertx-redis-client", RedisClientVersion.NAME);
+  }
+
+  @Test
+  public void testLibraryVersionIsPresent() {
+    assertNotNull(RedisClientVersion.VERSION);
+    assertFalse(RedisClientVersion.VERSION.isEmpty());
+  }
+
+  @Test
+  public void testFormatLibraryNameWithoutSuffixes() {
+    assertEquals("vertx-redis-client", RedisClientVersion.formatLibraryName(null));
+    assertEquals("vertx-redis-client", RedisClientVersion.formatLibraryName(Collections.emptyList()));
+  }
+
+  @Test
+  public void testFormatLibraryNameWithSingleSuffix() {
+    assertEquals("vertx-redis-client(quarkus-redis_v3.x)",
+      RedisClientVersion.formatLibraryName(Collections.singletonList("quarkus-redis_v3.x")));
+  }
+
+  @Test
+  public void testFormatLibraryNameWithMultipleSuffixes() {
+    assertEquals("vertx-redis-client(quarkus-redis_v3.x;spring-data_v3.2)",
+      RedisClientVersion.formatLibraryName(Arrays.asList("quarkus-redis_v3.x", "spring-data_v3.2")));
+  }
+
+  @Test
+  public void testFormatLibraryNameIgnoresBlankAndInvalidSuffixes() {
+    assertEquals("vertx-redis-client(valid)",
+      RedisClientVersion.formatLibraryName(Arrays.asList(null, "", "   ", "has space", "has(paren", "has;semi", "valid")));
+  }
+
+  @Test
+  public void testIsValidSuffix() {
+    assertTrue(RedisClientVersion.isValidSuffix("quarkus-redis_v3.x"));
+    assertFalse(RedisClientVersion.isValidSuffix("has space"));
+    assertFalse(RedisClientVersion.isValidSuffix("has(paren"));
+    assertFalse(RedisClientVersion.isValidSuffix("has)paren"));
+    assertFalse(RedisClientVersion.isValidSuffix("has;semi"));
+    assertFalse(RedisClientVersion.isValidSuffix(null));
+  }
+}

--- a/src/test/java/io/vertx/tests/redis/internal/RedisClientVersionTest.java
+++ b/src/test/java/io/vertx/tests/redis/internal/RedisClientVersionTest.java
@@ -8,7 +8,7 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RedisClientVersionTest {
@@ -19,9 +19,14 @@ public class RedisClientVersionTest {
   }
 
   @Test
-  public void testLibraryVersionIsPresent() {
-    assertNotNull(RedisClientVersion.VERSION);
-    assertFalse(RedisClientVersion.VERSION.isEmpty());
+  public void testLibraryVersionIsNeverAPlaceholder() {
+    // VERSION is null when running from class files (no JAR manifest); it must never fall back to a
+    // placeholder such as "unknown", and when present it must be a non-empty string
+    String version = RedisClientVersion.VERSION;
+    assertNotEquals("unknown", version);
+    if (version != null) {
+      assertFalse(version.isEmpty());
+    }
   }
 
   @Test
@@ -56,5 +61,22 @@ public class RedisClientVersionTest {
     assertFalse(RedisClientVersion.isValidSuffix("has)paren"));
     assertFalse(RedisClientVersion.isValidSuffix("has;semi"));
     assertFalse(RedisClientVersion.isValidSuffix(null));
+  }
+
+  @Test
+  public void testIsValidSuffixRejectsNonAscii() {
+    // control characters and DEL
+    assertFalse(RedisClientVersion.isValidSuffix("has\ttab"));
+    assertFalse(RedisClientVersion.isValidSuffix("hasdel"));
+    // non-ASCII BMP characters
+    assertFalse(RedisClientVersion.isValidSuffix("café"));
+    // characters outside the Basic Multilingual Plane (encoded as a surrogate pair)
+    assertFalse(RedisClientVersion.isValidSuffix("emoji😀"));
+  }
+
+  @Test
+  public void testFormatLibraryNameIgnoresNonAsciiSuffixes() {
+    assertEquals("vertx-redis-client(valid)",
+      RedisClientVersion.formatLibraryName(Arrays.asList("café", "emoji😀", "valid")));
   }
 }


### PR DESCRIPTION
# Add client self-identification via CLIENT SETINFO

## What
After the handshake, the client reports itself to the server via `CLIENT SETINFO` (Redis 7.2+):
- `lib-name` = `vertx-redis-client`, `lib-ver` = version from the JAR
- Enabled by default; opt out with `setClientIdentification(false)`
- Upstream frameworks can append suffixes (`vertx-redis-client(suffix1;suffix2)`) via `addLibrarySuffix(...)`

```java
new RedisOptions().addLibrarySuffix("quarkus-redis_v3.x");
new RedisOptions().setClientIdentification(false); // opt out
```

## Design
Pipelined after `HELLO` (single round-trip), per the Redis spec.
Graceful degradation: all `CLIENT SETINFO` failures are ignored, so pre-7.2 servers and restrictive ACLs (`NOPERM`) still connect.
Suffix validation: setters throw on illegal chars (whitespace ( ) ;); handshake also drops invalid ones as a safety net.
New  `clientIdentification` / `librarySuffixes` options round-trip via JSON.

## Scope
Suffixes are passed as opaque strings; a typed name/version API may follow.

## Testing
L1 unit: name composition + suffix validation
L2 (Redis 6.2): connects when CLIENT SETINFO is unsupported
L3 (Redis 7.2): lib-name / lib-ver / suffix / disable verified via CLIENT INFO